### PR TITLE
[2.5] Fix role revision index for rolebindings that bind to clusterroles

### DIFF
--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -90,8 +90,7 @@ func (p *policyRuleIndex) addRolesToHash(digest hash.Hash, subjectName string) {
 			digest.Write(null)
 		case "ClusterRole":
 			digest.Write([]byte(rb.RoleRef.Name))
-			digest.Write([]byte(rb.Namespace))
-			digest.Write([]byte(p.revisions.roleRevision(rb.Namespace, rb.RoleRef.Name)))
+			digest.Write([]byte(p.revisions.roleRevision("", rb.RoleRef.Name)))
 			digest.Write(null)
 		}
 	}


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/31982

This change ensures we're properly tracking revisions for ClusterRoles bound to RoleBindings. Before this change, the role revision index had elements like: `<rb-namespace>/<cr-name> --> <revision>` (should be `<cr-name> --> <revision>`), which caused OnChange handlers not to find the ClusterRole in question (since it was associated to the wrong namespace) and not update the revision number. Since the revision number wasn't getting updated for these ClusterRoles, cache keys weren't changing, causing stale access sets and schemas to be used.