### PR TITLE
Add support for OR and NOT filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,13 @@ Example, filtering by object name:
 /v1/{type}?filter=metadata.name=foo
 ```
 
-Filters are ANDed together, so an object must match all filters to be
+One filter can list multiple possible fields to match, these are ORed together:
+
+```
+/v1/{type}?filter=metadata.name=foo,metadata.namespace=foo
+```
+
+Stacked filters are ANDed together, so an object must match all filters to be
 included in the list.
 
 ```

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -1070,6 +1070,658 @@ func TestFilterList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "not filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+							op:    "!=",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "or'ed not filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+							op:    "!=",
+						},
+						{
+							field: []string{"data", "color"},
+							match: "green",
+							op:    "!=",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed or'ed filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+							op:    "!=",
+						},
+						{
+							field: []string{"metadata", "name"},
+							match: "fuji",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "fuji",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "granny-smith",
+						},
+						"data": map[string]interface{}{
+							"color": "green",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "anded and or'ed mixed equality filter",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "fuji",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "honeycrisp",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name": "granny-smith",
+							},
+							"data": map[string]interface{}{
+								"color": "green",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "fuji",
+							op:    "!=",
+						},
+					},
+				},
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "apple",
+						"metadata": map[string]interface{}{
+							"name": "honeycrisp",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match string array with not",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"pink",
+									"red",
+									"green",
+									"yellow",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"blue",
+									"red",
+									"black",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"colors": []interface{}{
+									"yellow",
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "colors"},
+							match: "yellow",
+							op:    "!=",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "berry",
+						},
+						"data": map[string]interface{}{
+							"colors": []interface{}{
+								"blue",
+								"red",
+								"black",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match object array with not",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "fuji",
+										"color": "pink",
+									},
+									map[string]interface{}{
+										"name":  "granny-smith",
+										"color": "green",
+									},
+									map[string]interface{}{
+										"name":  "red-delicious",
+										"color": "red",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "blueberry",
+										"color": "blue",
+									},
+									map[string]interface{}{
+										"name":  "raspberry",
+										"color": "red",
+									},
+									map[string]interface{}{
+										"name":  "blackberry",
+										"color": "black",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"varieties": []interface{}{
+									map[string]interface{}{
+										"name":  "cavendish",
+										"color": "yellow",
+									},
+									map[string]interface{}{
+										"name":  "plantain",
+										"color": "green",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "varieties", "color"},
+							match: "red",
+							op:    "!=",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "banana",
+						},
+						"data": map[string]interface{}{
+							"varieties": []interface{}{
+								map[string]interface{}{
+									"name":  "cavendish",
+									"color": "yellow",
+								},
+								map[string]interface{}{
+									"name":  "plantain",
+									"color": "green",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match nested array with not",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"pink",
+										"green",
+										"red",
+										"purple",
+									},
+									[]interface{}{
+										"fuji",
+										"granny-smith",
+										"red-delicious",
+										"black-diamond",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"blue",
+										"red",
+										"black",
+									},
+									[]interface{}{
+										"blueberry",
+										"raspberry",
+										"blackberry",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										"yellow",
+										"green",
+									},
+									[]interface{}{
+										"cavendish",
+										"plantain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "attributes"},
+							match: "black",
+							op:    "!=",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "banana",
+						},
+						"data": map[string]interface{}{
+							"attributes": []interface{}{
+								[]interface{}{
+									"yellow",
+									"green",
+								},
+								[]interface{}{
+									"cavendish",
+									"plantain",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match nested object array with mixed equality",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "apple",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"pink": "fuji",
+										},
+										map[string]interface{}{
+											"green": "granny-smith",
+										},
+										map[string]interface{}{
+											"pink": "honeycrisp",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "berry",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"blue": "blueberry",
+										},
+										map[string]interface{}{
+											"red": "raspberry",
+										},
+										map[string]interface{}{
+											"black": "blackberry",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "banana",
+							},
+							"data": map[string]interface{}{
+								"attributes": []interface{}{
+									[]interface{}{
+										map[string]interface{}{
+											"yellow": "cavendish",
+										},
+										map[string]interface{}{
+											"green": "plantain",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "attributes", "green"},
+							match: "plantain",
+							op:    "!=",
+						},
+						{
+							field: []string{"data", "attributes", "green"},
+							match: "granny-smith",
+						},
+					},
+				},
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "banana",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -11,7 +11,7 @@ func TestFilterList(t *testing.T) {
 	tests := []struct {
 		name    string
 		objects [][]unstructured.Unstructured
-		filters []Filter
+		filters []OrFilter
 		want    []unstructured.Unstructured
 	}{
 		{
@@ -42,10 +42,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "color"},
-					match: "pink",
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -101,14 +105,22 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "color"},
-					match: "pink",
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+						},
+					},
 				},
 				{
-					field: []string{"metadata", "name"},
-					match: "honey",
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "honey",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -153,10 +165,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "color"},
-					match: "purple",
+					filters: []Filter{
+						{
+							field: []string{"data", "color"},
+							match: "purple",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{},
@@ -189,7 +205,7 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{},
+			filters: []OrFilter{},
 			want: []unstructured.Unstructured{
 				{
 					Object: map[string]interface{}{
@@ -254,10 +270,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"spec", "volumes"},
-					match: "hostPath",
+					filters: []Filter{
+						{
+							field: []string{"spec", "volumes"},
+							match: "hostPath",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{},
@@ -301,10 +321,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "productType"},
-					match: "tablet",
+					filters: []Filter{
+						{
+							field: []string{"data", "productType"},
+							match: "tablet",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{},
@@ -326,10 +350,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "color", "shade"},
-					match: "green",
+					filters: []Filter{
+						{
+							field: []string{"data", "color", "shade"},
+							match: "green",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{},
@@ -384,10 +412,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "colors"},
-					match: "yellow",
+					filters: []Filter{
+						{
+							field: []string{"data", "colors"},
+							match: "yellow",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -496,10 +528,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "varieties", "color"},
-					match: "red",
+					filters: []Filter{
+						{
+							field: []string{"data", "varieties", "color"},
+							match: "red",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -625,10 +661,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "attributes"},
-					match: "black",
+					filters: []Filter{
+						{
+							field: []string{"data", "attributes"},
+							match: "black",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -752,10 +792,14 @@ func TestFilterList(t *testing.T) {
 					},
 				},
 			},
-			filters: []Filter{
+			filters: []OrFilter{
 				{
-					field: []string{"data", "attributes", "green"},
-					match: "plantain",
+					filters: []Filter{
+						{
+							field: []string{"data", "attributes", "green"},
+							match: "plantain",
+						},
+					},
 				},
 			},
 			want: []unstructured.Unstructured{
@@ -776,6 +820,251 @@ func TestFilterList(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single or filter, filter on one value",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pink-lady",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pomegranate",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "pink",
+						},
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pink-lady",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pomegranate",
+						},
+						"data": map[string]interface{}{
+							"color": "pink",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single or filter, filter on different value",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pink-lady",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pomegranate",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "pink",
+						},
+						{
+							field: []string{"metadata", "name"},
+							match: "pom",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pink-lady",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pomegranate",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single or filter, no matches",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pink-lady",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pomegranate",
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "blue",
+						},
+						{
+							field: []string{"metadata", "name"},
+							match: "watermelon",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{},
+		},
+		{
+			name: "and-ed or filters",
+			objects: [][]unstructured.Unstructured{
+				{
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pink-lady",
+							},
+							"data": map[string]interface{}{
+								"flavor": "sweet",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "pomegranate",
+							},
+							"data": map[string]interface{}{
+								"color":  "pink",
+								"flavor": "sweet",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind": "fruit",
+							"metadata": map[string]interface{}{
+								"name": "grapefruit",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+								"data": map[string]interface{}{
+									"flavor": "bitter",
+								},
+							},
+						},
+					},
+				},
+			},
+			filters: []OrFilter{
+				{
+					filters: []Filter{
+						{
+							field: []string{"metadata", "name"},
+							match: "pink",
+						},
+						{
+							field: []string{"data", "color"},
+							match: "pink",
+						},
+					},
+				},
+				{
+					filters: []Filter{
+						{
+							field: []string{"data", "flavor"},
+							match: "sweet",
+						},
+					},
+				},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pink-lady",
+						},
+						"data": map[string]interface{}{
+							"flavor": "sweet",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "fruit",
+						"metadata": map[string]interface{}{
+							"name": "pomegranate",
+						},
+						"data": map[string]interface{}{
+							"color":  "pink",
+							"flavor": "sweet",
 						},
 					},
 				},

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -281,8 +281,20 @@ func TestList(t *testing.T) {
 				newRequest("filter=data.color=green,data.color=pink", "user1"),
 				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=fuji", "user1"),
 				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=crispin", "user1"),
+				newRequest("filter=data.color!=green", "user1"),
+				newRequest("filter=data.color!=green,metadata.name=granny-smith", "user1"),
+				newRequest("filter=data.color!=green&filter=metadata.name!=crispin", "user1"),
 			},
 			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
 				{
 					"user1": "roleA",
 				},
@@ -346,6 +358,27 @@ func TestList(t *testing.T) {
 				},
 				{
 					Count: 0,
+				},
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/40141

# OR filters

Currently, multiple filters can be appended on the query string, and each subsequent filter is ANDed with the set. Items that pass through the filter set must match every filter in the set.

This change adds support for OR filters. A single filter key can specify multiple filters, separated by ','. An item that passes this filter can match any filter in the set.

For example, this filter matches items that have either "name" or "namespace" that match "example":

?filter=metadata.name=example,metadata.namespace=example

This filter matches items that have "name" that matches either "foo" or "bar":

?filter=metadata.name=foo,metadata.name=bar

Specifying more than one filter key in the query still ANDs each inner filter set together. This set of filters can match either a name of "foo" or "bar", but must in all cases match namespace "abc":

?filter=metadata.name=foo,metadata.name=bar&filter=metadata.namespace=abc

# NOT filters

This change adds support for excluding results using the != operator.

Example to exclude all results with name "example":

?filter=metadata.name!=example

Include all results from namespace "example" but exclude those with name
"example":

?filter=metadata.namespace=example&metadata.name!=example

Exclude results with name "foo" OR exclude results with name "bar"
(effectively includes results of both types):

?filter=metadata.name!=foo,metadata.name!=bar