### PR TITLE
feat: support k8s version less than 1.16

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -35,7 +35,7 @@ func (a *addQuery) RoundTrip(req *http.Request) (*http.Response, error) {
 	for k, v := range a.values {
 		q.Set(k, v)
 	}
-	req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+	req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io")
 	req.URL.RawQuery = q.Encode()
 	return a.next.RoundTrip(req)
 }
@@ -59,10 +59,10 @@ func NewFactory(cfg *rest.Config, impersonate bool) (*Factory, error) {
 
 	tableClientCfg := rest.CopyConfig(clientCfg)
 	tableClientCfg.Wrap(setTable)
-	tableClientCfg.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io"
+	tableClientCfg.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io"
 	tableWatchClientCfg := rest.CopyConfig(watchClientCfg)
 	tableWatchClientCfg.Wrap(setTable)
-	tableWatchClientCfg.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io"
+	tableWatchClientCfg.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io"
 
 	md, err := metadata.NewForConfig(cfg)
 	if err != nil {

--- a/pkg/resources/common/dynamiccolumns.go
+++ b/pkg/resources/common/dynamiccolumns.go
@@ -96,7 +96,7 @@ func newClient(config *rest.Config) (*rest.RESTClient, error) {
 	config = rest.CopyConfig(config)
 	config.RateLimiter = ratelimit.None
 	config.UserAgent = rest.DefaultKubernetesUserAgent()
-	config.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io"
+	config.AcceptContentTypes = "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io"
 	config.GroupVersion = &schema.GroupVersion{}
 	config.NegotiatedSerializer = serializer.NewCodecFactory(scheme)
 	config.APIPath = "/"

--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -169,7 +169,8 @@ func rowToObject(obj *unstructured.Unstructured) {
 		return
 	}
 	if obj.Object["kind"] != "Table" ||
-		obj.Object["apiVersion"] != "meta.k8s.io/v1" {
+		(obj.Object["apiVersion"] != "meta.k8s.io/v1" &&
+			obj.Object["apiVersion"] != "meta.k8s.io/v1beta1") {
 		return
 	}
 
@@ -181,7 +182,8 @@ func rowToObject(obj *unstructured.Unstructured) {
 
 func tableToList(obj *unstructured.UnstructuredList) {
 	if obj.Object["kind"] != "Table" ||
-		obj.Object["apiVersion"] != "meta.k8s.io/v1" {
+		(obj.Object["apiVersion"] != "meta.k8s.io/v1" &&
+			obj.Object["apiVersion"] != "meta.k8s.io/v1beta1") {
 		return
 	}
 


### PR DESCRIPTION
.Metadata.fields is not returned by steve api in k8s version 1.13.

K8S version less than 1.16 accepts v=v1beta1 header for table request.

The PR adds application/json;as=Table;v=v1beta1;g=meta.k8s.io header in request therefore .metadata.fields can be returned by steve api.