### PR TITLE
Add default api server and fix invalid open-api arbitrary type

### DIFF
--- a/pkg/schema/converter/openapi.go
+++ b/pkg/schema/converter/openapi.go
@@ -107,6 +107,8 @@ func toField(schema proto.Schema) schemas.Field {
 			f.Type = sub.GetPath().String()
 		}
 	case *proto.Arbitrary:
+		logrus.Debugf("arbitrary type: %v", schema)
+		f.Type = "json"
 	default:
 		logrus.Errorf("unknown type: %v", schema)
 		f.Type = "json"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	apiserver "github.com/rancher/apiserver/pkg/server"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/dynamiclistener/server"
 	"github.com/rancher/steve/pkg/accesscontrol"
@@ -33,6 +34,7 @@ type Server struct {
 	RESTConfig      *rest.Config
 	BaseSchemas     *types.APISchemas
 	AccessSetLookup accesscontrol.AccessSetLookup
+	APIServer       *apiserver.Server
 
 	authMiddleware      auth.Middleware
 	controllers         *Controllers
@@ -150,11 +152,12 @@ func setup(ctx context.Context, server *Server) error {
 		ccache,
 		sf)
 
-	handler, err := handler.New(server.RESTConfig, sf, server.authMiddleware, server.next, server.router)
+	apiServer, handler, err := handler.New(server.RESTConfig, sf, server.authMiddleware, server.next, server.router)
 	if err != nil {
 		return err
 	}
 
+	server.APIServer = apiServer
 	server.Handler = handler
 	server.SchemaFactory = sf
 	return nil


### PR DESCRIPTION
**Problem:**
1. allow steve to customize the `api-ui` response writer for the air-gap environment users
2. failed to view steve `v1` API when its CRDs schemas contain the arbitrary schema type of the openAPI.

e.g add [longhorn CRDs](https://github.com/longhorn/longhorn/blob/a6b624b889ee7f4c2a233fadc972c513563244a6/deploy/longhorn.yaml#L97-L99) which contains the object type openAPI schema and check steve api via https://localhost:9443/v1, the following error is shown:
```
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0014a4fc0 .spec}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0014a4fc0 .status}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0028c0040 .spec}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0028c0040 .status}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0029eb100 .spec}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc0029eb100 .status}}} 
WARN[0001] arbitrary type: &{{ map[x-kubernetes-preserve-unknown-fields:true] {0xc000d87c20 .spec}}} 

HTMLApi.js:298 Uncaught TypeError: Cannot read property 'replace' of undefined
    at HTMLApi._fieldMunge (HTMLApi.js:298)
    at HTMLApi._schemaMunge (HTMLApi.js:266)
    at HTMLApi.schemasMunge (HTMLApi.js:252)
    at v (async.js:493)
    at async.js:444
    at Array.forEach (<anonymous>)
    at a (async.js:46)
    at d (async.js:443)
```

**Solution:**
1. add default `apiserver` which allows custom API-UI configuration
2. presume openAPI Arbitrary type to JSON