### PR TITLE
Allow truncated secrets/configmaps in collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist
 *.swp
 .idea
+steve

--- a/pkg/resources/formatters/collection.go
+++ b/pkg/resources/formatters/collection.go
@@ -1,0 +1,36 @@
+package formatters
+
+import (
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/norman/types/convert"
+)
+
+const (
+	maxNumBytesInDataParam = "truncateBytes"
+	truncatedField         = "isTruncated"
+)
+
+func TruncateBytesInData(request *types.APIRequest, collection *types.GenericCollection) {
+	maxNumBytesInDataValue := request.Query.Get(maxNumBytesInDataParam)
+	if len(maxNumBytesInDataValue) == 0 {
+		return
+	}
+	maxNumBytes, err := convert.ToNumber(maxNumBytesInDataValue)
+	if err != nil {
+		return
+	}
+	for i := 0; i < len(collection.Data); i++ {
+		data := collection.Data[i].APIObject.Data()
+		resourceDataInt, ok := data["data"]
+		if !ok {
+			continue
+		}
+		resourceData := resourceDataInt.(map[string]interface{})
+		for k, v := range resourceData {
+			if len(v.(string)) > int(maxNumBytes) {
+				data[truncatedField] = true
+				resourceData[k] = v.(string)[:maxNumBytes]
+			}
+		}
+	}
+}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -52,10 +52,16 @@ func DefaultSchemaTemplates(cf *client.Factory,
 		{
 			ID:        "configmap",
 			Formatter: formatters.DropHelmData,
+			Customize: func(apiSchema *types.APISchema) {
+				apiSchema.CollectionFormatter = formatters.TruncateBytesInData
+			},
 		},
 		{
 			ID:        "secret",
 			Formatter: formatters.DropHelmData,
+			Customize: func(apiSchema *types.APISchema) {
+				apiSchema.CollectionFormatter = formatters.TruncateBytesInData
+			},
 		},
 		{
 			ID:        "pod",

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/steve/pkg/resources/formatters"
 	"github.com/rancher/steve/pkg/resources/userpreferences"
 	"github.com/rancher/steve/pkg/schema"
-	steveschema "github.com/rancher/steve/pkg/schema"
 	"github.com/rancher/steve/pkg/stores/proxy"
 	"github.com/rancher/steve/pkg/summarycache"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -24,7 +23,7 @@ import (
 )
 
 func DefaultSchemas(ctx context.Context, baseSchema *types.APISchemas, ccache clustercache.ClusterCache,
-	cg proxy.ClientGetter, schemaFactory steveschema.Factory, serverVersion string) error {
+	cg proxy.ClientGetter, schemaFactory schema.Factory, serverVersion string) error {
 	counts.Register(baseSchema, ccache)
 	subscribe.Register(baseSchema, func(apiOp *types.APIRequest) *types.APISchemas {
 		user, ok := request.UserFrom(apiOp.Context())


### PR DESCRIPTION
This PR adds the ability to specify an option, `truncateBytes`, to return a list of secrets / configmaps that are truncated. 

If truncated, the secrets will be returned with an `isTruncated` field.

Related Issue: https://github.com/rancher/rancher/issues/25487

---

#### Context

The purpose of this PR is to allow the UI to be able to add something like `?truncateBytes=640` in order to ensure that they aren't loading the entire contents of secrets / configmaps on just trying to list resources.

Instead, they will be able to partially load the resources and decide whether they need to collect the full data of the secret / configmap if it has been truncated (which is indicated by the `isTruncated` flag on the secret / configmap) when a user needs a detailed view of the content of a secret / configmap.