### PR TITLE
[2.4] Add default api server and fix invalid open-api arbitrary type

### DIFF
--- a/pkg/schema/converter/openapi.go
+++ b/pkg/schema/converter/openapi.go
@@ -107,6 +107,8 @@ func toField(schema proto.Schema) schemas.Field {
 			f.Type = sub.GetPath().String()
 		}
 	case *proto.Arbitrary:
+		logrus.Errorf("unknown type: %v", schema)
+		f.Type = "json"
 	default:
 		logrus.Errorf("unknown type: %v", schema)
 		f.Type = "json"

--- a/pkg/schemaserver/server/server.go
+++ b/pkg/schemaserver/server/server.go
@@ -210,10 +210,17 @@ func (s *Server) CustomAPIUIResponseWriter(cssURL, jsURL, version writer.StringG
 	if !ok {
 		return
 	}
-	w, ok := wi.(*writer.HTMLResponseWriter)
+
+	gw, ok := wi.(*writer.GzipWriter)
 	if !ok {
 		return
 	}
+
+	w, ok := gw.ResponseWriter.(*writer.HTMLResponseWriter)
+	if !ok {
+		return
+	}
+
 	w.CSSURL = cssURL
 	w.JSURL = jsURL
 	w.APIUIVersion = version

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/steve/pkg/auth"
 	"github.com/rancher/steve/pkg/client"
 	"github.com/rancher/steve/pkg/schema"
+	"github.com/rancher/steve/pkg/schemaserver/server"
 	"github.com/rancher/steve/pkg/schemaserver/types"
 	"github.com/rancher/steve/pkg/server/router"
 	"github.com/rancher/wrangler-api/pkg/generated/controllers/apiextensions.k8s.io"
@@ -32,6 +33,7 @@ type Server struct {
 
 	ClientFactory   *client.Factory
 	BaseSchemas     *types.APISchemas
+	APIServer       *server.Server
 	AccessSetLookup accesscontrol.AccessSetLookup
 	SchemaTemplates []schema.Template
 	AuthMiddleware  auth.Middleware

--- a/pkg/server/handler/apiserver.go
+++ b/pkg/server/handler/apiserver.go
@@ -16,15 +16,19 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func New(cfg *rest.Config, sf schema.Factory, authMiddleware auth.Middleware, next http.Handler, routerFunc router.RouterFunc) (http.Handler, error) {
+func New(cfg *rest.Config, sf schema.Factory, authMiddleware auth.Middleware, next http.Handler, routerFunc router.RouterFunc, schemaServer *server.Server) (http.Handler, error) {
 	var (
 		proxy http.Handler
 		err   error
 	)
 
+	if schemaServer == nil {
+		schemaServer = server.DefaultAPIServer()
+	}
+
 	a := &apiServer{
 		sf:     sf,
-		server: server.DefaultAPIServer(),
+		server: schemaServer,
 	}
 	a.server.AccessControl = accesscontrol.NewAccessControl()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,7 +89,7 @@ func setup(ctx context.Context, server *Server) (http.Handler, *schema.Collectio
 		ccache,
 		sf)
 
-	handler, err := handler.New(server.RestConfig, sf, server.AuthMiddleware, server.Next, server.Router)
+	handler, err := handler.New(server.RestConfig, sf, server.AuthMiddleware, server.Next, server.Router, server.APIServer)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Problems:
1. allow steve to customize the api-ui response writer for the air-gap environment users
2. failed to view steve v1 API when its CRDs schemas contain the arbitrary schema type of the openAPI.

These problems already fixed in 2.5, pick [PR](https://github.com/rancher/steve/pull/14) from the master branch to fix problems for 2.4