### PR TITLE
[2.5] Backport: Add ability to disallow methods per a schema attribute

### DIFF
--- a/pkg/attributes/attributes.go
+++ b/pkg/attributes/attributes.go
@@ -127,6 +127,25 @@ func Access(s *types.APISchema) interface{} {
 	return s.Attributes["access"]
 }
 
+func AddDisallowMethods(s *types.APISchema, methods ...string) {
+	data, ok := s.Attributes["disallowMethods"].(map[string]bool)
+	if !ok {
+		data = map[string]bool{}
+		s.Attributes["disallowMethods"] = data
+	}
+	for _, method := range methods {
+		data[method] = true
+	}
+}
+
+func DisallowMethods(s *types.APISchema) map[string]bool {
+	data, ok := s.Attributes["disallowMethods"].(map[string]bool)
+	if !ok {
+		return nil
+	}
+	return data
+}
+
 func SetAPIResource(s *types.APISchema, resource v1.APIResource) {
 	SetResource(s, resource.Name)
 	SetVerbs(s, resource.Verbs)

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -73,6 +73,14 @@ func formatter(summarycache *summarycache.SummaryCache) types.Formatter {
 			resource.Links["update"] = u
 		}
 
+		if _, ok := resource.Links["update"]; !ok && slice.ContainsString(resource.Schema.ResourceMethods, "blocked-PUT") {
+			resource.Links["update"] = "blocked"
+		}
+
+		if _, ok := resource.Links["remove"]; !ok && slice.ContainsString(resource.Schema.ResourceMethods, "blocked-DELETE") {
+			resource.Links["remove"] = "blocked"
+		}
+
 		if unstr, ok := resource.APIObject.Object.(*unstructured.Unstructured); ok {
 			s, rel := summarycache.SummaryAndRelationship(unstr)
 			data.PutValue(unstr.Object, map[string]interface{}{

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -99,21 +99,28 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 			}
 		}
 
+		allowed := func(method string) string {
+			if attributes.DisallowMethods(s)[method] {
+				return "blocked-" + method
+			}
+			return method
+		}
+
 		s = s.DeepCopy()
 		attributes.SetAccess(s, verbAccess)
 		if verbAccess.AnyVerb("list", "get") {
-			s.ResourceMethods = append(s.ResourceMethods, http.MethodGet)
-			s.CollectionMethods = append(s.CollectionMethods, http.MethodGet)
+			s.ResourceMethods = append(s.ResourceMethods, allowed(http.MethodGet))
+			s.CollectionMethods = append(s.CollectionMethods, allowed(http.MethodGet))
 		}
 		if verbAccess.AnyVerb("delete") {
-			s.ResourceMethods = append(s.ResourceMethods, http.MethodDelete)
+			s.ResourceMethods = append(s.ResourceMethods, allowed(http.MethodDelete))
 		}
 		if verbAccess.AnyVerb("update") {
-			s.ResourceMethods = append(s.ResourceMethods, http.MethodPut)
-			s.ResourceMethods = append(s.ResourceMethods, http.MethodPatch)
+			s.ResourceMethods = append(s.ResourceMethods, allowed(http.MethodPut))
+			s.ResourceMethods = append(s.ResourceMethods, allowed(http.MethodPatch))
 		}
 		if verbAccess.AnyVerb("create") {
-			s.CollectionMethods = append(s.CollectionMethods, http.MethodPost)
+			s.CollectionMethods = append(s.CollectionMethods, allowed(http.MethodPost))
 		}
 
 		if len(s.CollectionMethods) == 0 && len(s.ResourceMethods) == 0 {


### PR DESCRIPTION
Backporting the disallow methods 

`git cherry-pick d9512c366d0f35744ec7198d41802c2506ce1630` 
`git cherry-pick bcbcef36b3f10b14f06b3c5b525310447dcdb64a `