### PR TITLE
Update to Golang 1.17 for builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.13.4 as build
+FROM golang:1.17 as build
 COPY go.mod go.sum main.go /src/
 COPY pkg /src/pkg/
 #RUN --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
1.13 is far too old, update to Golang 1.17 when building docker.