### PR TITLE
Pagination, sorting, filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,153 @@
+steve
+=====
+
+Steve is a lightweight API proxy for Kubernetes whose aim is to create an
+interface layer suitable for dashboards to efficiently interact with
+Kubernetes.
+
+API Usage
+---------
+
+### Kubernetes proxy
+
+Requests made to `/api`, `/api/*`, `/apis/*`, `/openapi/*` and `/version` will
+be proxied directly to Kubernetes.
+
+### /v1 API
+
+Steve registers all Kubernetes resources as schemas in the /v1 API. Any
+endpoint can support methods GET, POST, PATCH, PUT, or DELETE, depending on
+what the underlying Kubernetes endpoint supports and the user's permissions.
+
+* `/v1/{type}` - all cluster-scoped resources OR all resources in all
+  namespaces of type `{type}` that the user has access to
+* `/v1/{type}/{name}` - cluster-scoped resource of type `{type}` and unique name `{name}`
+* `/v1/{type}/{namespace}` - all resources of type `{type}` under namespace `{namespace}`
+* `/v1/{type}/{namespace}/{name}` - resource of type `{type}` under namespace
+  `{namespace}` with name `{name}` unique within the namespace
+
+### Query parameters
+
+Steve supports query parameters to perform actions or process data on top of
+what Kubernetes supports.
+
+#### `link`
+
+Trigger a link handler, which is registered with the schema. Examples are
+calling the shell for a cluster, or following logs during cluster or catalog
+operations:
+
+```
+GET /v1/management.cattle.io.clusters/local?link=log
+```
+
+#### `action`
+
+Trigger an action handler, which is registered with the schema. Examples are
+generating a kubeconfig for a cluster, or installing an app from a catalog:
+
+```
+POST /v1/catalog.cattle.io.clusterrepos/rancher-partner-charts?action=install
+```
+
+#### `filter`
+
+Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).
+
+Filter results by a designated field. Filter keys use dot notation to denote
+the subfield of an object to filter on. The filter value is matched as a
+substring.
+
+Example, filtering by object name:
+
+```
+/v1/{type}?filter=metadata.name=foo
+```
+
+Filters are ANDed together, so an object must match all filters to be
+included in the list.
+
+```
+/v1/{type}?filter=metadata.name=foo&filter=metadata.namespace=bar
+```
+
+Arrays are searched for matching items. If any item in the array matches, the
+item is included in the list.
+
+```
+/v1/{type}?filter=spec.containers.image=alpine
+```
+
+#### `sort`
+
+Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).
+
+Results can be sorted lexicographically by primary and secondary columns.
+
+Sorting by only a primary column, for example name:
+
+```
+/v1/{type}?sort=metadata.name
+```
+
+Reverse sorting by name:
+
+```
+/v1/{type}?sort=-metadata.name
+```
+
+The secondary sort criteria is comma separated.
+
+Example, sorting by name and creation time in ascending order:
+
+```
+/v1/{type}?sort=metadata.name,metadata.creationTimestamp
+```
+
+Reverse sort by name, normal sort by creation time:
+
+```
+/v1/{type}?sort=-metadata.name,metadata.creationTimestamp
+```
+
+Normal sort by name, reverse sort by creation time:
+
+```
+/v1/{type}?sort=metadata.name,-metadata.creationTimestamp
+```
+
+#### `page`, `pagesize`, and `revision`
+
+Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).
+
+Results can be batched by pages for easier display.
+
+Example initial request returning a page with 10 results:
+
+```
+/v1/{type}?pagesize=10
+```
+
+Pages are one-indexed, so this is equivalent to
+
+```
+/v1/{type}?pagesize=10&page=1
+```
+To retrieve subsequent pages, the page number and the list revision number must
+be included in the request. This ensures the page will be retrieved from the
+cache, rather than making a new request to Kubernetes. If the revision number
+is omitted, a new fetch is performed in order to get the latest revision. The
+revision is included in the list response.
+
+```
+/v1/{type}?pagezie=10&page=2&revision=107440
+```
+
+The total number of pages and individual items are included in the list
+response as `pages` and `count` respectively.
+
+If a page number is out of bounds, an empty list is returned.
+
+`page` and `pagesize` can be used alongside the `limit` and `continue`
+parameters supported by Kubernetes. `limit` and `continue` are typically used
+for server-side chunking and do not guarantee results in any order.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,39 @@ generating a kubeconfig for a cluster, or installing an app from a catalog:
 POST /v1/catalog.cattle.io.clusterrepos/rancher-partner-charts?action=install
 ```
 
+#### `limit`
+
+Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).
+
+Set the maximum number of results to retrieve from Kubernetes. The limit is
+passed on as a parameter to the Kubernetes request. The purpose of setting this
+limit is to prevent a huge response from overwhelming Steve and Rancher. For
+more information about setting limits, review the Kubernetes documentation on
+[retrieving results in
+chunks](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks).
+
+The limit controls the size of the set coming from Kubernetes, and then
+filtering, sorting, and pagination are applied on that set. Because of this, if
+the result set is partial, there is no guarantee that the result returned to
+the client is fully sorted across the entire list, only across the returned
+chunk.
+
+The returned response will include a `continue` token, which indicates that the
+result is partial and must be used in the subsequent request to retrieve the
+next chunk.
+
+The default limit is 100000. To override the default, set `limit=-1`.
+
+#### `continue`
+
+Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).
+
+Continue retrieving the next chunk of a partial list. The continue token is
+included in the response of a limited list and indicates that the result is
+partial. This token can then be used as a query parameter to retrieve the next
+chunk. All chunks have been retrieved when the continue field in the response
+is empty.
+
 #### `filter`
 
 Only applicable to list requests (`/v1/{type}` and `/v1/{type}/{namespace}`).

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
-	github.com/rancher/apiserver v0.0.0-20221205175736-7c507bd5c076
+	github.com/rancher/apiserver v0.0.0-20221220225852-94cba4f28cfd
 	github.com/rancher/dynamiclistener v0.3.5
 	github.com/rancher/kubernetes-provider-detector v0.1.2
 	github.com/rancher/norman v0.0.0-20221205184727-32ef2e185b99

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rancher/apiserver v0.0.0-20221205175736-7c507bd5c076 h1:wS95KbXFI1QOVQr3Tz+qyOJ9iia1ITCnjsapxJyI/9U=
-github.com/rancher/apiserver v0.0.0-20221205175736-7c507bd5c076/go.mod h1:xwQhXv3XFxWfA6tLa4ZeaERu8ldNbyKv2sF+mT+c5WA=
+github.com/rancher/apiserver v0.0.0-20221220225852-94cba4f28cfd h1:g0hNrbONfmY4lxvrD2q9KkueYYY4wKUYscm6Ih0QfQ0=
+github.com/rancher/apiserver v0.0.0-20221220225852-94cba4f28cfd/go.mod h1:xwQhXv3XFxWfA6tLa4ZeaERu8ldNbyKv2sF+mT+c5WA=
 github.com/rancher/client-go v1.25.4-rancher1 h1:9MlBC8QbgngUkhNzMR8rZmmCIj6WNRHFOnYiwC2Kty4=
 github.com/rancher/client-go v1.25.4-rancher1/go.mod h1:8trHCAC83XKY0wsBIpbirZU4NTUpbuhc2JnI7OruGZw=
 github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S+WV0JA6A=

--- a/pkg/stores/partition/listprocessor/processor.go
+++ b/pkg/stores/partition/listprocessor/processor.go
@@ -1,0 +1,150 @@
+// Package listprocessor contains methods for filtering, sorting, and paginating lists of objects.
+package listprocessor
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/wrangler/pkg/data"
+	"github.com/rancher/wrangler/pkg/data/convert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	defaultLimit  = 100000
+	continueParam = "continue"
+	limitParam    = "limit"
+	filterParam   = "filter"
+)
+
+// ListOptions represents the query parameters that may be included in a list request.
+type ListOptions struct {
+	ChunkSize int
+	Resume    string
+	Filters   []Filter
+}
+
+// Filter represents a field to filter by.
+// A subfield in an object is represented in a request query using . notation, e.g. 'metadata.name'.
+// The subfield is internally represented as a slice, e.g. [metadata, name].
+type Filter struct {
+	field []string
+	match string
+}
+
+// ParseQuery parses the query params of a request and returns a ListOptions.
+func ParseQuery(apiOp *types.APIRequest) *ListOptions {
+	chunkSize := getLimit(apiOp)
+	q := apiOp.Request.URL.Query()
+	cont := q.Get(continueParam)
+	filterParams := q[filterParam]
+	filterOpts := []Filter{}
+	for _, filters := range filterParams {
+		filter := strings.Split(filters, "=")
+		if len(filter) != 2 {
+			continue
+		}
+		filterOpts = append(filterOpts, Filter{field: strings.Split(filter[0], "."), match: filter[1]})
+	}
+	return &ListOptions{
+		ChunkSize: chunkSize,
+		Resume:    cont,
+		Filters:   filterOpts,
+	}
+}
+
+// getLimit extracts the limit parameter from the request or sets a default of 100000.
+// Since a default is always set, this implies that clients must always be
+// aware that the list may be incomplete.
+func getLimit(apiOp *types.APIRequest) int {
+	limitString := apiOp.Request.URL.Query().Get(limitParam)
+	limit, err := strconv.Atoi(limitString)
+	if err != nil {
+		limit = 0
+	}
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	return limit
+}
+
+// FilterList accepts a channel of unstructured objects and a slice of filters and returns the filtered list.
+// Filters are ANDed together.
+func FilterList(list <-chan []unstructured.Unstructured, filters []Filter) []unstructured.Unstructured {
+	result := []unstructured.Unstructured{}
+	for items := range list {
+		for _, item := range items {
+			if len(filters) == 0 {
+				result = append(result, item)
+				continue
+			}
+			if matchesAll(item.Object, filters) {
+				result = append(result, item)
+			}
+		}
+	}
+	return result
+}
+
+func matchesOne(obj map[string]interface{}, filter Filter) bool {
+	var objValue interface{}
+	var ok bool
+	subField := []string{}
+	for !ok && len(filter.field) > 0 {
+		objValue, ok = data.GetValue(obj, filter.field...)
+		if !ok {
+			subField = append(subField, filter.field[len(filter.field)-1])
+			filter.field = filter.field[:len(filter.field)-1]
+		}
+	}
+	if !ok {
+		return false
+	}
+	switch typedVal := objValue.(type) {
+	case string, int, bool:
+		if len(subField) > 0 {
+			return false
+		}
+		stringVal := convert.ToString(typedVal)
+		if strings.Contains(stringVal, filter.match) {
+			return true
+		}
+	case []interface{}:
+		filter = Filter{field: subField, match: filter.match}
+		if matchesAny(typedVal, filter) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAny(obj []interface{}, filter Filter) bool {
+	for _, v := range obj {
+		switch typedItem := v.(type) {
+		case string, int, bool:
+			stringVal := convert.ToString(typedItem)
+			if strings.Contains(stringVal, filter.match) {
+				return true
+			}
+		case map[string]interface{}:
+			if matchesOne(typedItem, filter) {
+				return true
+			}
+		case []interface{}:
+			if matchesAny(typedItem, filter) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesAll(obj map[string]interface{}, filters []Filter) bool {
+	for _, f := range filters {
+		if !matchesOne(obj, f) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/stores/partition/listprocessor/processor.go
+++ b/pkg/stores/partition/listprocessor/processor.go
@@ -161,15 +161,12 @@ func ParseQuery(apiOp *types.APIRequest) *ListOptions {
 }
 
 // getLimit extracts the limit parameter from the request or sets a default of 100000.
-// Since a default is always set, this implies that clients must always be
-// aware that the list may be incomplete.
+// The default limit can be explicitly disabled by setting it to zero or negative.
+// If the default is accepted, clients must be aware that the list may be incomplete, and use the "continue" token to get the next chunk of results.
 func getLimit(apiOp *types.APIRequest) int {
 	limitString := apiOp.Request.URL.Query().Get(limitParam)
 	limit, err := strconv.Atoi(limitString)
 	if err != nil {
-		limit = 0
-	}
-	if limit <= 0 {
 		limit = defaultLimit
 	}
 	return limit

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -796,3 +796,322 @@ func TestFilterList(t *testing.T) {
 		})
 	}
 }
+
+func TestSortList(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []unstructured.Unstructured
+		sort    Sort
+		want    []unstructured.Unstructured
+	}{
+		{
+			name: "sort metadata.name",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				field: []string{"metadata", "name"},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reverse sort metadata.name",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				field: []string{"metadata", "name"},
+				order: DESC,
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid field",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				field: []string{"data", "productType"},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unsorted",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+			sort: Sort{},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := SortList(test.objects, test.sort)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -1115,3 +1115,202 @@ func TestSortList(t *testing.T) {
 		})
 	}
 }
+
+func TestPaginateList(t *testing.T) {
+	objects := []unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "fuji",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "honeycrisp",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "granny-smith",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "red-delicious",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "crispin",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "bramley",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "golden-delicious",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"kind": "apple",
+				"metadata": map[string]interface{}{
+					"name": "macintosh",
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name       string
+		objects    []unstructured.Unstructured
+		pagination Pagination
+		want       []unstructured.Unstructured
+		wantPages  int
+	}{
+		{
+			name:    "pagesize=3, page=unset",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+			},
+			want:      objects[:3],
+			wantPages: 3,
+		},
+		{
+			name:    "pagesize=3, page=1",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+				page:     1,
+			},
+			want:      objects[:3],
+			wantPages: 3,
+		},
+		{
+			name:    "pagesize=3, page=2",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+				page:     2,
+			},
+			want:      objects[3:6],
+			wantPages: 3,
+		},
+		{
+			name:    "pagesize=3, page=last",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+				page:     3,
+			},
+			want:      objects[6:],
+			wantPages: 3,
+		},
+		{
+			name:    "pagesize=3, page>last",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+				page:     37,
+			},
+			want:      []unstructured.Unstructured{},
+			wantPages: 3,
+		},
+		{
+			name:    "pagesize=3, page<0",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 3,
+				page:     -4,
+			},
+			want:      objects[:3],
+			wantPages: 3,
+		},
+		{
+			name:       "pagesize=0",
+			objects:    objects,
+			pagination: Pagination{},
+			want:       objects,
+			wantPages:  0,
+		},
+		{
+			name:    "pagesize=-1",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: -7,
+			},
+			want:      objects,
+			wantPages: 0,
+		},
+		{
+			name:    "even page size, even list size",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 2,
+				page:     2,
+			},
+			want:      objects[2:4],
+			wantPages: 4,
+		},
+		{
+			name:    "even page size, odd list size",
+			objects: objects[1:],
+			pagination: Pagination{
+				pageSize: 2,
+				page:     2,
+			},
+			want:      objects[3:5],
+			wantPages: 4,
+		},
+		{
+			name:    "odd page size, even list size",
+			objects: objects,
+			pagination: Pagination{
+				pageSize: 5,
+				page:     2,
+			},
+			want:      objects[5:],
+			wantPages: 2,
+		},
+		{
+			name:    "odd page size, odd list size",
+			objects: objects[1:],
+			pagination: Pagination{
+				pageSize: 3,
+				page:     2,
+			},
+			want:      objects[4:7],
+			wantPages: 3,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotPages := PaginateList(test.objects, test.pagination)
+			assert.Equal(t, test.want, got)
+			assert.Equal(t, test.wantPages, gotPages)
+		})
+	}
+}

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -1,0 +1,798 @@
+package listprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestFilterList(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects [][]unstructured.Unstructured
+		filters []Filter
+		want    []unstructured.Unstructured
+	}{
+		{
+			name: "single filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "color"},
+					match: "pink",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multi filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "honeycrisp",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "color"},
+					match: "pink",
+				},
+				{
+					field: []string{"metadata", "name"},
+					match: "honey",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no matches",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "color"},
+					match: "purple",
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
+		{
+			name: "no filters",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter field does not match",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "honeycrisp",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"spec", "volumes"},
+					match: "hostPath",
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
+		{
+			name: "filter subfield does not match",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "honeycrisp",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "productType"},
+					match: "tablet",
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
+		{
+			name: "almost valid filter key",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "color", "shade"},
+					match: "green",
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
+		{
+			name: "match string array",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"pink",
+									"red",
+									"green",
+									"yellow",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"blue",
+									"red",
+									"black",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"yellow",
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "colors"},
+					match: "yellow",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "apple",
+						},
+						"data": map[string]interface{}{
+							"colors": []interface{}{
+								"pink",
+								"red",
+								"green",
+								"yellow",
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "banana",
+						},
+						"data": map[string]interface{}{
+							"colors": []interface{}{
+								"yellow",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match object array",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "fuji",
+										"color": "pink",
+									},
+									map[string]interface{}{
+										"name":  "granny-smith",
+										"color": "green",
+									},
+									map[string]interface{}{
+										"name":  "red-delicious",
+										"color": "red",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "blueberry",
+										"color": "blue",
+									},
+									map[string]interface{}{
+										"name":  "raspberry",
+										"color": "red",
+									},
+									map[string]interface{}{
+										"name":  "blackberry",
+										"color": "black",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "cavendish",
+										"color": "yellow",
+									},
+									map[string]interface{}{
+										"name":  "plantain",
+										"color": "green",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "varieties", "color"},
+					match: "red",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "apple",
+						},
+						"data": map[string]interface{}{
+							"varieties": []interface{}{
+								map[string]interface{}{
+									"name":  "fuji",
+									"color": "pink",
+								},
+								map[string]interface{}{
+									"name":  "granny-smith",
+									"color": "green",
+								},
+								map[string]interface{}{
+									"name":  "red-delicious",
+									"color": "red",
+								},
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "berry",
+						},
+						"data": map[string]interface{}{
+							"varieties": []interface{}{
+								map[string]interface{}{
+									"name":  "blueberry",
+									"color": "blue",
+								},
+								map[string]interface{}{
+									"name":  "raspberry",
+									"color": "red",
+								},
+								map[string]interface{}{
+									"name":  "blackberry",
+									"color": "black",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match nested array",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"pink",
+										"green",
+										"red",
+										"purple",
+									},
+									[]interface{}{
+										"fuji",
+										"granny-smith",
+										"red-delicious",
+										"black-diamond",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"blue",
+										"red",
+										"black",
+									},
+									[]interface{}{
+										"blueberry",
+										"raspberry",
+										"blackberry",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"yellow",
+										"green",
+									},
+									[]interface{}{
+										"cavendish",
+										"plantain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "attributes"},
+					match: "black",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "apple",
+						},
+						"data": map[string]interface{}{
+							"attributes": []interface{}{
+								[]interface{}{
+									"pink",
+									"green",
+									"red",
+									"purple",
+								},
+								[]interface{}{
+									"fuji",
+									"granny-smith",
+									"red-delicious",
+									"black-diamond",
+								},
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "berry",
+						},
+						"data": map[string]interface{}{
+							"attributes": []interface{}{
+								[]interface{}{
+									"blue",
+									"red",
+									"black",
+								},
+								[]interface{}{
+									"blueberry",
+									"raspberry",
+									"blackberry",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match nested object array",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"pink": "fuji",
+										},
+										map[string]interface{}{
+											"green": "granny-smith",
+										},
+										map[string]interface{}{
+											"pink": "honeycrisp",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"blue": "blueberry",
+										},
+										map[string]interface{}{
+											"red": "raspberry",
+										},
+										map[string]interface{}{
+											"black": "blackberry",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"yellow": "cavendish",
+										},
+										map[string]interface{}{
+											"green": "plantain",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []Filter{
+				{
+					field: []string{"data", "attributes", "green"},
+					match: "plantain",
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "banana",
+						},
+						"data": map[string]interface{}{
+							"attributes": []interface{}{
+								[]interface{}{
+									map[string]interface{}{
+										"yellow": "cavendish",
+									},
+									map[string]interface{}{
+										"green": "plantain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ch := make(chan []unstructured.Unstructured)
+			go func() {
+				for _, o := range test.objects {
+					ch <- o
+				}
+				close(ch)
+			}()
+			got := FilterList(ch, test.filters)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -842,7 +842,7 @@ func TestSortList(t *testing.T) {
 				},
 			},
 			sort: Sort{
-				field: []string{"metadata", "name"},
+				primaryField: []string{"metadata", "name"},
 			},
 			want: []unstructured.Unstructured{
 				{
@@ -918,8 +918,8 @@ func TestSortList(t *testing.T) {
 				},
 			},
 			sort: Sort{
-				field: []string{"metadata", "name"},
-				order: DESC,
+				primaryField: []string{"metadata", "name"},
+				primaryOrder: DESC,
 			},
 			want: []unstructured.Unstructured{
 				{
@@ -995,7 +995,7 @@ func TestSortList(t *testing.T) {
 				},
 			},
 			sort: Sort{
-				field: []string{"data", "productType"},
+				primaryField: []string{"data", "productType"},
 			},
 			want: []unstructured.Unstructured{
 				{
@@ -1102,6 +1102,318 @@ func TestSortList(t *testing.T) {
 						},
 						"data": map[string]interface{}{
 							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "primary sort ascending, secondary sort ascending",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				primaryField:   []string{"data", "color"},
+				secondaryField: []string{"metadata", "name"},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "primary sort ascending, secondary sort descending",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				primaryField:   []string{"data", "color"},
+				secondaryField: []string{"metadata", "name"},
+				secondaryOrder: DESC,
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "primary sort descending, secondary sort ascending",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				primaryField:   []string{"data", "color"},
+				primaryOrder:   DESC,
+				secondaryField: []string{"metadata", "name"},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "primary sort descending, secondary sort descending",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+			sort: Sort{
+				primaryField:   []string{"data", "color"},
+				primaryOrder:   DESC,
+				secondaryField: []string{"metadata", "name"},
+				secondaryOrder: DESC,
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
 						},
 					},
 				},

--- a/pkg/stores/partition/parallel.go
+++ b/pkg/stores/partition/parallel.go
@@ -72,7 +72,7 @@ func indexOrZero(partitions []Partition, name string) int {
 // List returns a stream of objects up to the requested limit.
 // If the continue token is not empty, it decodes it and returns the stream
 // starting at the indicated marker.
-func (p *ParallelPartitionLister) List(ctx context.Context, limit int, resume string) (<-chan []unstructured.Unstructured, error) {
+func (p *ParallelPartitionLister) List(ctx context.Context, limit int, resume, revision string) (<-chan []unstructured.Unstructured, error) {
 	var state listState
 	if resume != "" {
 		bytes, err := base64.StdEncoding.DecodeString(resume)
@@ -86,6 +86,8 @@ func (p *ParallelPartitionLister) List(ctx context.Context, limit int, resume st
 		if state.Limit > 0 {
 			limit = state.Limit
 		}
+	} else {
+		state.Revision = revision
 	}
 
 	result := make(chan []unstructured.Unstructured)

--- a/pkg/stores/partition/parallel.go
+++ b/pkg/stores/partition/parallel.go
@@ -137,7 +137,7 @@ func (p *ParallelPartitionLister) feeder(ctx context.Context, state listState, l
 	}()
 
 	for i := indexOrZero(p.Partitions, state.PartitionName); i < len(p.Partitions); i++ {
-		if capacity <= 0 || isDone(ctx) {
+		if (limit > 0 && capacity <= 0) || isDone(ctx) {
 			break
 		}
 
@@ -197,7 +197,7 @@ func (p *ParallelPartitionLister) feeder(ctx context.Context, state listState, l
 
 				// Case 1: the capacity has been reached across all goroutines but the list is still only partial,
 				// so save the state so that the next page can be requested later.
-				if len(list.Items) > capacity {
+				if limit > 0 && len(list.Items) > capacity {
 					result <- list.Items[:capacity]
 					// save state to redo this list at this offset
 					p.state = &listState{

--- a/pkg/stores/partition/store.go
+++ b/pkg/stores/partition/store.go
@@ -128,6 +128,7 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 	}
 
 	list := listprocessor.FilterList(stream, opts.Filters)
+	list = listprocessor.SortList(list, opts.Sort)
 
 	for _, item := range list {
 		item := item

--- a/pkg/stores/partition/store.go
+++ b/pkg/stores/partition/store.go
@@ -129,6 +129,8 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 
 	list := listprocessor.FilterList(stream, opts.Filters)
 	list = listprocessor.SortList(list, opts.Sort)
+	result.Count = len(list)
+	list, pages := listprocessor.PaginateList(list, opts.Pagination)
 
 	for _, item := range list {
 		item := item
@@ -137,6 +139,8 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 
 	result.Revision = lister.Revision()
 	result.Continue = lister.Continue()
+	result.Pages = pages
+
 	return result, lister.Err()
 }
 

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -77,8 +77,12 @@ func TestList(t *testing.T) {
 				newRequest("limit=1", "user1"),
 				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
 				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
+				newRequest("limit=-1", "user1"),
 			},
 			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
 				{
 					"user1": "roleA",
 				},
@@ -123,6 +127,14 @@ func TestList(t *testing.T) {
 				{
 					Count: 1,
 					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
 						newApple("crispin").toObj(),
 					},
 				},

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -2,6 +2,7 @@ package partition
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -21,20 +22,37 @@ import (
 
 func TestList(t *testing.T) {
 	tests := []struct {
-		name       string
-		apiOps     []*types.APIRequest
-		partitions []Partition
-		objects    map[string]*unstructured.UnstructuredList
-		want       []types.APIObjectList
+		name          string
+		apiOps        []*types.APIRequest
+		access        []map[string]string
+		partitions    map[string][]Partition
+		objects       map[string]*unstructured.UnstructuredList
+		want          []types.APIObjectList
+		wantCache     []mockCache
+		disableCache  bool
+		wantListCalls []map[string]int
 	}{
 		{
 			name: "basic",
 			apiOps: []*types.APIRequest{
 				newRequest("", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "all",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -60,9 +78,22 @@ func TestList(t *testing.T) {
 				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
 				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "all",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -102,12 +133,19 @@ func TestList(t *testing.T) {
 			apiOps: []*types.APIRequest{
 				newRequest("", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "green",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "yellow",
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -144,18 +182,31 @@ func TestList(t *testing.T) {
 				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`))), "user1"),
 				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`))), "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "pink",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "green",
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "yellow",
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "red",
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "pink",
+					},
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+					mockPartition{
+						name: "red",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -216,9 +267,19 @@ func TestList(t *testing.T) {
 				newRequest("filter=data.color=green", "user1"),
 				newRequest("filter=data.color=green&filter=metadata.name=bramley", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "all",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -252,15 +313,22 @@ func TestList(t *testing.T) {
 			apiOps: []*types.APIRequest{
 				newRequest("filter=data.category=baking", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "pink",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "green",
-				},
-				mockPartition{
-					name: "yellow",
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "pink",
+					},
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -299,9 +367,19 @@ func TestList(t *testing.T) {
 				newRequest("sort=metadata.name", "user1"),
 				newRequest("sort=-metadata.name", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "all",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -340,12 +418,19 @@ func TestList(t *testing.T) {
 			apiOps: []*types.APIRequest{
 				newRequest("sort=metadata.name", "user1"),
 			},
-			partitions: []Partition{
-				mockPartition{
-					name: "green",
+			access: []map[string]string{
+				{
+					"user1": "roleA",
 				},
-				mockPartition{
-					name: "yellow",
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
 				},
 			},
 			objects: map[string]*unstructured.UnstructuredList{
@@ -375,17 +460,1178 @@ func TestList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"all": 1},
+				{"all": 1},
+				{"all": 1},
+			},
+		},
+		{
+			name: "access-change pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleB"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"all": 1},
+				{"all": 2},
+			},
+		},
+		{
+			name: "pagination with cache disabled",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+			wantCache:    []mockCache{},
+			disableCache: true,
+			wantListCalls: []map[string]int{
+				{"all": 1},
+				{"all": 2},
+				{"all": 3},
+			},
+		},
+		{
+			name: "multi-partition pagesize=1",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("crispin").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("crispin").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"green": 1, "yellow": 1},
+				{"green": 1, "yellow": 1},
+			},
+		},
+		{
+			name: "pagesize=1 & limit=2 & continue",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1&limit=2", "user1"),
+				newRequest("pagesize=1&page=2&limit=2", "user1"),             // does not use cache
+				newRequest("pagesize=1&page=2&revision=42&limit=2", "user1"), // uses cache
+				newRequest("pagesize=1&page=3&revision=42&limit=2", "user1"), // next page from cache
+				newRequest(fmt.Sprintf("pagesize=1&revision=42&limit=2&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`)))))), "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("crispin").Unstructured,
+						newApple("red-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    2,
+							resume:       "",
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+								},
+							},
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    2,
+							resume:       "",
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+								},
+							},
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    2,
+							resume:       "",
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+								},
+							},
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    2,
+							resume:       "",
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+								},
+							},
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    2,
+							resume:       "",
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+								},
+							},
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+						{
+							chunkSize:    2,
+							resume:       base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("crispin").Unstructured,
+								newApple("red-delicious").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"all": 2},
+				{"all": 4},
+				{"all": 4},
+				{"all": 4},
+				{"all": 5},
+			},
+		},
+		{
+			name: "multi-user pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1", "user2"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user2"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+				"user2": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "42",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("fuji").Unstructured,
+								newApple("granny-smith").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"all": 1},
+				{"all": 2},
+				{"all": 2},
+				{"all": 2},
+			},
+		},
+		{
+			name: "multi-partition multi-user pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1", "user2"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+				newRequest("pagesize=1&page=2&revision=103", "user2"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+				"user2": {
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("golden-delicious").toObj(),
+					},
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						cacheKey{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "103",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("crispin").Unstructured,
+								newApple("golden-delicious").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "103",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("crispin").Unstructured,
+								newApple("golden-delicious").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user2", "roleB"),
+							resourcePath: "/apples",
+							revision:     "103",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("crispin").Unstructured,
+								newApple("golden-delicious").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"green": 1, "yellow": 0},
+				{"green": 1, "yellow": 1},
+				{"green": 1, "yellow": 1},
+				{"green": 1, "yellow": 1},
+			},
+		},
+		{
+			name: "multi-partition access-change pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+			},
+			wantCache: []mockCache{
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						cacheKey{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+					},
+				},
+				{
+					contents: map[cacheKey]*unstructured.UnstructuredList{
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleA"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+						{
+							chunkSize:    100000,
+							pageSize:     1,
+							accessID:     getAccessID("user1", "roleB"),
+							resourcePath: "/apples",
+							revision:     "102",
+						}: {
+							Items: []unstructured.Unstructured{
+								newApple("granny-smith").Unstructured,
+								newApple("bramley").Unstructured,
+							},
+						},
+					},
+				},
+			},
+			wantListCalls: []map[string]int{
+				{"green": 1},
+				{"green": 2},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
 			stores := map[string]*mockStore{}
-			for _, p := range test.partitions {
-				stores[p.Name()] = &mockStore{
-					contents: test.objects[p.Name()],
+			for _, partitions := range test.partitions {
+				for _, p := range partitions {
+					stores[p.Name()] = &mockStore{
+						contents: test.objects[p.Name()],
+					}
 				}
 			}
-			asl := &mockAccessSetLookup{}
+			asl := &mockAccessSetLookup{userRoles: test.access}
+			if test.disableCache {
+				t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "Y")
+			}
 			store := NewStore(mockPartitioner{
 				stores:     stores,
 				partitions: test.partitions,
@@ -394,6 +1640,21 @@ func TestList(t *testing.T) {
 				got, gotErr := store.List(req, schema)
 				assert.Nil(t, gotErr)
 				assert.Equal(t, test.want[i], got)
+				if test.disableCache {
+					assert.Nil(t, store.listCache)
+				}
+				if len(test.wantCache) > 0 {
+					assert.Equal(t, len(test.wantCache[i].contents), len(store.listCache.Keys()))
+					for k, v := range test.wantCache[i].contents {
+						cachedVal, _ := store.listCache.Get(k)
+						assert.Equal(t, v, cachedVal)
+					}
+				}
+				if len(test.wantListCalls) > 0 {
+					for name, _ := range store.Partitioner.(mockPartitioner).stores {
+						assert.Equal(t, test.wantListCalls[i][name], store.Partitioner.(mockPartitioner).stores[name].called)
+					}
+				}
 			}
 		})
 	}
@@ -401,7 +1662,7 @@ func TestList(t *testing.T) {
 
 type mockPartitioner struct {
 	stores     map[string]*mockStore
-	partitions []Partition
+	partitions map[string][]Partition
 }
 
 func (m mockPartitioner) Lookup(apiOp *types.APIRequest, schema *types.APISchema, verb, id string) (Partition, error) {
@@ -409,7 +1670,8 @@ func (m mockPartitioner) Lookup(apiOp *types.APIRequest, schema *types.APISchema
 }
 
 func (m mockPartitioner) All(apiOp *types.APIRequest, schema *types.APISchema, verb, id string) ([]Partition, error) {
-	return m.partitions, nil
+	user, _ := request.UserFrom(apiOp.Request.Context())
+	return m.partitions[user.GetName()], nil
 }
 
 func (m mockPartitioner) Store(apiOp *types.APIRequest, partition Partition) (UnstructuredStore, error) {
@@ -427,9 +1689,11 @@ func (m mockPartition) Name() string {
 type mockStore struct {
 	contents  *unstructured.UnstructuredList
 	partition mockPartition
+	called    int
 }
 
 func (m *mockStore) List(apiOp *types.APIRequest, schema *types.APISchema) (*unstructured.UnstructuredList, error) {
+	m.called++
 	query, _ := url.ParseQuery(apiOp.Request.URL.RawQuery)
 	l := query.Get("limit")
 	if l == "" {
@@ -479,6 +1743,10 @@ func (m *mockStore) Delete(apiOp *types.APIRequest, schema *types.APISchema, id 
 
 func (m *mockStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan watch.Event, error) {
 	panic("not implemented")
+}
+
+type mockCache struct {
+	contents map[cacheKey]*unstructured.UnstructuredList
 }
 
 var colorMap = map[string]string{
@@ -540,14 +1808,25 @@ func (a apple) with(data map[string]string) apple {
 	return a
 }
 
-type mockAccessSetLookup struct{}
+type mockAccessSetLookup struct {
+	accessID  string
+	userRoles []map[string]string
+}
 
-func (m *mockAccessSetLookup) AccessFor(_ user.Info) *accesscontrol.AccessSet {
+func (m *mockAccessSetLookup) AccessFor(user user.Info) *accesscontrol.AccessSet {
+	userName := user.GetName()
+	access := getAccessID(userName, m.userRoles[0][userName])
+	m.userRoles = m.userRoles[1:]
 	return &accesscontrol.AccessSet{
-		ID: "aabbccdd",
+		ID: access,
 	}
 }
 
 func (m *mockAccessSetLookup) PurgeUserData(_ string) {
 	panic("not implemented")
+}
+
+func getAccessID(user, role string) string {
+	h := sha256.Sum256([]byte(user + role))
+	return string(h[:])
 }

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -414,6 +414,117 @@ func TestList(t *testing.T) {
 			},
 		},
 		{
+			name: "sorting with secondary sort",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=data.color,metadata.name,", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "sorting with missing primary sort is unsorted",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=,metadata.name", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "sorting with missing secondary sort is single-column sorted",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name,", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("honeycrisp").toObj(),
+					},
+				},
+			},
+		},
+		{
 			name: "multi-partition sort=metadata.name",
 			apiOps: []*types.APIRequest{
 				newRequest("sort=metadata.name", "user1"),

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -1,0 +1,354 @@
+package partition
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiOps     []*types.APIRequest
+		partitions []Partition
+		objects    map[string]types.APIObjectList
+		want       []types.APIObjectList
+	}{
+		{
+			name: "basic",
+			apiOps: []*types.APIRequest{
+				newRequest(""),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "all",
+				},
+			},
+			objects: map[string]types.APIObjectList{
+				"all": {
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "limit and continue",
+			apiOps: []*types.APIRequest{
+				newRequest("limit=1"),
+				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))))),
+				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))))),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "all",
+				},
+			},
+			objects: map[string]types.APIObjectList{
+				"all": {
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition",
+			apiOps: []*types.APIRequest{
+				newRequest(""),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "green",
+				},
+				mockPartition{
+					name: "yellow",
+				},
+			},
+			objects: map[string]types.APIObjectList{
+				"pink": {
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				"green": {
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				"yellow": {
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition with limit and continue",
+			apiOps: []*types.APIRequest{
+				newRequest("limit=3"),
+				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)))),
+				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)))),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "pink",
+				},
+				mockPartition{
+					name: "green",
+				},
+				mockPartition{
+					name: "yellow",
+				},
+				mockPartition{
+					name: "red",
+				},
+			},
+			objects: map[string]types.APIObjectList{
+				"pink": {
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+					},
+				},
+				"green": {
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("bramley").toObj(),
+					},
+				},
+				"yellow": {
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+						newApple("golden-delicious").toObj(),
+					},
+				},
+				"red": {
+					Objects: []types.APIObject{
+						newApple("red-delicious").toObj(),
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+						newApple("crispin").toObj(),
+						newApple("golden-delicious").toObj(),
+					},
+				},
+				{
+					Objects: []types.APIObject{
+						newApple("red-delicious").toObj(),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
+			stores := map[string]*mockStore{}
+			for _, p := range test.partitions {
+				stores[p.Name()] = &mockStore{
+					contents: test.objects[p.Name()],
+				}
+			}
+			store := Store{
+				Partitioner: mockPartitioner{
+					stores:     stores,
+					partitions: test.partitions,
+				},
+			}
+			for i, req := range test.apiOps {
+				got, gotErr := store.List(req, schema)
+				assert.Nil(t, gotErr)
+				assert.Equal(t, test.want[i], got)
+			}
+		})
+	}
+}
+
+type mockPartitioner struct {
+	stores     map[string]*mockStore
+	partitions []Partition
+}
+
+func (m mockPartitioner) Lookup(apiOp *types.APIRequest, schema *types.APISchema, verb, id string) (Partition, error) {
+	panic("not implemented")
+}
+
+func (m mockPartitioner) All(apiOp *types.APIRequest, schema *types.APISchema, verb, id string) ([]Partition, error) {
+	return m.partitions, nil
+}
+
+func (m mockPartitioner) Store(apiOp *types.APIRequest, partition Partition) (types.Store, error) {
+	return m.stores[partition.Name()], nil
+}
+
+type mockPartition struct {
+	name string
+}
+
+func (m mockPartition) Name() string {
+	return m.name
+}
+
+type mockStore struct {
+	contents  types.APIObjectList
+	partition mockPartition
+}
+
+func (m *mockStore) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+	query, _ := url.ParseQuery(apiOp.Request.URL.RawQuery)
+	l := query.Get("limit")
+	if l == "" {
+		return m.contents, nil
+	}
+	i := 0
+	if c := query.Get("continue"); c != "" {
+		start, _ := base64.StdEncoding.DecodeString(c)
+		for j, obj := range m.contents.Objects {
+			if string(start) == obj.Name() {
+				i = j
+				break
+			}
+		}
+	}
+	lInt, _ := strconv.Atoi(l)
+	contents := m.contents
+	if len(contents.Objects) > i+lInt {
+		contents.Continue = base64.StdEncoding.EncodeToString([]byte(contents.Objects[i+lInt].Name()))
+	}
+	if i > len(contents.Objects) {
+		return contents, nil
+	}
+	if i+lInt > len(contents.Objects) {
+		contents.Objects = contents.Objects[i:]
+		return contents, nil
+	}
+	contents.Objects = contents.Objects[i : i+lInt]
+	return contents, nil
+}
+
+func (m *mockStore) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+	panic("not implemented")
+}
+
+func (m *mockStore) Create(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+	panic("not implemented")
+}
+
+func (m *mockStore) Update(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
+	panic("not implemented")
+}
+
+func (m *mockStore) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+	panic("not implemented")
+}
+
+func (m *mockStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan types.APIEvent, error) {
+	panic("not implemented")
+}
+
+var colorMap = map[string]string{
+	"fuji":             "pink",
+	"honeycrisp":       "pink",
+	"granny-smith":     "green",
+	"bramley":          "green",
+	"crispin":          "yellow",
+	"golden-delicious": "yellow",
+	"red-delicious":    "red",
+}
+
+func newRequest(query string) *types.APIRequest {
+	return &types.APIRequest{
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme:   "https",
+				Host:     "rancher",
+				Path:     "/apples",
+				RawQuery: query,
+			},
+		},
+	}
+}
+
+type apple struct {
+	unstructured.Unstructured
+}
+
+func newApple(name string) apple {
+	return apple{unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "apple",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"data": map[string]interface{}{
+				"color": colorMap[name],
+			},
+		},
+	}}
+}
+
+func (a apple) toObj() types.APIObject {
+	return types.APIObject{
+		Type:   "apple",
+		ID:     a.Object["metadata"].(map[string]interface{})["name"].(string),
+		Object: &a.Unstructured,
+	}
+}

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -42,6 +42,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 1,
 					Objects: []types.APIObject{
 						newApple("fuji").toObj(),
 					},
@@ -71,18 +72,21 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count:    1,
 					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
 					Objects: []types.APIObject{
 						newApple("fuji").toObj(),
 					},
 				},
 				{
+					Count:    1,
 					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
 					Objects: []types.APIObject{
 						newApple("granny-smith").toObj(),
 					},
 				},
 				{
+					Count: 1,
 					Objects: []types.APIObject{
 						newApple("crispin").toObj(),
 					},
@@ -121,6 +125,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 2,
 					Objects: []types.APIObject{
 						newApple("granny-smith").toObj(),
 						newApple("crispin").toObj(),
@@ -176,6 +181,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count:    3,
 					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
 					Objects: []types.APIObject{
 						newApple("fuji").toObj(),
@@ -184,6 +190,7 @@ func TestList(t *testing.T) {
 					},
 				},
 				{
+					Count:    3,
 					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
 					Objects: []types.APIObject{
 						newApple("bramley").toObj(),
@@ -192,6 +199,7 @@ func TestList(t *testing.T) {
 					},
 				},
 				{
+					Count: 1,
 					Objects: []types.APIObject{
 						newApple("red-delicious").toObj(),
 					},
@@ -221,12 +229,14 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 2,
 					Objects: []types.APIObject{
 						newApple("granny-smith").toObj(),
 						newApple("bramley").toObj(),
 					},
 				},
 				{
+					Count: 1,
 					Objects: []types.APIObject{
 						newApple("bramley").toObj(),
 					},
@@ -270,6 +280,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 3,
 					Objects: []types.APIObject{
 						newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).toObj(),
 						newApple("granny-smith").with(map[string]string{"category": "baking"}).toObj(),
@@ -301,6 +312,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 4,
 					Objects: []types.APIObject{
 						newApple("bramley").toObj(),
 						newApple("crispin").toObj(),
@@ -309,6 +321,7 @@ func TestList(t *testing.T) {
 					},
 				},
 				{
+					Count: 4,
 					Objects: []types.APIObject{
 						newApple("granny-smith").toObj(),
 						newApple("fuji").toObj(),
@@ -350,6 +363,7 @@ func TestList(t *testing.T) {
 			},
 			want: []types.APIObjectList{
 				{
+					Count: 2,
 					Objects: []types.APIObject{
 						newApple("crispin").toObj(),
 						newApple("granny-smith").toObj(),

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -278,6 +278,85 @@ func TestList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with sorting",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name"),
+				newRequest("sort=-metadata.name"),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "all",
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+						newApple("crispin").toObj(),
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("fuji").toObj(),
+						newApple("crispin").toObj(),
+						newApple("bramley").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition sort=metadata.name",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name"),
+			},
+			partitions: []Partition{
+				mockPartition{
+					name: "green",
+				},
+				mockPartition{
+					name: "yellow",
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+					},
+				},
+				"yellow": {
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -75,14 +75,15 @@ type Store struct {
 func NewProxyStore(clientGetter ClientGetter, notifier RelationshipNotifier, lookup accesscontrol.AccessSetLookup) types.Store {
 	return &errorStore{
 		Store: &WatchRefresh{
-			Store: &partition.Store{
-				Partitioner: &rbacPartitioner{
+			Store: partition.NewStore(
+				&rbacPartitioner{
 					proxyStore: &Store{
 						clientGetter: clientGetter,
 						notifier:     notifier,
 					},
 				},
-			},
+				lookup,
+			),
 			asl: lookup,
 		},
 	}

--- a/pkg/stores/proxy/rbac_store.go
+++ b/pkg/stores/proxy/rbac_store.go
@@ -9,7 +9,9 @@ import (
 	"github.com/rancher/steve/pkg/attributes"
 	"github.com/rancher/steve/pkg/stores/partition"
 	"github.com/rancher/wrangler/pkg/kv"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 var (
@@ -85,8 +87,8 @@ func (p *rbacPartitioner) All(apiOp *types.APIRequest, schema *types.APISchema, 
 	}
 }
 
-// Store returns a proxy Store suited to listing and watching resources by partition.
-func (p *rbacPartitioner) Store(apiOp *types.APIRequest, partition partition.Partition) (types.Store, error) {
+// Store returns an UnstructuredStore suited to listing and watching resources by partition.
+func (p *rbacPartitioner) Store(apiOp *types.APIRequest, partition partition.Partition) (partition.UnstructuredStore, error) {
 	return &byNameOrNamespaceStore{
 		Store:     p.proxyStore,
 		partition: partition.(Partition),
@@ -99,7 +101,7 @@ type byNameOrNamespaceStore struct {
 }
 
 // List returns a list of resources by partition.
-func (b *byNameOrNamespaceStore) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (b *byNameOrNamespaceStore) List(apiOp *types.APIRequest, schema *types.APISchema) (*unstructured.UnstructuredList, error) {
 	if b.partition.Passthrough {
 		return b.Store.List(apiOp, schema)
 	}
@@ -112,7 +114,7 @@ func (b *byNameOrNamespaceStore) List(apiOp *types.APIRequest, schema *types.API
 }
 
 // Watch returns a channel of resources by partition.
-func (b *byNameOrNamespaceStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest) (chan types.APIEvent, error) {
+func (b *byNameOrNamespaceStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest) (chan watch.Event, error) {
 	if b.partition.Passthrough {
 		return b.Store.Watch(apiOp, schema, wr)
 	}


### PR DESCRIPTION
Commit summary:

### Add unit tests for partition listing

### Refactor proxy store

Filtering and sorting needs to operate on unstructured data. It also
needs to operate after the parallel partitioner, higher in the store
stack. This means that the proxy Store needs to return raw, unstructured
data up to the partitioner. This change moves all conversions from
unstructured Kubernetes types to apiserver objects up from the proxy
store into the partitioner.

### Add filtering to partition store

Extend the partition store to parse query params as list filters. Filter
keys use dot notation to denote the subfield of an object to filter on.
Example:

GET /v1/secrets?filter=metadata.name=foo

Filters are ANDed together, so an object must match all filters to be
included in the list. Example:

GET /v1/secrets?filter=metadata.name=foo&filter=metadata.namespace=bar

Arrays are searched for matching items. If any item in the array
matches, the item is included in the list. Example:

GET /v1/pods?filter=spec.containers.image=alpine

### Add sorting to partition store

Extend the partition store to parse the "sort" query parameter as a
sorting condition. Dot notation is used to denote the object field.
Preceding the key with "-" denotes descending (reverse) order.

Example sorting by name:

GET /v1/secrets?sort=metadata.name

Reverse sorting by name:

GET /v1/secrets?sort=-metadata.name

All values are converted to strings and sorted lexicographically.

### Add pagination to partition store

Extend the partition store to parse page and pagesize parameters and
return a subset of list results. The total number of pages is included
in the list response.

Request an initial page:

GET /v1/secrets?pagesize=10

or

GET /v1/secrets?pagesize=10&page=1

Request subsequent pages, or arbitrary pages:

GET /v1/secrets?pagesize=10&page=37

If a page number is out of bounds, an empty list is returned.

### Add caching to pagination

Cache filtered, sorted results for fast subsequent page retrieval.

Requests for cached queries need to include the list revision number
along with other queries. If no specific revision is requested, a new
fetch is done in order to get the latest revision. The revision is
included in the list response.

Example first request:

GET /v1/secrets?pagesize=10

Example subsequent page request:

GET /v1/secrets?pagesize=10&page=1&revision=107740

### Add pagination tests for partition listing

### Add secondary sort parameter

Extend the sorting functionality in the partition store to support
primary and secondary sorting criteria. Sorting parameters are specified
by a single 'sort' query and comma separated. Example:

Sort by name and creation time:

GET /v1/secrets?sort=metadata.name,metadata.creationTimestamp

Reverse sort by name, normal sort by creation time:

GET /v1/secrets?sort=-metadata.name,metadata.creationTimestamp

Normal sort by name, reverse sort by creation time:

GET /v1/secrets?sort=metadata.name,-metadata.creationTimestamp

### Add README
Add an initial README to explain the basics of the API and the new
parameters.

Issue: https://github.com/rancher/rancher/issues/38427

~Depends on https://github.com/rancher/steve/pull/60~
Depends on https://github.com/rancher/steve/pull/63