### PR TITLE
Don't cancel context of subscribe on method exit

### DIFF
--- a/pkg/server/store/proxy/rbac_store.go
+++ b/pkg/server/store/proxy/rbac_store.go
@@ -182,7 +182,6 @@ func (r *RBACStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, w ty
 	}
 
 	ctx, cancel := context.WithCancel(apiOp.Context())
-	defer cancel()
 	apiOp = apiOp.WithContext(ctx)
 
 	eg := errgroup.Group{}
@@ -218,6 +217,7 @@ func (r *RBACStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, w ty
 		defer close(response)
 		<-ctx.Done()
 		eg.Wait()
+		cancel()
 	}()
 
 	return response, nil


### PR DESCRIPTION
The ws channels created by `project-member` are cancelled early.

Reproduction steps

1. Create the cluster cluster1
2. Create the user test-user and add it as a member of cluster1 with the role ClusterMember, then add it to the Default project with the role ProjectMember
3. Log in with test-user and create a deployment from the command line. 
4. Navigate to the dashboard page, The ws connection with socketId = 2 will report a recurring error, as shown in the figure

![Jietu20210625-140001](https://user-images.githubusercontent.com/27733391/123731027-f677bb00-d8c9-11eb-9afd-06bc835b88ed.jpg)


https://github.com/cnrancher/pandaria/issues/1549