### PR TITLE
Bump API extension from v1beta1 to v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rancher/kubernetes-provider-detector v0.1.2
 	github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4
 	github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4
-	github.com/rancher/wrangler v0.7.1
+	github.com/rancher/wrangler v0.8.1-0.20210421002857-0b7c314c3022
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2
 	github.com/urfave/cli/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -452,8 +453,8 @@ github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9/go.mod h
 github.com/rancher/kubernetes-provider-detector v0.1.2 h1:iFfmmcZiGya6s3cS4Qxksyqqw5hPbbIDHgKJ2Y44XKM=
 github.com/rancher/kubernetes-provider-detector v0.1.2/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
-github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b h1:DQLpu44dsR+2qYvg1wyYadk108MWMHUOqvb2z4274Vs=
-github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
+github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d h1:vfjPEF6M7Jf1/zK1xF7z2drLfniooKcgDQdoXO5+U7w=
+github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4 h1:9lH3XiG7lSoQVaqeZTmydzxasRSiYoc3PdOoAvpQAyc=
 github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4/go.mod h1:W9LfZ96OfjkWSGTy2DUqYPt47Jpzrs7eM0i3AAx6fOI=
@@ -462,8 +463,8 @@ github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4/go.mod h1:d
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIqAQPHysxNlHqmKbUiDIx9ULt9IHUauh9aOnr67k=
-github.com/rancher/wrangler v0.7.1 h1:wngOkoJpnT98c/faIDp0WGhLoMY1z4Xy1H9HygwNG98=
-github.com/rancher/wrangler v0.7.1/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
+github.com/rancher/wrangler v0.8.1-0.20210421002857-0b7c314c3022 h1:7sJKHjNa0n+NYIAJ5YT02pFcDXpuh1QH6wOu14VZvek=
+github.com/rancher/wrangler v0.8.1-0.20210421002857-0b7c314c3022/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -568,6 +569,8 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -636,6 +639,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -690,6 +695,10 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/controllers/schema/schemas.go
+++ b/pkg/controllers/schema/schemas.go
@@ -11,13 +11,13 @@ import (
 	"github.com/rancher/steve/pkg/resources/common"
 	schema2 "github.com/rancher/steve/pkg/schema"
 	"github.com/rancher/steve/pkg/schema/converter"
-	apiextcontrollerv1beta1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1beta1"
+	apiextensionsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io/v1"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 	authorizationv1 "k8s.io/api/authorization/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -43,7 +43,7 @@ type handler struct {
 	schemas *schema2.Collection
 	client  discovery.DiscoveryInterface
 	cols    *common.DynamicColumns
-	crd     apiextcontrollerv1beta1.CustomResourceDefinitionClient
+	crd     apiextensionsv1.CustomResourceDefinitionClient
 	ssar    authorizationv1client.SelfSubjectAccessReviewInterface
 	handler SchemasHandler
 }
@@ -51,7 +51,7 @@ type handler struct {
 func Register(ctx context.Context,
 	cols *common.DynamicColumns,
 	discovery discovery.DiscoveryInterface,
-	crd apiextcontrollerv1beta1.CustomResourceDefinitionController,
+	crd apiextensionsv1.CustomResourceDefinitionController,
 	apiService v1.APIServiceController,
 	ssar authorizationv1client.SelfSubjectAccessReviewInterface,
 	schemasHandler SchemasHandler,
@@ -71,7 +71,7 @@ func Register(ctx context.Context,
 	crd.OnChange(ctx, "schema", h.OnChangeCRD)
 }
 
-func (h *handler) OnChangeCRD(key string, crd *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+func (h *handler) OnChangeCRD(key string, crd *extv1.CustomResourceDefinition) (*extv1.CustomResourceDefinition, error) {
 	h.queueRefresh()
 	return crd, nil
 }

--- a/pkg/schema/converter/crd.go
+++ b/pkg/schema/converter/crd.go
@@ -4,9 +4,9 @@ import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/attributes"
 	"github.com/rancher/steve/pkg/schema/table"
-	"github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1beta1"
+	apiextensionsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"github.com/rancher/wrangler/pkg/schemas"
-	beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func AddCustomResources(crd v1beta1.CustomResourceDefinitionClient, schemas map[string]*types.APISchema) error {
+func AddCustomResources(crd apiextensionsv1.CustomResourceDefinitionClient, schemas map[string]*types.APISchema) error {
 	crds, err := crd.List(metav1.ListOptions{})
 	if err != nil {
 		return nil
@@ -38,31 +38,19 @@ func AddCustomResources(crd v1beta1.CustomResourceDefinitionClient, schemas map[
 			continue
 		}
 
-		var columns []table.Column
-		for _, col := range crd.Spec.AdditionalPrinterColumns {
-			columns = append(columns, table.Column{
-				Name:  col.Name,
-				Field: col.JSONPath,
-				Type:  col.Type,
-			})
-		}
-
 		group, kind := crd.Spec.Group, crd.Status.AcceptedNames.Kind
 
-		if crd.Spec.Version != "" {
-			forVersion(&crd, group, crd.Spec.Version, kind, schemas, crd.Spec.AdditionalPrinterColumns, columns)
-		}
 		for _, version := range crd.Spec.Versions {
-			forVersion(&crd, group, version.Name, kind, schemas, crd.Spec.AdditionalPrinterColumns, columns)
+			forVersion(group, kind, schemas, version)
 		}
 	}
 
 	return nil
 }
 
-func forVersion(crd *beta1.CustomResourceDefinition, group, version, kind string, schemasMap map[string]*types.APISchema, columnDefs []beta1.CustomResourceColumnDefinition, columns []table.Column) {
+func forVersion(group, kind string, schemasMap map[string]*types.APISchema, version extv1.CustomResourceDefinitionVersion) {
 	var versionColumns []table.Column
-	for _, col := range columnDefs {
+	for _, col := range version.AdditionalPrinterColumns {
 		versionColumns = append(versionColumns, table.Column{
 			Name:   col.Name,
 			Field:  col.JSONPath,
@@ -70,13 +58,10 @@ func forVersion(crd *beta1.CustomResourceDefinition, group, version, kind string
 			Format: col.Format,
 		})
 	}
-	if len(versionColumns) == 0 {
-		versionColumns = columns
-	}
 
 	id := GVKToVersionedSchemaID(schema.GroupVersionKind{
 		Group:   group,
-		Version: version,
+		Version: version.Name,
 		Kind:    kind,
 	})
 
@@ -84,12 +69,12 @@ func forVersion(crd *beta1.CustomResourceDefinition, group, version, kind string
 	if schema == nil {
 		return
 	}
-	if len(columns) > 0 {
-		attributes.SetColumns(schema, columns)
+	if len(versionColumns) > 0 {
+		attributes.SetColumns(schema, versionColumns)
 	}
 
-	if crd.Spec.Validation != nil && crd.Spec.Validation.OpenAPIV3Schema != nil {
-		if fieldsSchema := modelV3ToSchema(id, crd.Spec.Validation.OpenAPIV3Schema, schemasMap); fieldsSchema != nil {
+	if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+		if fieldsSchema := modelV3ToSchema(id, version.Schema.OpenAPIV3Schema, schemasMap); fieldsSchema != nil {
 			for k, v := range staticFields {
 				fieldsSchema.ResourceFields[k] = v
 			}

--- a/pkg/schema/converter/k8stonorman.go
+++ b/pkg/schema/converter/k8stonorman.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1beta1"
+	apiextensionsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 )
@@ -38,7 +38,7 @@ func GVRToPluralName(gvr schema.GroupVersionResource) string {
 	return fmt.Sprintf("%s.%s", gvr.Group, gvr.Resource)
 }
 
-func ToSchemas(crd v1beta1.CustomResourceDefinitionClient, client discovery.DiscoveryInterface) (map[string]*types.APISchema, error) {
+func ToSchemas(crd apiextensionsv1.CustomResourceDefinitionClient, client discovery.DiscoveryInterface) (map[string]*types.APISchema, error) {
 	result := map[string]*types.APISchema{}
 
 	if err := AddOpenAPI(client, result); err != nil {

--- a/pkg/schema/converter/openapiv3.go
+++ b/pkg/schema/converter/openapiv3.go
@@ -3,10 +3,10 @@ package converter
 import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/wrangler/pkg/schemas"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-func modelV3ToSchema(name string, k *v1beta1.JSONSchemaProps, schemasMap map[string]*types.APISchema) *types.APISchema {
+func modelV3ToSchema(name string, k *extv1.JSONSchemaProps, schemasMap map[string]*types.APISchema) *types.APISchema {
 	s := types.APISchema{
 		Schema: &schemas.Schema{
 			ID:             name,
@@ -41,14 +41,14 @@ func modelV3ToSchema(name string, k *v1beta1.JSONSchemaProps, schemasMap map[str
 	return &s
 }
 
-func toResourceField(name string, schema v1beta1.JSONSchemaProps, schemasMap map[string]*types.APISchema) schemas.Field {
+func toResourceField(name string, schema extv1.JSONSchemaProps, schemasMap map[string]*types.APISchema) schemas.Field {
 	f := schemas.Field{
 		Description: schema.Description,
 		Nullable:    true,
 		Create:      true,
 		Update:      true,
 	}
-	var itemSchema *v1beta1.JSONSchemaProps
+	var itemSchema *extv1.JSONSchemaProps
 	if schema.Items != nil {
 		if schema.Items.Schema != nil {
 			itemSchema = schema.Items.Schema

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io"
-	apiextensionsv1beta1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1beta1"
+	apiextensionsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io"
 	apiregistrationv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
@@ -25,7 +25,7 @@ type Controllers struct {
 	Core       corev1.Interface
 	RBAC       rbacv1.Interface
 	API        apiregistrationv1.Interface
-	CRD        apiextensionsv1beta1.Interface
+	CRD        apiextensionsv1.Interface
 	starters   []start.Starter
 }
 
@@ -75,7 +75,7 @@ func NewController(cfg *rest.Config, opts *generic.FactoryOptions) (*Controllers
 	c.Core = core.Core().V1()
 	c.RBAC = rbac.Rbac().V1()
 	c.API = api.Apiregistration().V1()
-	c.CRD = crd.Apiextensions().V1beta1()
+	c.CRD = crd.Apiextensions().V1()
 	c.RESTConfig = cfg
 
 	return c, nil


### PR DESCRIPTION
**Problem:**
need to bump k8s apiextension from v1beta1 to v1 due to:
```
apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```

**Solution:**
Bump API extension from v1beta1 to v1


**Related PR:**
https://github.com/rancher/wrangler/pull/154