### PR TITLE
Change cache default to false

### DIFF
--- a/pkg/stores/partition/store.go
+++ b/pkg/stores/partition/store.go
@@ -29,7 +29,7 @@ const (
 	// Not related to the total size in memory of the cache, as any item could take any amount of memory.
 	cacheSizeEnv     = "CATTLE_REQUEST_CACHE_SIZE_INT"
 	defaultCacheSize = 1000
-	// Set to non-empty to disable list request caching entirely.
+	// Set to "false" to enable list request caching.
 	cacheDisableEnv = "CATTLE_REQUEST_CACHE_DISABLED"
 )
 
@@ -60,7 +60,7 @@ func NewStore(partitioner Partitioner, asl accesscontrol.AccessSetLookup) *Store
 		Partitioner: partitioner,
 		asl:         asl,
 	}
-	if v := os.Getenv(cacheDisableEnv); v == "" {
+	if v := os.Getenv(cacheDisableEnv); v == "false" {
 		s.listCache = cache.NewLRUExpireCache(cacheSize)
 	}
 	return s

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -1941,8 +1941,8 @@ func TestList(t *testing.T) {
 				}
 			}
 			asl := &mockAccessSetLookup{userRoles: test.access}
-			if test.disableCache {
-				t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "Y")
+			if !test.disableCache {
+				t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "false")
 			}
 			store := NewStore(mockPartitioner{
 				stores:     stores,
@@ -2024,7 +2024,6 @@ func TestListByRevision(t *testing.T) {
 		},
 	}, asl)
 	req := newRequest("", "user1")
-	t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "Y")
 
 	got, gotErr := store.List(req, schema)
 	assert.Nil(t, gotErr)


### PR DESCRIPTION
**Issue:**
https://github.com/rancher/rancher/issues/41379

**Problem:**
Steve cache needs to be reevaluated due to performance issues before being enabled by default. See https://github.com/rancher/rancher/issues/41378 for more details.

**Solution:**
Disable steve cache by default. Adopting odd pattern of env needs to explicitly be set to "false". This is because the change is temporary and opting to do it this way prevents us from needing to create another env var or renaming this one.