### PR TITLE
LRU cache: fix concurrent map write

### DIFF
--- a/pkg/stores/partition/store.go
+++ b/pkg/stores/partition/store.go
@@ -216,8 +216,8 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 	list, pages := listprocessor.PaginateList(list, opts.Pagination)
 
 	for _, item := range list {
-		item := item
-		result.Objects = append(result.Objects, toAPI(schema, &item, nil))
+		item := item.DeepCopy()
+		result.Objects = append(result.Objects, toAPI(schema, item, nil))
 	}
 
 	result.Revision = key.revision


### PR DESCRIPTION
Addresses https://github.com/rancher/rancher/issues/40892.

Problem is that returned objects are mutated by `formatter` while a pointer is kept in the LRU. If two users concurrently format the same object, a race condition happens on their underlying maps.

This is a straightforward solution to deep copy objects before they are returned for formatting.