### PR TITLE
Make watches debuggable

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -318,6 +318,9 @@ func (s *Store) listAndWatch(apiOp *types.APIRequest, client dynamic.ResourceInt
 				obj, err := s.byID(apiOp, schema, rel.Namespace, rel.Name)
 				if err == nil {
 					result <- s.toAPIEvent(apiOp, schema, watch.Modified, obj)
+				} else {
+					logrus.Debugf("notifier watch error: %v", err)
+					returnErr(errors.Wrapf(err, "notifier watch error: %v", err), result)
 				}
 			}
 			return fmt.Errorf("closed")
@@ -327,6 +330,12 @@ func (s *Store) listAndWatch(apiOp *types.APIRequest, client dynamic.ResourceInt
 	eg.Go(func() error {
 		for event := range watcher.ResultChan() {
 			if event.Type == watch.Error {
+				if status, ok := event.Object.(*metav1.Status); ok {
+					logrus.Debugf("event watch error: %s", status.Message)
+					returnErr(fmt.Errorf("event watch error: %s", status.Message), result)
+				} else {
+					logrus.Debugf("event watch error: could not decode event object %T", event.Object)
+				}
 				continue
 			}
 			result <- s.toAPIEvent(apiOp, schema, event.Type, event.Object)


### PR DESCRIPTION
# Return websocket error and add logging for watches

Add debug logs and send websocket messages when the watch is closed
unexpectedly.

In addition to being helpful for debugging, the dashboard specifically
looks for a `resource.error` event containing the string "too old" in
order to trigger the watch to be resynced with a refreshed revision
number.  Without this error returned, the dashboard will only see
`resource.stop` events and never change its behavior, continuing to try
to restart the watch with an incorrect resource version.

# Make watch timeout configurable

By default, a watch times out after 30 minutes. For debugging purposes,
it's convenient if this can be decreased. Add an environment variable
CATTLE_WATCH_TIMEOUT_SECONDS to enable setting the timeout in seconds.

https://github.com/rancher/rancher/issues/37627