### PR TITLE
Routes includes apis path prefix

### DIFF
--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -34,8 +34,9 @@ func Routes(h Handlers) http.Handler {
 	m.Path("/v1/{type:schemas}/{name:.*}").Handler(h.GenericResource)
 	m.Path("/v1/{type}").Handler(h.GenericResource)
 	m.Path("/v1/{type}/{name}").Handler(h.GenericResource)
-	m.Path("/api").Handler(h.K8sProxy)
+	m.Path("/api").Handler(h.K8sProxy) // Can't just prefix this as UI needs /apikeys path
 	m.PathPrefix("/api/").Handler(h.K8sProxy)
+	m.PathPrefix("/apis").Handler(h.K8sProxy)
 	m.PathPrefix("/openapi").Handler(h.K8sProxy)
 	m.PathPrefix("/version").Handler(h.K8sProxy)
 	m.NotFoundHandler = h.Next


### PR DESCRIPTION
The correct fix
Rancher tests passing here: https://drone-pr.rancher.io/rancher/rancher/7463/1/2