### PR TITLE
[2.5] Prevent write on closed channel

### DIFF
--- a/pkg/summarycache/summarycache.go
+++ b/pkg/summarycache/summarycache.go
@@ -80,6 +80,7 @@ func (s *SummaryCache) OnInboundRelationshipChange(ctx context.Context, schema *
 	s.cbs[id] = cb
 
 	go func() {
+		defer close(ret)
 		for rel := range cb {
 			if rel.Kind == kind &&
 				rel.APIVersion == apiVersion &&
@@ -94,7 +95,6 @@ func (s *SummaryCache) OnInboundRelationshipChange(ctx context.Context, schema *
 		s.Lock()
 		defer s.Unlock()
 		close(cb)
-		defer close(ret)
 		delete(s.cbs, id)
 	}()
 


### PR DESCRIPTION
Closing a channel in a separate goroutine than the one it is being written from can cause a write on closed channel panic. https://github.com/rancher/rancher/issues/37353