### PR TITLE
Fixes a bug with resource.error watch events

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -257,7 +257,7 @@ func (s *Store) list(apiOp *types.APIRequest, schema *types.APISchema, client dy
 
 func returnErr(err error, c chan watch.Event) {
 	c <- watch.Event{
-		Type: "resource.error",
+		Type: watch.Error,
 		Object: &metav1.Status{
 			Message: err.Error(),
 		},


### PR DESCRIPTION
Watch events need to have a type defined by
k8s.io/apimachinery/pkg/watch to be properly interpreted. Fixes a bug where this was not the case

Related to rancher/rancher#40131