### PR TITLE
[WIP] Optimize schema generation

### DIFF
--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -150,6 +150,31 @@ func (p *policyRuleIndex) addAccess(accessSet *AccessSet, namespace string, role
 	}
 }
 
+func (p *policyRuleIndex) removeAccess(accessSet *AccessSet, namespace string, roleRef rbacv1.RoleRef) {
+	for _, rule := range p.getRules(namespace, roleRef) {
+		for _, group := range rule.APIGroups {
+			for _, resource := range rule.ResourceNames {
+				names := rule.ResourceNames
+				if len(names) == 0 {
+					names = []string{All}
+				}
+				for _, resourceName := range names {
+					for _, verb := range rule.Verbs {
+						accessSet.Remove(verb,
+							schema.GroupResource{
+								Group:    group,
+								Resource: resource,
+							}, Access{
+								Namespace:    namespace,
+								ResourceName: resourceName,
+							})
+					}
+				}
+			}
+		}
+	}
+}
+
 func (p *policyRuleIndex) getRules(namespace string, roleRef rbacv1.RoleRef) []rbacv1.PolicyRule {
 	switch roleRef.Kind {
 	case "ClusterRole":

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -19,17 +19,18 @@ import (
 	steveschema "github.com/rancher/steve/pkg/schema"
 	"github.com/rancher/steve/pkg/stores/proxy"
 	"github.com/rancher/steve/pkg/summarycache"
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/discovery"
 )
 
 func DefaultSchemas(ctx context.Context, baseSchema *types.APISchemas, ccache clustercache.ClusterCache,
-	cg proxy.ClientGetter, schemaFactory steveschema.Factory, serverVersion string) error {
+	cg proxy.ClientGetter, schemaFactory steveschema.Factory, serverVersion string, rbac v1.Interface) error {
 	counts.Register(baseSchema, ccache)
 	subscribe.Register(baseSchema, func(apiOp *types.APIRequest) *types.APISchemas {
 		user, ok := request.UserFrom(apiOp.Context())
 		if ok {
-			schemas, err := schemaFactory.Schemas(user)
+			schemas, err := schemaFactory.SchemasWithWatch(user, rbac)
 			if err == nil {
 				return schemas
 			}

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -9,6 +9,11 @@ import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/accesscontrol"
 	"github.com/rancher/steve/pkg/attributes"
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -35,6 +40,117 @@ func (c *Collection) Schemas(user user.Info) (*types.APISchemas, error) {
 	}
 
 	c.cache.Add(access.ID, schemas, 24*time.Hour)
+	return schemas, nil
+}
+
+func (c *Collection) setup(rbac v1.Interface) error {
+	c.watchLock.Lock()
+	defer c.watchLock.Unlock()
+	if c.roleBindings == nil {
+		c.roleBindings = rbac.RoleBinding()
+	}
+	if c.rbByUser == nil {
+		c.rbByUser = make(map[string]chan watch.Event)
+	}
+	if c.rbWatch == nil {
+		rbs, err := c.roleBindings.List("", metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		logrus.Tracef("[steve.schema.Collection] starting rolebindings watch")
+		timeout := int64(30 * 60)
+		c.rbWatch, err = c.roleBindings.Watch("", metav1.ListOptions{
+			ResourceVersion: rbs.ResourceVersion,
+			TimeoutSeconds:  &timeout,
+		})
+		if err != nil {
+			return err
+		}
+		go func() {
+			defer func() { c.rbWatch = nil }()
+			defer c.rbWatch.Stop()
+			for e := range c.rbWatch.ResultChan() {
+				rb := e.Object.(*rbacv1.RoleBinding)
+				for _, s := range rb.Subjects {
+					logrus.Tracef("[steve.schema.Collection] got event for user [%s] : %+v", s.Name, e)
+					if _, ok := c.rbByUser[s.Name]; !ok {
+						c.rbByUser[s.Name] = make(chan watch.Event, 10)
+					}
+					c.rbByUser[s.Name] <- e
+				}
+			}
+			logrus.Tracef("[steve.schema.Collection] role binding watch closed")
+		}()
+	}
+	if c.watchesStarted == nil {
+		c.watchesStarted = make(map[string]struct{})
+	}
+	return nil
+}
+
+func (c *Collection) SchemasWithWatch(user user.Info, rbac v1.Interface) (*types.APISchemas, error) {
+	if err := c.setup(rbac); err != nil {
+		return nil, err
+	}
+	access := c.as.AccessFor(user)
+	if _, ok := c.watchesStarted[user.GetUID()]; !ok {
+		go func() {
+			c.watchesStarted[user.GetUID()] = struct{}{}
+			defer delete(c.watchesStarted, user.GetUID())
+			if _, ok := c.rbByUser[user.GetUID()]; !ok {
+				c.rbByUser[user.GetUID()] = make(chan watch.Event, 10) // FIXME handle groups
+			}
+			for e := range c.rbByUser[user.GetUID()] {
+				rb := e.Object.(*rbacv1.RoleBinding)
+				switch e.Type {
+				case watch.Added:
+					c.as.AddAccess(access, rb.Namespace, rb.RoleRef)
+				case watch.Modified:
+					userInSubjects := false
+					for _, s := range rb.Subjects {
+						if s.Name == user.GetUID() {
+							userInSubjects = true
+							break
+						}
+					}
+					if userInSubjects {
+						c.as.AddAccess(access, rb.Namespace, rb.RoleRef)
+					} else {
+						c.as.RemoveAccess(access, rb.Namespace, rb.RoleRef)
+					}
+				case watch.Deleted:
+					c.as.RemoveAccess(access, rb.Namespace, rb.RoleRef)
+				default:
+					continue
+				}
+				schemas, err := c.schemasForSubject(access)
+				if err != nil {
+					logrus.Errorf("steve schemas error: %v", err) // FIXME real error handling
+				}
+				c.lock.Lock()
+				c.cache.Add(access.ID, schemas, 24*time.Hour)
+				c.lock.Unlock()
+			}
+			logrus.Tracef("[steve.schema.Collection] role binding by user channel closed")
+		}()
+	}
+
+	c.lock.RLock()
+	val, ok := c.cache.Get(access.ID)
+	c.lock.RUnlock()
+	if ok {
+		schemas, _ := val.(*types.APISchemas)
+		return schemas, nil
+	}
+
+	schemas, err := c.schemasForSubject(access)
+	if err != nil {
+		return nil, err
+	}
+
+	c.lock.Lock()
+	c.cache.Add(access.ID, schemas, 24*time.Hour)
+	c.lock.Unlock()
 	return schemas, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -138,7 +138,7 @@ func setup(ctx context.Context, server *Server) error {
 	server.ClusterCache = ccache
 	sf := schema.NewCollection(ctx, server.BaseSchemas, asl)
 
-	if err = resources.DefaultSchemas(ctx, server.BaseSchemas, ccache, server.ClientFactory, sf, server.Version); err != nil {
+	if err = resources.DefaultSchemas(ctx, server.BaseSchemas, ccache, server.ClientFactory, sf, server.Version, server.controllers.RBAC); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
first commit - add ability to look up access by schema - helps optimize the actual creation of new objects since the request is known
second commit - prevent the full regeneration of the access set and schemas for a user by adding watches that asynchronously update the access set - helps optimize general dashboard subscriptions