### PR TITLE
Fix drone validate build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
   - name: validate
     image: registry.suse.com/bci/bci-base:15.4
     commands:
-      - zypper in -y go=1.19 git tar gzip make
+      - zypper in -y "golang(API)=1.19" git tar gzip make
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
       - mv ./bin/golangci-lint /usr/local/bin/golangci-lint
       - GOBIN=/usr/local/bin go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
go1.19 provides go=1.19.9, the right symbol for the major version is golang(API)

See https://build.opensuse.org/package/view_file/openSUSE:Factory/go1.19/go1.19.spec?expand=1