### PR TITLE
Steve cache

### DIFF
--- a/pkg/stores/partition/store.go
+++ b/pkg/stores/partition/store.go
@@ -19,15 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-const (
-	// Number of list request entries to save before cache replacement.
-	// Not related to the total size in memory of the cache, as any item could take any amount of memory.
-	cacheSizeEnv     = "CATTLE_REQUEST_CACHE_SIZE_INT"
-	defaultCacheSize = 1000
-	// Set to "false" to enable list request caching.
-	cacheDisableEnv = "CATTLE_REQUEST_CACHE_DISABLED"
-)
-
 // Partitioner is an interface for interacting with partitions.
 type Partitioner interface {
 	Lookup(apiOp *types.APIRequest, schema *types.APISchema, verb, id string) (Partition, error)

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -2,15 +2,14 @@ package partition
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"testing"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/steve/pkg/accesscontrol"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/schemas"
 	"github.com/stretchr/testify/assert"
@@ -24,2510 +23,1658 @@ import (
 )
 
 func TestList(t *testing.T) {
-	/*
-		tests := []struct {
-			name          string
-			apiOps        []*types.APIRequest
-			access        []map[string]string
-			partitions    map[string][]Partition
-			objects       map[string]*unstructured.UnstructuredList
-			want          []types.APIObjectList
-			wantCache     []mockCache
-			disableCache  bool
-			wantListCalls []map[string]int
-		}{
-							{
-								name: "basic",
-								apiOps: []*types.APIRequest{
-									newRequest("", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "limit and continue",
-								apiOps: []*types.APIRequest{
-									newRequest("limit=1", "user1"),
-									newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
-									newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
-									newRequest("limit=-1", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("granny-smith").Unstructured,
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count:    1,
-										Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-										},
-									},
-									{
-										Count:    1,
-										Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("crispin").toObj(),
-										},
-									},
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("granny-smith").toObj(),
-											newApple("crispin").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "multi-partition",
-								apiOps: []*types.APIRequest{
-									newRequest("", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "green",
-										},
-										mockPartition{
-											name: "yellow",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-										},
-									},
-									"green": {
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").Unstructured,
-										},
-									},
-									"yellow": {
-										Items: []unstructured.Unstructured{
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-											newApple("crispin").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "multi-partition with limit and continue",
-								apiOps: []*types.APIRequest{
-									newRequest("limit=3", "user1"),
-									newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`))), "user1"),
-									newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`))), "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "pink",
-										},
-										mockPartition{
-											name: "green",
-										},
-										mockPartition{
-											name: "yellow",
-										},
-										mockPartition{
-											name: "red",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("honeycrisp").Unstructured,
-										},
-									},
-									"green": {
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").Unstructured,
-											newApple("bramley").Unstructured,
-										},
-									},
-									"yellow": {
-										Items: []unstructured.Unstructured{
-											newApple("crispin").Unstructured,
-											newApple("golden-delicious").Unstructured,
-										},
-									},
-									"red": {
-										Items: []unstructured.Unstructured{
-											newApple("red-delicious").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count:    3,
-										Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("honeycrisp").toObj(),
-											newApple("granny-smith").toObj(),
-										},
-									},
-									{
-										Count:    3,
-										Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
-										Objects: []types.APIObject{
-											newApple("bramley").toObj(),
-											newApple("crispin").toObj(),
-											newApple("golden-delicious").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("red-delicious").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "with filters",
-								apiOps: []*types.APIRequest{
-									newRequest("filter=data.color=green", "user1"),
-									newRequest("filter=data.color=green&filter=metadata.name=bramley", "user1"),
-									newRequest("filter=data.color=green,data.color=pink", "user1"),
-									newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=fuji", "user1"),
-									newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=crispin", "user1"),
-									newRequest("filter=data.color!=green", "user1"),
-									newRequest("filter=data.color!=green,metadata.name=granny-smith", "user1"),
-									newRequest("filter=data.color!=green&filter=metadata.name!=crispin", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("granny-smith").Unstructured,
-											newApple("bramley").Unstructured,
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-											newApple("bramley").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("bramley").toObj(),
-										},
-									},
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("granny-smith").toObj(),
-											newApple("bramley").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-										},
-									},
-									{
-										Count: 0,
-									},
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("crispin").toObj(),
-										},
-									},
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("granny-smith").toObj(),
-											newApple("crispin").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "multi-partition with filters",
-								apiOps: []*types.APIRequest{
-									newRequest("filter=data.category=baking", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "pink",
-										},
-										mockPartition{
-											name: "green",
-										},
-										mockPartition{
-											name: "yellow",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").with(map[string]string{"category": "eating"}).Unstructured,
-											newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).Unstructured,
-										},
-									},
-									"green": {
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").with(map[string]string{"category": "baking"}).Unstructured,
-											newApple("bramley").with(map[string]string{"category": "eating"}).Unstructured,
-										},
-									},
-									"yellow": {
-										Items: []unstructured.Unstructured{
-											newApple("crispin").with(map[string]string{"category": "baking"}).Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).toObj(),
-											newApple("granny-smith").with(map[string]string{"category": "baking"}).toObj(),
-											newApple("crispin").with(map[string]string{"category": "baking"}).toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "with sorting",
-								apiOps: []*types.APIRequest{
-									newRequest("sort=metadata.name", "user1"),
-									newRequest("sort=-metadata.name", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("granny-smith").Unstructured,
-											newApple("bramley").Unstructured,
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 4,
-										Objects: []types.APIObject{
-											newApple("bramley").toObj(),
-											newApple("crispin").toObj(),
-											newApple("fuji").toObj(),
-											newApple("granny-smith").toObj(),
-										},
-									},
-									{
-										Count: 4,
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-											newApple("fuji").toObj(),
-											newApple("crispin").toObj(),
-											newApple("bramley").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "sorting with secondary sort",
-								apiOps: []*types.APIRequest{
-									newRequest("sort=data.color,metadata.name,", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("honeycrisp").Unstructured,
-											newApple("granny-smith").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-											newApple("fuji").toObj(),
-											newApple("honeycrisp").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "sorting with missing primary sort is unsorted",
-								apiOps: []*types.APIRequest{
-									newRequest("sort=,metadata.name", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("honeycrisp").Unstructured,
-											newApple("granny-smith").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("honeycrisp").toObj(),
-											newApple("granny-smith").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "sorting with missing secondary sort is single-column sorted",
-								apiOps: []*types.APIRequest{
-									newRequest("sort=metadata.name,", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("honeycrisp").Unstructured,
-											newApple("granny-smith").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").toObj(),
-											newApple("granny-smith").toObj(),
-											newApple("honeycrisp").toObj(),
-										},
-									},
-								},
-							},
-							{
-								name: "multi-partition sort=metadata.name",
-								apiOps: []*types.APIRequest{
-									newRequest("sort=metadata.name", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "green",
-										},
-										mockPartition{
-											name: "yellow",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-										},
-									},
-									"green": {
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").Unstructured,
-										},
-									},
-									"yellow": {
-										Items: []unstructured.Unstructured{
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("crispin").toObj(),
-											newApple("granny-smith").toObj(),
-										},
-									},
-								},
-							},
-						{
-							name: "pagination",
-							apiOps: []*types.APIRequest{
-								newRequest("pagesize=1", "user1"),
-								newRequest("pagesize=1&page=2&revision=42", "user1"),
-								newRequest("pagesize=1&page=3&revision=42", "user1"),
-							},
-							access: []map[string]string{
-								{
-									"user1": "roleA",
-								},
-								{
-									"user1": "roleA",
-								},
-								{
-									"user1": "roleA",
-								},
-							},
-							partitions: map[string][]Partition{
-								"user1": {
-									mockPartition{
-										name: "all",
-									},
-								},
-							},
-							objects: map[string]*unstructured.UnstructuredList{
-								"all": {
-									Object: map[string]interface{}{
-										"metadata": map[string]interface{}{
-											"resourceVersion": "42",
-										},
-									},
-									Items: []unstructured.Unstructured{
-										newApple("fuji").Unstructured,
-										newApple("granny-smith").Unstructured,
-									},
-								},
-							},
-							want: []types.APIObjectList{
-								{
-									Count:    2,
-									Pages:    2,
-									Revision: "42",
-									Objects: []types.APIObject{
-										newApple("fuji").toObj(),
-									},
-								},
-								{
-									Count:    2,
-									Pages:    2,
-									Revision: "42",
-									Objects: []types.APIObject{
-										newApple("granny-smith").toObj(),
-									},
-								},
-								{
-									Count:    2,
-									Pages:    2,
-									Revision: "42",
-								},
-							},
-							wantCache: []mockCache{
-								{
-									contents: map[cacheKey]*unstructured.UnstructuredList{
-										{
-											chunkSize:    100000,
-											pageSize:     1,
-											accessID:     getAccessID("user1", "roleA"),
-											resourcePath: "/apples",
-											revision:     "42",
-										}: {
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-								},
-								{
-									contents: map[cacheKey]*unstructured.UnstructuredList{
-										{
-											chunkSize:    100000,
-											pageSize:     1,
-											accessID:     getAccessID("user1", "roleA"),
-											resourcePath: "/apples",
-											revision:     "42",
-										}: {
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-								},
-								{
-									contents: map[cacheKey]*unstructured.UnstructuredList{
-										{
-											chunkSize:    100000,
-											pageSize:     1,
-											accessID:     getAccessID("user1", "roleA"),
-											resourcePath: "/apples",
-											revision:     "42",
-										}: {
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-								},
-							},
-							wantListCalls: []map[string]int{
-								{"all": 1},
-								{"all": 1},
-								{"all": 1},
-							},
+	tests := []struct {
+		name       string
+		apiOps     []*types.APIRequest
+		access     []map[string]string
+		partitions map[string][]Partition
+		objects    map[string]*unstructured.UnstructuredList
+		want       []types.APIObjectList
+	}{
+		{
+			name: "basic",
+			apiOps: []*types.APIRequest{
+				newRequest("", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "limit and continue",
+			apiOps: []*types.APIRequest{
+				newRequest("limit=1", "user1"),
+				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
+				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
+				newRequest("limit=-1", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    1,
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    1,
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition",
+			apiOps: []*types.APIRequest{
+				newRequest("", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+					},
+				},
+				"yellow": {
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition with limit and continue",
+			apiOps: []*types.APIRequest{
+				newRequest("limit=3", "user1"),
+				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`))), "user1"),
+				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`))), "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "pink",
+					},
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+					mockPartition{
+						name: "red",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+					},
+				},
+				"green": {
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+				"red": {
+					Items: []unstructured.Unstructured{
+						newApple("red-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    3,
+					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    3,
+					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+						newApple("crispin").toObj(),
+						newApple("golden-delicious").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("red-delicious").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "with filters",
+			apiOps: []*types.APIRequest{
+				newRequest("filter=data.color=green", "user1"),
+				newRequest("filter=data.color=green&filter=metadata.name=bramley", "user1"),
+				newRequest("filter=data.color=green,data.color=pink", "user1"),
+				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=fuji", "user1"),
+				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=crispin", "user1"),
+				newRequest("filter=data.color!=green", "user1"),
+				newRequest("filter=data.color!=green,metadata.name=granny-smith", "user1"),
+				newRequest("filter=data.color!=green&filter=metadata.name!=crispin", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count: 0,
+				},
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition with filters",
+			apiOps: []*types.APIRequest{
+				newRequest("filter=data.category=baking", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "pink",
+					},
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").with(map[string]string{"category": "eating"}).Unstructured,
+						newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).Unstructured,
+					},
+				},
+				"green": {
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").with(map[string]string{"category": "baking"}).Unstructured,
+						newApple("bramley").with(map[string]string{"category": "eating"}).Unstructured,
+					},
+				},
+				"yellow": {
+					Items: []unstructured.Unstructured{
+						newApple("crispin").with(map[string]string{"category": "baking"}).Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).toObj(),
+						newApple("granny-smith").with(map[string]string{"category": "baking"}).toObj(),
+						newApple("crispin").with(map[string]string{"category": "baking"}).toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "with sorting",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name", "user1"),
+				newRequest("sort=-metadata.name", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 4,
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+						newApple("crispin").toObj(),
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count: 4,
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("fuji").toObj(),
+						newApple("crispin").toObj(),
+						newApple("bramley").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "sorting with secondary sort",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=data.color,metadata.name,", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "sorting with missing primary sort is unsorted",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=,metadata.name", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("honeycrisp").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "sorting with missing secondary sort is single-column sorted",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name,", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("honeycrisp").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+						newApple("granny-smith").toObj(),
+						newApple("honeycrisp").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition sort=metadata.name",
+			apiOps: []*types.APIRequest{
+				newRequest("sort=metadata.name", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+					},
+				},
+				"yellow": {
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
 						},
-						/*
-								{
-									name: "access-change pagination",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1&page=2&revision=42", "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleB",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "all",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"all": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "42",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("fuji").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleB"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"all": 1},
-										{"all": 2},
-									},
-								},
-								{
-									name: "pagination with cache disabled",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1&page=2&revision=42", "user1"),
-										newRequest("pagesize=1&page=3&revision=42", "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "all",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"all": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "42",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("fuji").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-										},
-									},
-									wantCache:    []mockCache{},
-									disableCache: true,
-									wantListCalls: []map[string]int{
-										{"all": 1},
-										{"all": 2},
-										{"all": 3},
-									},
-								},
-								{
-									name: "multi-partition pagesize=1",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1&page=2&revision=102", "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "green",
-											},
-											mockPartition{
-												name: "yellow",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"pink": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "101",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-											},
-										},
-										"green": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "102",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("granny-smith").Unstructured,
-											},
-										},
-										"yellow": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "103",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("crispin").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("crispin").toObj(),
-											},
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("crispin").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("crispin").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"green": 1, "yellow": 1},
-										{"green": 1, "yellow": 1},
-									},
-								},
-								{
-									name: "pagesize=1 & limit=2 & continue",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1&limit=2", "user1"),
-										newRequest("pagesize=1&page=2&limit=2", "user1"),             // does not use cache
-										newRequest("pagesize=1&page=2&revision=42&limit=2", "user1"), // uses cache
-										newRequest("pagesize=1&page=3&revision=42&limit=2", "user1"), // next page from cache
-										newRequest(fmt.Sprintf("pagesize=1&revision=42&limit=2&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`)))))), "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "all",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"all": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "42",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-												newApple("crispin").Unstructured,
-												newApple("red-delicious").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-											Objects: []types.APIObject{
-												newApple("fuji").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("crispin").toObj(),
-											},
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    2,
-													resume:       "",
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Object: map[string]interface{}{
-														"metadata": map[string]interface{}{
-															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-														},
-													},
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    2,
-													resume:       "",
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Object: map[string]interface{}{
-														"metadata": map[string]interface{}{
-															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-														},
-													},
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    2,
-													resume:       "",
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Object: map[string]interface{}{
-														"metadata": map[string]interface{}{
-															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-														},
-													},
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    2,
-													resume:       "",
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Object: map[string]interface{}{
-														"metadata": map[string]interface{}{
-															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-														},
-													},
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    2,
-													resume:       "",
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Object: map[string]interface{}{
-														"metadata": map[string]interface{}{
-															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-														},
-													},
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-												{
-													chunkSize:    2,
-													resume:       base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("crispin").Unstructured,
-														newApple("red-delicious").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"all": 2},
-										{"all": 4},
-										{"all": 4},
-										{"all": 4},
-										{"all": 5},
-									},
-								},
-								{
-									name: "multi-user pagination",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1", "user2"),
-										newRequest("pagesize=1&page=2&revision=42", "user1"),
-										newRequest("pagesize=1&page=2&revision=42", "user2"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user2": "roleB",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user2": "roleB",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "all",
-											},
-										},
-										"user2": {
-											mockPartition{
-												name: "all",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"all": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "42",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("fuji").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("fuji").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("fuji").Unstructured,
-														newApple("granny-smith").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"all": 1},
-										{"all": 2},
-										{"all": 2},
-										{"all": 2},
-									},
-								},
-								{
-									name: "multi-partition multi-user pagination",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1", "user2"),
-										newRequest("pagesize=1&page=2&revision=102", "user1"),
-										newRequest("pagesize=1&page=2&revision=103", "user2"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user2": "roleB",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user2": "roleB",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "green",
-											},
-										},
-										"user2": {
-											mockPartition{
-												name: "yellow",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"pink": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "101",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-											},
-										},
-										"green": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "102",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("granny-smith").Unstructured,
-												newApple("bramley").Unstructured,
-											},
-										},
-										"yellow": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "103",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("crispin").Unstructured,
-												newApple("golden-delicious").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "103",
-											Objects: []types.APIObject{
-												newApple("crispin").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("bramley").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "103",
-											Objects: []types.APIObject{
-												newApple("golden-delicious").toObj(),
-											},
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												cacheKey{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "103",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("crispin").Unstructured,
-														newApple("golden-delicious").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "103",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("crispin").Unstructured,
-														newApple("golden-delicious").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user2", "roleB"),
-													resourcePath: "/apples",
-													revision:     "103",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("crispin").Unstructured,
-														newApple("golden-delicious").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"green": 1, "yellow": 0},
-										{"green": 1, "yellow": 1},
-										{"green": 1, "yellow": 1},
-										{"green": 1, "yellow": 1},
-									},
-								},
-								{
-									name: "multi-partition access-change pagination",
-									apiOps: []*types.APIRequest{
-										newRequest("pagesize=1", "user1"),
-										newRequest("pagesize=1&page=2&revision=102", "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleB",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "green",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"pink": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "101",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-											},
-										},
-										"green": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "102",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("granny-smith").Unstructured,
-												newApple("bramley").Unstructured,
-											},
-										},
-										"yellow": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "103",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("crispin").Unstructured,
-												newApple("golden-delicious").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("granny-smith").toObj(),
-											},
-										},
-										{
-											Count:    2,
-											Pages:    2,
-											Revision: "102",
-											Objects: []types.APIObject{
-												newApple("bramley").toObj(),
-											},
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												cacheKey{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-												{
-													chunkSize:    100000,
-													pageSize:     1,
-													accessID:     getAccessID("user1", "roleB"),
-													resourcePath: "/apples",
-													revision:     "102",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("granny-smith").Unstructured,
-														newApple("bramley").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"green": 1},
-										{"green": 2},
-									},
-								},
-								{
-									name: "pagination with or filters",
-									apiOps: []*types.APIRequest{
-										newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
-										newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
-										newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
-									},
-									access: []map[string]string{
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-										{
-											"user1": "roleA",
-										},
-									},
-									partitions: map[string][]Partition{
-										"user1": {
-											mockPartition{
-												name: "all",
-											},
-										},
-									},
-									objects: map[string]*unstructured.UnstructuredList{
-										"all": {
-											Object: map[string]interface{}{
-												"metadata": map[string]interface{}{
-													"resourceVersion": "42",
-												},
-											},
-											Items: []unstructured.Unstructured{
-												newApple("fuji").Unstructured,
-												newApple("granny-smith").Unstructured,
-												newApple("red-delicious").Unstructured,
-												newApple("golden-delicious").Unstructured,
-												newApple("crispin").Unstructured,
-											},
-										},
-									},
-									want: []types.APIObjectList{
-										{
-											Count:    3,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("red-delicious").toObj(),
-												newApple("golden-delicious").toObj(),
-											},
-										},
-										{
-											Count:    3,
-											Pages:    2,
-											Revision: "42",
-											Objects: []types.APIObject{
-												newApple("crispin").toObj(),
-											},
-										},
-										{
-											Count:    3,
-											Pages:    2,
-											Revision: "42",
-										},
-									},
-									wantCache: []mockCache{
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													filters:      "data.color=el,metadata.name=el",
-													pageSize:     2,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("red-delicious").Unstructured,
-														newApple("golden-delicious").Unstructured,
-														newApple("crispin").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													filters:      "data.color=el,metadata.name=el",
-													pageSize:     2,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("red-delicious").Unstructured,
-														newApple("golden-delicious").Unstructured,
-														newApple("crispin").Unstructured,
-													},
-												},
-											},
-										},
-										{
-											contents: map[cacheKey]*unstructured.UnstructuredList{
-												{
-													chunkSize:    100000,
-													filters:      "data.color=el,metadata.name=el",
-													pageSize:     2,
-													accessID:     getAccessID("user1", "roleA"),
-													resourcePath: "/apples",
-													revision:     "42",
-												}: {
-													Items: []unstructured.Unstructured{
-														newApple("red-delicious").Unstructured,
-														newApple("golden-delicious").Unstructured,
-														newApple("crispin").Unstructured,
-													},
-												},
-											},
-										},
-									},
-									wantListCalls: []map[string]int{
-										{"all": 1},
-										{"all": 1},
-										{"all": 1},
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "green",
-										},
-									},
-									"user2": {
-										mockPartition{
-											name: "yellow",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "101",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-										},
-									},
-									"green": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "102",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").Unstructured,
-											newApple("bramley").Unstructured,
-										},
-									},
-									"yellow": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "103",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("crispin").Unstructured,
-											newApple("golden-delicious").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "102",
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-										},
-									},
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "103",
-										Objects: []types.APIObject{
-											newApple("crispin").toObj(),
-										},
-									},
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "102",
-										Objects: []types.APIObject{
-											newApple("bramley").toObj(),
-										},
-									},
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "103",
-										Objects: []types.APIObject{
-											newApple("golden-delicious").toObj(),
-										},
-									},
-								},
-								wantCache: []mockCache{
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											cacheKey{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user2", "roleB"),
-												resourcePath: "/apples",
-												revision:     "103",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("crispin").Unstructured,
-													newApple("golden-delicious").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user2", "roleB"),
-												resourcePath: "/apples",
-												revision:     "103",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("crispin").Unstructured,
-													newApple("golden-delicious").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user2", "roleB"),
-												resourcePath: "/apples",
-												revision:     "103",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("crispin").Unstructured,
-													newApple("golden-delicious").Unstructured,
-												},
-											},
-										},
-									},
-								},
-								wantListCalls: []map[string]int{
-									{"green": 1, "yellow": 0},
-									{"green": 1, "yellow": 1},
-									{"green": 1, "yellow": 1},
-									{"green": 1, "yellow": 1},
-								},
-							},
-							{
-								name: "multi-partition access-change pagination",
-								apiOps: []*types.APIRequest{
-									newRequest("pagesize=1", "user1"),
-									newRequest("pagesize=1&page=2&revision=102", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleB",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "green",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"pink": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "101",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-										},
-									},
-									"green": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "102",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("granny-smith").Unstructured,
-											newApple("bramley").Unstructured,
-										},
-									},
-									"yellow": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "103",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("crispin").Unstructured,
-											newApple("golden-delicious").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "102",
-										Objects: []types.APIObject{
-											newApple("granny-smith").toObj(),
-										},
-									},
-									{
-										Count:    2,
-										Pages:    2,
-										Revision: "102",
-										Objects: []types.APIObject{
-											newApple("bramley").toObj(),
-										},
-									},
-								},
-								wantCache: []mockCache{
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											cacheKey{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-											{
-												chunkSize:    100000,
-												pageSize:     1,
-												accessID:     getAccessID("user1", "roleB"),
-												resourcePath: "/apples",
-												revision:     "102",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("granny-smith").Unstructured,
-													newApple("bramley").Unstructured,
-												},
-											},
-										},
-									},
-								},
-								wantListCalls: []map[string]int{
-									{"green": 1},
-									{"green": 2},
-								},
-							},
-							{
-								name: "pagination with or filters",
-								apiOps: []*types.APIRequest{
-									newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
-									newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
-									newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Object: map[string]interface{}{
-											"metadata": map[string]interface{}{
-												"resourceVersion": "42",
-											},
-										},
-										Items: []unstructured.Unstructured{
-											newApple("fuji").Unstructured,
-											newApple("granny-smith").Unstructured,
-											newApple("red-delicious").Unstructured,
-											newApple("golden-delicious").Unstructured,
-											newApple("crispin").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count:    3,
-										Pages:    2,
-										Revision: "42",
-										Objects: []types.APIObject{
-											newApple("red-delicious").toObj(),
-											newApple("golden-delicious").toObj(),
-										},
-									},
-									{
-										Count:    3,
-										Pages:    2,
-										Revision: "42",
-										Objects: []types.APIObject{
-											newApple("crispin").toObj(),
-										},
-									},
-									{
-										Count:    3,
-										Pages:    2,
-										Revision: "42",
-									},
-								},
-								wantCache: []mockCache{
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												filters:      "data.color=el,metadata.name=el",
-												pageSize:     2,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "42",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("red-delicious").Unstructured,
-													newApple("golden-delicious").Unstructured,
-													newApple("crispin").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												filters:      "data.color=el,metadata.name=el",
-												pageSize:     2,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "42",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("red-delicious").Unstructured,
-													newApple("golden-delicious").Unstructured,
-													newApple("crispin").Unstructured,
-												},
-											},
-										},
-									},
-									{
-										contents: map[cacheKey]*unstructured.UnstructuredList{
-											{
-												chunkSize:    100000,
-												filters:      "data.color=el,metadata.name=el",
-												pageSize:     2,
-												accessID:     getAccessID("user1", "roleA"),
-												resourcePath: "/apples",
-												revision:     "42",
-											}: {
-												Items: []unstructured.Unstructured{
-													newApple("red-delicious").Unstructured,
-													newApple("golden-delicious").Unstructured,
-													newApple("crispin").Unstructured,
-												},
-											},
-										},
-									},
-								},
-								wantListCalls: []map[string]int{
-									{"all": 1},
-									{"all": 1},
-									{"all": 1},
-								},
-							},
-							{
-								name: "with project filters",
-								apiOps: []*types.APIRequest{
-									newRequest("projectsornamespaces=p-abcde", "user1"),
-									newRequest("projectsornamespaces=p-abcde,p-fghij", "user1"),
-									newRequest("projectsornamespaces=p-abcde,n2", "user1"),
-									newRequest("projectsornamespaces!=p-abcde", "user1"),
-									newRequest("projectsornamespaces!=p-abcde,p-fghij", "user1"),
-									newRequest("projectsornamespaces!=p-abcde,n2", "user1"),
-									newRequest("projectsornamespaces=foobar", "user1"),
-									newRequest("projectsornamespaces!=foobar", "user1"),
-								},
-								access: []map[string]string{
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-									{
-										"user1": "roleA",
-									},
-								},
-								partitions: map[string][]Partition{
-									"user1": {
-										mockPartition{
-											name: "all",
-										},
-									},
-								},
-								objects: map[string]*unstructured.UnstructuredList{
-									"all": {
-										Items: []unstructured.Unstructured{
-											newApple("fuji").withNamespace("n1").Unstructured,
-											newApple("granny-smith").withNamespace("n1").Unstructured,
-											newApple("bramley").withNamespace("n2").Unstructured,
-											newApple("crispin").withNamespace("n3").Unstructured,
-										},
-									},
-								},
-								want: []types.APIObjectList{
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("fuji").withNamespace("n1").toObj(),
-											newApple("granny-smith").withNamespace("n1").toObj(),
-										},
-									},
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").withNamespace("n1").toObj(),
-											newApple("granny-smith").withNamespace("n1").toObj(),
-											newApple("bramley").withNamespace("n2").toObj(),
-										},
-									},
-									{
-										Count: 3,
-										Objects: []types.APIObject{
-											newApple("fuji").withNamespace("n1").toObj(),
-											newApple("granny-smith").withNamespace("n1").toObj(),
-											newApple("bramley").withNamespace("n2").toObj(),
-										},
-									},
-									{
-										Count: 2,
-										Objects: []types.APIObject{
-											newApple("bramley").withNamespace("n2").toObj(),
-											newApple("crispin").withNamespace("n3").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("crispin").withNamespace("n3").toObj(),
-										},
-									},
-									{
-										Count: 1,
-										Objects: []types.APIObject{
-											newApple("crispin").withNamespace("n3").toObj(),
-										},
-									},
-									{
-										Count: 0,
-									},
-									{
-										Count: 4,
-										Objects: []types.APIObject{
-											newApple("fuji").withNamespace("n1").toObj(),
-											newApple("granny-smith").withNamespace("n1").toObj(),
-											newApple("bramley").withNamespace("n2").toObj(),
-											newApple("crispin").withNamespace("n3").toObj(),
-										},
-									},
-								},
-							},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+		},
+		{
+			name: "access-change pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+		},
+		{
+			name: "pagination with cache disabled",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+		},
+		{
+			name: "multi-partition pagesize=1",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "pagesize=1 & limit=2 & continue",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1&limit=2", "user1"),
+				newRequest("pagesize=1&page=2&limit=2", "user1"),             // does not use cache
+				newRequest("pagesize=1&page=2&revision=42&limit=2", "user1"), // uses cache
+				newRequest("pagesize=1&page=3&revision=42&limit=2", "user1"), // next page from cache
+				newRequest(fmt.Sprintf("pagesize=1&revision=42&limit=2&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`)))))), "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("crispin").Unstructured,
+						newApple("red-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-user pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1", "user2"),
+				newRequest("pagesize=1&page=2&revision=42", "user1"),
+				newRequest("pagesize=1&page=2&revision=42", "user2"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+				"user2": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("fuji").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition multi-user pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1", "user2"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+				newRequest("pagesize=1&page=2&revision=103", "user2"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user2": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+				"user2": {
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("golden-delicious").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition access-change pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "pagination with or filters",
+			apiOps: []*types.APIRequest{
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("red-delicious").Unstructured,
+						newApple("golden-delicious").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("red-delicious").toObj(),
+						newApple("golden-delicious").toObj(),
+					},
+				},
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+		},
+		{
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+				"user2": {
+					mockPartition{
+						name: "yellow",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "103",
+					Objects: []types.APIObject{
+						newApple("golden-delicious").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "multi-partition access-change pagination",
+			apiOps: []*types.APIRequest{
+				newRequest("pagesize=1", "user1"),
+				newRequest("pagesize=1&page=2&revision=102", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleB",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "green",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"pink": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "101",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+					},
+				},
+				"green": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "102",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("granny-smith").Unstructured,
+						newApple("bramley").Unstructured,
+					},
+				},
+				"yellow": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "103",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("crispin").Unstructured,
+						newApple("golden-delicious").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("granny-smith").toObj(),
+					},
+				},
+				{
+					Count:    2,
+					Pages:    2,
+					Revision: "102",
+					Objects: []types.APIObject{
+						newApple("bramley").toObj(),
+					},
+				},
+			},
+		},
+		{
+			name: "pagination with or filters",
+			apiOps: []*types.APIRequest{
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
+				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"resourceVersion": "42",
+						},
+					},
+					Items: []unstructured.Unstructured{
+						newApple("fuji").Unstructured,
+						newApple("granny-smith").Unstructured,
+						newApple("red-delicious").Unstructured,
+						newApple("golden-delicious").Unstructured,
+						newApple("crispin").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("red-delicious").toObj(),
+						newApple("golden-delicious").toObj(),
+					},
+				},
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+					Objects: []types.APIObject{
+						newApple("crispin").toObj(),
+					},
+				},
+				{
+					Count:    3,
+					Pages:    2,
+					Revision: "42",
+				},
+			},
+		},
+		{
+			name: "with project filters",
+			apiOps: []*types.APIRequest{
+				newRequest("projectsornamespaces=p-abcde", "user1"),
+				newRequest("projectsornamespaces=p-abcde,p-fghij", "user1"),
+				newRequest("projectsornamespaces=p-abcde,n2", "user1"),
+				newRequest("projectsornamespaces!=p-abcde", "user1"),
+				newRequest("projectsornamespaces!=p-abcde,p-fghij", "user1"),
+				newRequest("projectsornamespaces!=p-abcde,n2", "user1"),
+				newRequest("projectsornamespaces=foobar", "user1"),
+				newRequest("projectsornamespaces!=foobar", "user1"),
+			},
+			access: []map[string]string{
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+				{
+					"user1": "roleA",
+				},
+			},
+			partitions: map[string][]Partition{
+				"user1": {
+					mockPartition{
+						name: "all",
+					},
+				},
+			},
+			objects: map[string]*unstructured.UnstructuredList{
+				"all": {
+					Items: []unstructured.Unstructured{
+						newApple("fuji").withNamespace("n1").Unstructured,
+						newApple("granny-smith").withNamespace("n1").Unstructured,
+						newApple("bramley").withNamespace("n2").Unstructured,
+						newApple("crispin").withNamespace("n3").Unstructured,
+					},
+				},
+			},
+			want: []types.APIObjectList{
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("fuji").withNamespace("n1").toObj(),
+						newApple("granny-smith").withNamespace("n1").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").withNamespace("n1").toObj(),
+						newApple("granny-smith").withNamespace("n1").toObj(),
+						newApple("bramley").withNamespace("n2").toObj(),
+					},
+				},
+				{
+					Count: 3,
+					Objects: []types.APIObject{
+						newApple("fuji").withNamespace("n1").toObj(),
+						newApple("granny-smith").withNamespace("n1").toObj(),
+						newApple("bramley").withNamespace("n2").toObj(),
+					},
+				},
+				{
+					Count: 2,
+					Objects: []types.APIObject{
+						newApple("bramley").withNamespace("n2").toObj(),
+						newApple("crispin").withNamespace("n3").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("crispin").withNamespace("n3").toObj(),
+					},
+				},
+				{
+					Count: 1,
+					Objects: []types.APIObject{
+						newApple("crispin").withNamespace("n3").toObj(),
+					},
+				},
+				{
+					Count: 0,
+				},
+				{
+					Count: 4,
+					Objects: []types.APIObject{
+						newApple("fuji").withNamespace("n1").toObj(),
+						newApple("granny-smith").withNamespace("n1").toObj(),
+						newApple("bramley").withNamespace("n2").toObj(),
+						newApple("crispin").withNamespace("n3").toObj(),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
+			stores := map[string]UnstructuredStore{}
+			for _, partitions := range test.partitions {
+				for _, p := range partitions {
+					stores[p.Name()] = &mockStore{
+						contents: test.objects[p.Name()],
+					}
 				}
-				for _, test := range tests {
-					t.Run(test.name, func(t *testing.T) {
-						schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
-						stores := map[string]UnstructuredStore{}
-						for _, partitions := range test.partitions {
-							for _, p := range partitions {
-								stores[p.Name()] = &mockStore{
-									contents: test.objects[p.Name()],
-								}
-							}
-						}
-						asl := &mockAccessSetLookup{userRoles: test.access}
-						if !test.disableCache {
-							t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "false")
-						}
-						store := NewStore(mockPartitioner{
-							stores:     stores,
-							partitions: test.partitions,
-						}, mockNamespaceCache{})
-						for i, req := range test.apiOps {
-							got, gotErr := store.List(req, schema)
-							assert.Nil(t, gotErr)
-							assert.Equal(t, test.want[i], got)
-							/*
-								if test.disableCache {
-									assert.Nil(t, store.listCache)
-								}
-								if len(test.wantCache) > 0 {
-									assert.Equal(t, len(test.wantCache[i].contents), len(store.listCache.Keys()))
-									for k, v := range test.wantCache[i].contents {
-										cachedVal, _ := store.listCache.Get(k)
-										assert.Equal(t, v, cachedVal)
-									}
-								}
-							if len(test.wantListCalls) > 0 {
-								for name, _ := range store.Partitioner.(mockPartitioner).stores {
-									assert.Equal(t, test.wantListCalls[i][name], store.Partitioner.(mockPartitioner).stores[name].(*mockStore).called)
-								}
-							}
-						}
-					})
-		}*/
+			}
+			store := NewStore(mockPartitioner{
+				stores:     stores,
+				partitions: test.partitions,
+			}, mockNamespaceCache{})
+			for i, req := range test.apiOps {
+				got, gotErr := store.List(req, schema)
+				assert.Nil(t, gotErr)
+				assert.Equal(t, test.want[i], got)
+			}
+		})
+	}
 }
 
 func TestListByRevision(t *testing.T) {
@@ -2715,12 +1862,6 @@ func (m *mockVersionedStore) List(apiOp *types.APIRequest, schema *types.APISche
 	return contents, nil, nil
 }
 
-/*
-type mockCache struct {
-	contents map[cacheKey]*unstructured.UnstructuredList
-}
-*/
-
 var colorMap = map[string]string{
 	"fuji":             "pink",
 	"honeycrisp":       "pink",
@@ -2789,29 +1930,6 @@ func (a apple) with(data map[string]string) apple {
 func (a apple) withNamespace(namespace string) apple {
 	a.Object["metadata"].(map[string]interface{})["namespace"] = namespace
 	return a
-}
-
-type mockAccessSetLookup struct {
-	accessID  string
-	userRoles []map[string]string
-}
-
-func (m *mockAccessSetLookup) AccessFor(user user.Info) *accesscontrol.AccessSet {
-	userName := user.GetName()
-	access := getAccessID(userName, m.userRoles[0][userName])
-	m.userRoles = m.userRoles[1:]
-	return &accesscontrol.AccessSet{
-		ID: access,
-	}
-}
-
-func (m *mockAccessSetLookup) PurgeUserData(_ string) {
-	panic("not implemented")
-}
-
-func getAccessID(user, role string) string {
-	h := sha256.Sum256([]byte(user + role))
-	return string(h[:])
 }
 
 var namespaces = map[string]*corev1.Namespace{

--- a/pkg/stores/partition/store_test.go
+++ b/pkg/stores/partition/store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -25,2080 +24,2515 @@ import (
 )
 
 func TestList(t *testing.T) {
-	tests := []struct {
-		name          string
-		apiOps        []*types.APIRequest
-		access        []map[string]string
-		partitions    map[string][]Partition
-		objects       map[string]*unstructured.UnstructuredList
-		want          []types.APIObjectList
-		wantCache     []mockCache
-		disableCache  bool
-		wantListCalls []map[string]int
-	}{
-		{
-			name: "basic",
-			apiOps: []*types.APIRequest{
-				newRequest("", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "limit and continue",
-			apiOps: []*types.APIRequest{
-				newRequest("limit=1", "user1"),
-				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
-				newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
-				newRequest("limit=-1", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    1,
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    1,
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-					},
-				},
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("granny-smith").toObj(),
-						newApple("crispin").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "multi-partition",
-			apiOps: []*types.APIRequest{
-				newRequest("", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "green",
-					},
-					mockPartition{
-						name: "yellow",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-				"green": {
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-					},
-				},
-				"yellow": {
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-						newApple("crispin").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "multi-partition with limit and continue",
-			apiOps: []*types.APIRequest{
-				newRequest("limit=3", "user1"),
-				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`))), "user1"),
-				newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`))), "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "pink",
-					},
-					mockPartition{
-						name: "green",
-					},
-					mockPartition{
-						name: "yellow",
-					},
-					mockPartition{
-						name: "red",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("honeycrisp").Unstructured,
-					},
-				},
-				"green": {
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-						newApple("bramley").Unstructured,
-					},
-				},
-				"yellow": {
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-						newApple("golden-delicious").Unstructured,
-					},
-				},
-				"red": {
-					Items: []unstructured.Unstructured{
-						newApple("red-delicious").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    3,
-					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("honeycrisp").toObj(),
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    3,
-					Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
-					Objects: []types.APIObject{
-						newApple("bramley").toObj(),
-						newApple("crispin").toObj(),
-						newApple("golden-delicious").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("red-delicious").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "with filters",
-			apiOps: []*types.APIRequest{
-				newRequest("filter=data.color=green", "user1"),
-				newRequest("filter=data.color=green&filter=metadata.name=bramley", "user1"),
-				newRequest("filter=data.color=green,data.color=pink", "user1"),
-				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=fuji", "user1"),
-				newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=crispin", "user1"),
-				newRequest("filter=data.color!=green", "user1"),
-				newRequest("filter=data.color!=green,metadata.name=granny-smith", "user1"),
-				newRequest("filter=data.color!=green&filter=metadata.name!=crispin", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-						newApple("bramley").Unstructured,
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-						newApple("bramley").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("bramley").toObj(),
-					},
-				},
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("granny-smith").toObj(),
-						newApple("bramley").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count: 0,
-				},
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("crispin").toObj(),
-					},
-				},
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("granny-smith").toObj(),
-						newApple("crispin").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "multi-partition with filters",
-			apiOps: []*types.APIRequest{
-				newRequest("filter=data.category=baking", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "pink",
-					},
-					mockPartition{
-						name: "green",
-					},
-					mockPartition{
-						name: "yellow",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").with(map[string]string{"category": "eating"}).Unstructured,
-						newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).Unstructured,
-					},
-				},
-				"green": {
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").with(map[string]string{"category": "baking"}).Unstructured,
-						newApple("bramley").with(map[string]string{"category": "eating"}).Unstructured,
-					},
-				},
-				"yellow": {
-					Items: []unstructured.Unstructured{
-						newApple("crispin").with(map[string]string{"category": "baking"}).Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).toObj(),
-						newApple("granny-smith").with(map[string]string{"category": "baking"}).toObj(),
-						newApple("crispin").with(map[string]string{"category": "baking"}).toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "with sorting",
-			apiOps: []*types.APIRequest{
-				newRequest("sort=metadata.name", "user1"),
-				newRequest("sort=-metadata.name", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-						newApple("bramley").Unstructured,
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 4,
-					Objects: []types.APIObject{
-						newApple("bramley").toObj(),
-						newApple("crispin").toObj(),
-						newApple("fuji").toObj(),
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count: 4,
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-						newApple("fuji").toObj(),
-						newApple("crispin").toObj(),
-						newApple("bramley").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "sorting with secondary sort",
-			apiOps: []*types.APIRequest{
-				newRequest("sort=data.color,metadata.name,", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("honeycrisp").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-						newApple("fuji").toObj(),
-						newApple("honeycrisp").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "sorting with missing primary sort is unsorted",
-			apiOps: []*types.APIRequest{
-				newRequest("sort=,metadata.name", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("honeycrisp").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("honeycrisp").toObj(),
-						newApple("granny-smith").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "sorting with missing secondary sort is single-column sorted",
-			apiOps: []*types.APIRequest{
-				newRequest("sort=metadata.name,", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("honeycrisp").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-						newApple("granny-smith").toObj(),
-						newApple("honeycrisp").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "multi-partition sort=metadata.name",
-			apiOps: []*types.APIRequest{
-				newRequest("sort=metadata.name", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "green",
-					},
-					mockPartition{
-						name: "yellow",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-				"green": {
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-					},
-				},
-				"yellow": {
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-						newApple("granny-smith").toObj(),
-					},
-				},
-			},
-		},
-		{
-			name: "pagination",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1&page=2&revision=42", "user1"),
-				newRequest("pagesize=1&page=3&revision=42", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"all": 1},
-				{"all": 1},
-				{"all": 1},
-			},
-		},
-		{
-			name: "access-change pagination",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1&page=2&revision=42", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleB",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleB"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"all": 1},
-				{"all": 2},
-			},
-		},
-		{
-			name: "pagination with cache disabled",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1&page=2&revision=42", "user1"),
-				newRequest("pagesize=1&page=3&revision=42", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-				},
-			},
-			wantCache:    []mockCache{},
-			disableCache: true,
-			wantListCalls: []map[string]int{
-				{"all": 1},
-				{"all": 2},
-				{"all": 3},
-			},
-		},
-		{
-			name: "multi-partition pagesize=1",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1&page=2&revision=102", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "green",
-					},
-					mockPartition{
-						name: "yellow",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "101",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-				"green": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "102",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-					},
-				},
-				"yellow": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "103",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-					},
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("crispin").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("crispin").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"green": 1, "yellow": 1},
-				{"green": 1, "yellow": 1},
-			},
-		},
-		{
-			name: "pagesize=1 & limit=2 & continue",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1&limit=2", "user1"),
-				newRequest("pagesize=1&page=2&limit=2", "user1"),             // does not use cache
-				newRequest("pagesize=1&page=2&revision=42&limit=2", "user1"), // uses cache
-				newRequest("pagesize=1&page=3&revision=42&limit=2", "user1"), // next page from cache
-				newRequest(fmt.Sprintf("pagesize=1&revision=42&limit=2&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`)))))), "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-						newApple("crispin").Unstructured,
-						newApple("red-delicious").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-					},
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    2,
-							resume:       "",
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+	/*
+		tests := []struct {
+			name          string
+			apiOps        []*types.APIRequest
+			access        []map[string]string
+			partitions    map[string][]Partition
+			objects       map[string]*unstructured.UnstructuredList
+			want          []types.APIObjectList
+			wantCache     []mockCache
+			disableCache  bool
+			wantListCalls []map[string]int
+		}{
+							{
+								name: "basic",
+								apiOps: []*types.APIRequest{
+									newRequest("", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+										},
+									},
 								},
 							},
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    2,
-							resume:       "",
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+							{
+								name: "limit and continue",
+								apiOps: []*types.APIRequest{
+									newRequest("limit=1", "user1"),
+									newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith")))))), "user1"),
+									newRequest(fmt.Sprintf("limit=1&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin")))))), "user1"),
+									newRequest("limit=-1", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("granny-smith").Unstructured,
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count:    1,
+										Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("granny-smith"))))),
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+										},
+									},
+									{
+										Count:    1,
+										Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"p":"all","c":"%s","l":1}`, base64.StdEncoding.EncodeToString([]byte("crispin"))))),
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("crispin").toObj(),
+										},
+									},
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("granny-smith").toObj(),
+											newApple("crispin").toObj(),
+										},
+									},
 								},
 							},
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    2,
-							resume:       "",
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+							{
+								name: "multi-partition",
+								apiOps: []*types.APIRequest{
+									newRequest("", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "green",
+										},
+										mockPartition{
+											name: "yellow",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+										},
+									},
+									"green": {
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").Unstructured,
+										},
+									},
+									"yellow": {
+										Items: []unstructured.Unstructured{
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+											newApple("crispin").toObj(),
+										},
+									},
 								},
 							},
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    2,
-							resume:       "",
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+							{
+								name: "multi-partition with limit and continue",
+								apiOps: []*types.APIRequest{
+									newRequest("limit=3", "user1"),
+									newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`))), "user1"),
+									newRequest(fmt.Sprintf("limit=3&continue=%s", base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`))), "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "pink",
+										},
+										mockPartition{
+											name: "green",
+										},
+										mockPartition{
+											name: "yellow",
+										},
+										mockPartition{
+											name: "red",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("honeycrisp").Unstructured,
+										},
+									},
+									"green": {
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").Unstructured,
+											newApple("bramley").Unstructured,
+										},
+									},
+									"yellow": {
+										Items: []unstructured.Unstructured{
+											newApple("crispin").Unstructured,
+											newApple("golden-delicious").Unstructured,
+										},
+									},
+									"red": {
+										Items: []unstructured.Unstructured{
+											newApple("red-delicious").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count:    3,
+										Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"green","o":1,"l":3}`)),
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("honeycrisp").toObj(),
+											newApple("granny-smith").toObj(),
+										},
+									},
+									{
+										Count:    3,
+										Continue: base64.StdEncoding.EncodeToString([]byte(`{"p":"red","l":3}`)),
+										Objects: []types.APIObject{
+											newApple("bramley").toObj(),
+											newApple("crispin").toObj(),
+											newApple("golden-delicious").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("red-delicious").toObj(),
+										},
+									},
 								},
 							},
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    2,
-							resume:       "",
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+							{
+								name: "with filters",
+								apiOps: []*types.APIRequest{
+									newRequest("filter=data.color=green", "user1"),
+									newRequest("filter=data.color=green&filter=metadata.name=bramley", "user1"),
+									newRequest("filter=data.color=green,data.color=pink", "user1"),
+									newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=fuji", "user1"),
+									newRequest("filter=data.color=green,data.color=pink&filter=metadata.name=crispin", "user1"),
+									newRequest("filter=data.color!=green", "user1"),
+									newRequest("filter=data.color!=green,metadata.name=granny-smith", "user1"),
+									newRequest("filter=data.color!=green&filter=metadata.name!=crispin", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("granny-smith").Unstructured,
+											newApple("bramley").Unstructured,
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+											newApple("bramley").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("bramley").toObj(),
+										},
+									},
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("granny-smith").toObj(),
+											newApple("bramley").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+										},
+									},
+									{
+										Count: 0,
+									},
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("crispin").toObj(),
+										},
+									},
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("granny-smith").toObj(),
+											newApple("crispin").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+										},
+									},
 								},
 							},
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
+							{
+								name: "multi-partition with filters",
+								apiOps: []*types.APIRequest{
+									newRequest("filter=data.category=baking", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "pink",
+										},
+										mockPartition{
+											name: "green",
+										},
+										mockPartition{
+											name: "yellow",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").with(map[string]string{"category": "eating"}).Unstructured,
+											newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).Unstructured,
+										},
+									},
+									"green": {
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").with(map[string]string{"category": "baking"}).Unstructured,
+											newApple("bramley").with(map[string]string{"category": "eating"}).Unstructured,
+										},
+									},
+									"yellow": {
+										Items: []unstructured.Unstructured{
+											newApple("crispin").with(map[string]string{"category": "baking"}).Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("honeycrisp").with(map[string]string{"category": "eating,baking"}).toObj(),
+											newApple("granny-smith").with(map[string]string{"category": "baking"}).toObj(),
+											newApple("crispin").with(map[string]string{"category": "baking"}).toObj(),
+										},
+									},
+								},
 							},
-						},
+							{
+								name: "with sorting",
+								apiOps: []*types.APIRequest{
+									newRequest("sort=metadata.name", "user1"),
+									newRequest("sort=-metadata.name", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("granny-smith").Unstructured,
+											newApple("bramley").Unstructured,
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 4,
+										Objects: []types.APIObject{
+											newApple("bramley").toObj(),
+											newApple("crispin").toObj(),
+											newApple("fuji").toObj(),
+											newApple("granny-smith").toObj(),
+										},
+									},
+									{
+										Count: 4,
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+											newApple("fuji").toObj(),
+											newApple("crispin").toObj(),
+											newApple("bramley").toObj(),
+										},
+									},
+								},
+							},
+							{
+								name: "sorting with secondary sort",
+								apiOps: []*types.APIRequest{
+									newRequest("sort=data.color,metadata.name,", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("honeycrisp").Unstructured,
+											newApple("granny-smith").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+											newApple("fuji").toObj(),
+											newApple("honeycrisp").toObj(),
+										},
+									},
+								},
+							},
+							{
+								name: "sorting with missing primary sort is unsorted",
+								apiOps: []*types.APIRequest{
+									newRequest("sort=,metadata.name", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("honeycrisp").Unstructured,
+											newApple("granny-smith").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("honeycrisp").toObj(),
+											newApple("granny-smith").toObj(),
+										},
+									},
+								},
+							},
+							{
+								name: "sorting with missing secondary sort is single-column sorted",
+								apiOps: []*types.APIRequest{
+									newRequest("sort=metadata.name,", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("honeycrisp").Unstructured,
+											newApple("granny-smith").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").toObj(),
+											newApple("granny-smith").toObj(),
+											newApple("honeycrisp").toObj(),
+										},
+									},
+								},
+							},
+							{
+								name: "multi-partition sort=metadata.name",
+								apiOps: []*types.APIRequest{
+									newRequest("sort=metadata.name", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "green",
+										},
+										mockPartition{
+											name: "yellow",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+										},
+									},
+									"green": {
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").Unstructured,
+										},
+									},
+									"yellow": {
+										Items: []unstructured.Unstructured{
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("crispin").toObj(),
+											newApple("granny-smith").toObj(),
+										},
+									},
+								},
+							},
 						{
-							chunkSize:    2,
-							resume:       base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("crispin").Unstructured,
-								newApple("red-delicious").Unstructured,
+							name: "pagination",
+							apiOps: []*types.APIRequest{
+								newRequest("pagesize=1", "user1"),
+								newRequest("pagesize=1&page=2&revision=42", "user1"),
+								newRequest("pagesize=1&page=3&revision=42", "user1"),
+							},
+							access: []map[string]string{
+								{
+									"user1": "roleA",
+								},
+								{
+									"user1": "roleA",
+								},
+								{
+									"user1": "roleA",
+								},
+							},
+							partitions: map[string][]Partition{
+								"user1": {
+									mockPartition{
+										name: "all",
+									},
+								},
+							},
+							objects: map[string]*unstructured.UnstructuredList{
+								"all": {
+									Object: map[string]interface{}{
+										"metadata": map[string]interface{}{
+											"resourceVersion": "42",
+										},
+									},
+									Items: []unstructured.Unstructured{
+										newApple("fuji").Unstructured,
+										newApple("granny-smith").Unstructured,
+									},
+								},
+							},
+							want: []types.APIObjectList{
+								{
+									Count:    2,
+									Pages:    2,
+									Revision: "42",
+									Objects: []types.APIObject{
+										newApple("fuji").toObj(),
+									},
+								},
+								{
+									Count:    2,
+									Pages:    2,
+									Revision: "42",
+									Objects: []types.APIObject{
+										newApple("granny-smith").toObj(),
+									},
+								},
+								{
+									Count:    2,
+									Pages:    2,
+									Revision: "42",
+								},
+							},
+							wantCache: []mockCache{
+								{
+									contents: map[cacheKey]*unstructured.UnstructuredList{
+										{
+											chunkSize:    100000,
+											pageSize:     1,
+											accessID:     getAccessID("user1", "roleA"),
+											resourcePath: "/apples",
+											revision:     "42",
+										}: {
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+								},
+								{
+									contents: map[cacheKey]*unstructured.UnstructuredList{
+										{
+											chunkSize:    100000,
+											pageSize:     1,
+											accessID:     getAccessID("user1", "roleA"),
+											resourcePath: "/apples",
+											revision:     "42",
+										}: {
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+								},
+								{
+									contents: map[cacheKey]*unstructured.UnstructuredList{
+										{
+											chunkSize:    100000,
+											pageSize:     1,
+											accessID:     getAccessID("user1", "roleA"),
+											resourcePath: "/apples",
+											revision:     "42",
+										}: {
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+								},
+							},
+							wantListCalls: []map[string]int{
+								{"all": 1},
+								{"all": 1},
+								{"all": 1},
 							},
 						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"all": 2},
-				{"all": 4},
-				{"all": 4},
-				{"all": 4},
-				{"all": 5},
-			},
-		},
-		{
-			name: "multi-user pagination",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1", "user2"),
-				newRequest("pagesize=1&page=2&revision=42", "user1"),
-				newRequest("pagesize=1&page=2&revision=42", "user2"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user2": "roleB",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user2": "roleB",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-				"user2": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("fuji").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
+						/*
+								{
+									name: "access-change pagination",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1&page=2&revision=42", "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleB",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "all",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"all": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "42",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("fuji").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleB"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"all": 1},
+										{"all": 2},
+									},
+								},
+								{
+									name: "pagination with cache disabled",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1&page=2&revision=42", "user1"),
+										newRequest("pagesize=1&page=3&revision=42", "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "all",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"all": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "42",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("fuji").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+										},
+									},
+									wantCache:    []mockCache{},
+									disableCache: true,
+									wantListCalls: []map[string]int{
+										{"all": 1},
+										{"all": 2},
+										{"all": 3},
+									},
+								},
+								{
+									name: "multi-partition pagesize=1",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1&page=2&revision=102", "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "green",
+											},
+											mockPartition{
+												name: "yellow",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"pink": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "101",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+											},
+										},
+										"green": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "102",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("granny-smith").Unstructured,
+											},
+										},
+										"yellow": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "103",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("crispin").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("crispin").toObj(),
+											},
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("crispin").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("crispin").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"green": 1, "yellow": 1},
+										{"green": 1, "yellow": 1},
+									},
+								},
+								{
+									name: "pagesize=1 & limit=2 & continue",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1&limit=2", "user1"),
+										newRequest("pagesize=1&page=2&limit=2", "user1"),             // does not use cache
+										newRequest("pagesize=1&page=2&revision=42&limit=2", "user1"), // uses cache
+										newRequest("pagesize=1&page=3&revision=42&limit=2", "user1"), // next page from cache
+										newRequest(fmt.Sprintf("pagesize=1&revision=42&limit=2&continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`)))))), "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "all",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"all": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "42",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+												newApple("crispin").Unstructured,
+												newApple("red-delicious").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+											Objects: []types.APIObject{
+												newApple("fuji").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Continue: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("crispin").toObj(),
+											},
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    2,
+													resume:       "",
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Object: map[string]interface{}{
+														"metadata": map[string]interface{}{
+															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+														},
+													},
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    2,
+													resume:       "",
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Object: map[string]interface{}{
+														"metadata": map[string]interface{}{
+															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+														},
+													},
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    2,
+													resume:       "",
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Object: map[string]interface{}{
+														"metadata": map[string]interface{}{
+															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+														},
+													},
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    2,
+													resume:       "",
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Object: map[string]interface{}{
+														"metadata": map[string]interface{}{
+															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+														},
+													},
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    2,
+													resume:       "",
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Object: map[string]interface{}{
+														"metadata": map[string]interface{}{
+															"continue": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+														},
+													},
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+												{
+													chunkSize:    2,
+													resume:       base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"r":"42","p":"all","c":"%s","l":2}`, base64.StdEncoding.EncodeToString([]byte(`crispin`))))),
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("crispin").Unstructured,
+														newApple("red-delicious").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"all": 2},
+										{"all": 4},
+										{"all": 4},
+										{"all": 4},
+										{"all": 5},
+									},
+								},
+								{
+									name: "multi-user pagination",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1", "user2"),
+										newRequest("pagesize=1&page=2&revision=42", "user1"),
+										newRequest("pagesize=1&page=2&revision=42", "user2"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user2": "roleB",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user2": "roleB",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "all",
+											},
+										},
+										"user2": {
+											mockPartition{
+												name: "all",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"all": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "42",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("fuji").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("fuji").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("fuji").Unstructured,
+														newApple("granny-smith").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"all": 1},
+										{"all": 2},
+										{"all": 2},
+										{"all": 2},
+									},
+								},
+								{
+									name: "multi-partition multi-user pagination",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1", "user2"),
+										newRequest("pagesize=1&page=2&revision=102", "user1"),
+										newRequest("pagesize=1&page=2&revision=103", "user2"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user2": "roleB",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user2": "roleB",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "green",
+											},
+										},
+										"user2": {
+											mockPartition{
+												name: "yellow",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"pink": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "101",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+											},
+										},
+										"green": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "102",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("granny-smith").Unstructured,
+												newApple("bramley").Unstructured,
+											},
+										},
+										"yellow": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "103",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("crispin").Unstructured,
+												newApple("golden-delicious").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "103",
+											Objects: []types.APIObject{
+												newApple("crispin").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("bramley").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "103",
+											Objects: []types.APIObject{
+												newApple("golden-delicious").toObj(),
+											},
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												cacheKey{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "103",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("crispin").Unstructured,
+														newApple("golden-delicious").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "103",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("crispin").Unstructured,
+														newApple("golden-delicious").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user2", "roleB"),
+													resourcePath: "/apples",
+													revision:     "103",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("crispin").Unstructured,
+														newApple("golden-delicious").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"green": 1, "yellow": 0},
+										{"green": 1, "yellow": 1},
+										{"green": 1, "yellow": 1},
+										{"green": 1, "yellow": 1},
+									},
+								},
+								{
+									name: "multi-partition access-change pagination",
+									apiOps: []*types.APIRequest{
+										newRequest("pagesize=1", "user1"),
+										newRequest("pagesize=1&page=2&revision=102", "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleB",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "green",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"pink": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "101",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+											},
+										},
+										"green": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "102",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("granny-smith").Unstructured,
+												newApple("bramley").Unstructured,
+											},
+										},
+										"yellow": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "103",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("crispin").Unstructured,
+												newApple("golden-delicious").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("granny-smith").toObj(),
+											},
+										},
+										{
+											Count:    2,
+											Pages:    2,
+											Revision: "102",
+											Objects: []types.APIObject{
+												newApple("bramley").toObj(),
+											},
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												cacheKey{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+												{
+													chunkSize:    100000,
+													pageSize:     1,
+													accessID:     getAccessID("user1", "roleB"),
+													resourcePath: "/apples",
+													revision:     "102",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("granny-smith").Unstructured,
+														newApple("bramley").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"green": 1},
+										{"green": 2},
+									},
+								},
+								{
+									name: "pagination with or filters",
+									apiOps: []*types.APIRequest{
+										newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
+										newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
+										newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
+									},
+									access: []map[string]string{
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+										{
+											"user1": "roleA",
+										},
+									},
+									partitions: map[string][]Partition{
+										"user1": {
+											mockPartition{
+												name: "all",
+											},
+										},
+									},
+									objects: map[string]*unstructured.UnstructuredList{
+										"all": {
+											Object: map[string]interface{}{
+												"metadata": map[string]interface{}{
+													"resourceVersion": "42",
+												},
+											},
+											Items: []unstructured.Unstructured{
+												newApple("fuji").Unstructured,
+												newApple("granny-smith").Unstructured,
+												newApple("red-delicious").Unstructured,
+												newApple("golden-delicious").Unstructured,
+												newApple("crispin").Unstructured,
+											},
+										},
+									},
+									want: []types.APIObjectList{
+										{
+											Count:    3,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("red-delicious").toObj(),
+												newApple("golden-delicious").toObj(),
+											},
+										},
+										{
+											Count:    3,
+											Pages:    2,
+											Revision: "42",
+											Objects: []types.APIObject{
+												newApple("crispin").toObj(),
+											},
+										},
+										{
+											Count:    3,
+											Pages:    2,
+											Revision: "42",
+										},
+									},
+									wantCache: []mockCache{
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													filters:      "data.color=el,metadata.name=el",
+													pageSize:     2,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("red-delicious").Unstructured,
+														newApple("golden-delicious").Unstructured,
+														newApple("crispin").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													filters:      "data.color=el,metadata.name=el",
+													pageSize:     2,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("red-delicious").Unstructured,
+														newApple("golden-delicious").Unstructured,
+														newApple("crispin").Unstructured,
+													},
+												},
+											},
+										},
+										{
+											contents: map[cacheKey]*unstructured.UnstructuredList{
+												{
+													chunkSize:    100000,
+													filters:      "data.color=el,metadata.name=el",
+													pageSize:     2,
+													accessID:     getAccessID("user1", "roleA"),
+													resourcePath: "/apples",
+													revision:     "42",
+												}: {
+													Items: []unstructured.Unstructured{
+														newApple("red-delicious").Unstructured,
+														newApple("golden-delicious").Unstructured,
+														newApple("crispin").Unstructured,
+													},
+												},
+											},
+										},
+									},
+									wantListCalls: []map[string]int{
+										{"all": 1},
+										{"all": 1},
+										{"all": 1},
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "green",
+										},
+									},
+									"user2": {
+										mockPartition{
+											name: "yellow",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "101",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+										},
+									},
+									"green": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "102",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").Unstructured,
+											newApple("bramley").Unstructured,
+										},
+									},
+									"yellow": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "103",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("crispin").Unstructured,
+											newApple("golden-delicious").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "102",
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+										},
+									},
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "103",
+										Objects: []types.APIObject{
+											newApple("crispin").toObj(),
+										},
+									},
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "102",
+										Objects: []types.APIObject{
+											newApple("bramley").toObj(),
+										},
+									},
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "103",
+										Objects: []types.APIObject{
+											newApple("golden-delicious").toObj(),
+										},
+									},
+								},
+								wantCache: []mockCache{
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											cacheKey{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user2", "roleB"),
+												resourcePath: "/apples",
+												revision:     "103",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("crispin").Unstructured,
+													newApple("golden-delicious").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user2", "roleB"),
+												resourcePath: "/apples",
+												revision:     "103",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("crispin").Unstructured,
+													newApple("golden-delicious").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user2", "roleB"),
+												resourcePath: "/apples",
+												revision:     "103",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("crispin").Unstructured,
+													newApple("golden-delicious").Unstructured,
+												},
+											},
+										},
+									},
+								},
+								wantListCalls: []map[string]int{
+									{"green": 1, "yellow": 0},
+									{"green": 1, "yellow": 1},
+									{"green": 1, "yellow": 1},
+									{"green": 1, "yellow": 1},
+								},
 							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
+							{
+								name: "multi-partition access-change pagination",
+								apiOps: []*types.APIRequest{
+									newRequest("pagesize=1", "user1"),
+									newRequest("pagesize=1&page=2&revision=102", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleB",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "green",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"pink": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "101",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+										},
+									},
+									"green": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "102",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("granny-smith").Unstructured,
+											newApple("bramley").Unstructured,
+										},
+									},
+									"yellow": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "103",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("crispin").Unstructured,
+											newApple("golden-delicious").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "102",
+										Objects: []types.APIObject{
+											newApple("granny-smith").toObj(),
+										},
+									},
+									{
+										Count:    2,
+										Pages:    2,
+										Revision: "102",
+										Objects: []types.APIObject{
+											newApple("bramley").toObj(),
+										},
+									},
+								},
+								wantCache: []mockCache{
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											cacheKey{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+											{
+												chunkSize:    100000,
+												pageSize:     1,
+												accessID:     getAccessID("user1", "roleB"),
+												resourcePath: "/apples",
+												revision:     "102",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("granny-smith").Unstructured,
+													newApple("bramley").Unstructured,
+												},
+											},
+										},
+									},
+								},
+								wantListCalls: []map[string]int{
+									{"green": 1},
+									{"green": 2},
+								},
 							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
+							{
+								name: "pagination with or filters",
+								apiOps: []*types.APIRequest{
+									newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
+									newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
+									newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Object: map[string]interface{}{
+											"metadata": map[string]interface{}{
+												"resourceVersion": "42",
+											},
+										},
+										Items: []unstructured.Unstructured{
+											newApple("fuji").Unstructured,
+											newApple("granny-smith").Unstructured,
+											newApple("red-delicious").Unstructured,
+											newApple("golden-delicious").Unstructured,
+											newApple("crispin").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count:    3,
+										Pages:    2,
+										Revision: "42",
+										Objects: []types.APIObject{
+											newApple("red-delicious").toObj(),
+											newApple("golden-delicious").toObj(),
+										},
+									},
+									{
+										Count:    3,
+										Pages:    2,
+										Revision: "42",
+										Objects: []types.APIObject{
+											newApple("crispin").toObj(),
+										},
+									},
+									{
+										Count:    3,
+										Pages:    2,
+										Revision: "42",
+									},
+								},
+								wantCache: []mockCache{
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												filters:      "data.color=el,metadata.name=el",
+												pageSize:     2,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "42",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("red-delicious").Unstructured,
+													newApple("golden-delicious").Unstructured,
+													newApple("crispin").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												filters:      "data.color=el,metadata.name=el",
+												pageSize:     2,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "42",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("red-delicious").Unstructured,
+													newApple("golden-delicious").Unstructured,
+													newApple("crispin").Unstructured,
+												},
+											},
+										},
+									},
+									{
+										contents: map[cacheKey]*unstructured.UnstructuredList{
+											{
+												chunkSize:    100000,
+												filters:      "data.color=el,metadata.name=el",
+												pageSize:     2,
+												accessID:     getAccessID("user1", "roleA"),
+												resourcePath: "/apples",
+												revision:     "42",
+											}: {
+												Items: []unstructured.Unstructured{
+													newApple("red-delicious").Unstructured,
+													newApple("golden-delicious").Unstructured,
+													newApple("crispin").Unstructured,
+												},
+											},
+										},
+									},
+								},
+								wantListCalls: []map[string]int{
+									{"all": 1},
+									{"all": 1},
+									{"all": 1},
+								},
 							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
+							{
+								name: "with project filters",
+								apiOps: []*types.APIRequest{
+									newRequest("projectsornamespaces=p-abcde", "user1"),
+									newRequest("projectsornamespaces=p-abcde,p-fghij", "user1"),
+									newRequest("projectsornamespaces=p-abcde,n2", "user1"),
+									newRequest("projectsornamespaces!=p-abcde", "user1"),
+									newRequest("projectsornamespaces!=p-abcde,p-fghij", "user1"),
+									newRequest("projectsornamespaces!=p-abcde,n2", "user1"),
+									newRequest("projectsornamespaces=foobar", "user1"),
+									newRequest("projectsornamespaces!=foobar", "user1"),
+								},
+								access: []map[string]string{
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+									{
+										"user1": "roleA",
+									},
+								},
+								partitions: map[string][]Partition{
+									"user1": {
+										mockPartition{
+											name: "all",
+										},
+									},
+								},
+								objects: map[string]*unstructured.UnstructuredList{
+									"all": {
+										Items: []unstructured.Unstructured{
+											newApple("fuji").withNamespace("n1").Unstructured,
+											newApple("granny-smith").withNamespace("n1").Unstructured,
+											newApple("bramley").withNamespace("n2").Unstructured,
+											newApple("crispin").withNamespace("n3").Unstructured,
+										},
+									},
+								},
+								want: []types.APIObjectList{
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("fuji").withNamespace("n1").toObj(),
+											newApple("granny-smith").withNamespace("n1").toObj(),
+										},
+									},
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").withNamespace("n1").toObj(),
+											newApple("granny-smith").withNamespace("n1").toObj(),
+											newApple("bramley").withNamespace("n2").toObj(),
+										},
+									},
+									{
+										Count: 3,
+										Objects: []types.APIObject{
+											newApple("fuji").withNamespace("n1").toObj(),
+											newApple("granny-smith").withNamespace("n1").toObj(),
+											newApple("bramley").withNamespace("n2").toObj(),
+										},
+									},
+									{
+										Count: 2,
+										Objects: []types.APIObject{
+											newApple("bramley").withNamespace("n2").toObj(),
+											newApple("crispin").withNamespace("n3").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("crispin").withNamespace("n3").toObj(),
+										},
+									},
+									{
+										Count: 1,
+										Objects: []types.APIObject{
+											newApple("crispin").withNamespace("n3").toObj(),
+										},
+									},
+									{
+										Count: 0,
+									},
+									{
+										Count: 4,
+										Objects: []types.APIObject{
+											newApple("fuji").withNamespace("n1").toObj(),
+											newApple("granny-smith").withNamespace("n1").toObj(),
+											newApple("bramley").withNamespace("n2").toObj(),
+											newApple("crispin").withNamespace("n3").toObj(),
+										},
+									},
+								},
 							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("fuji").Unstructured,
-								newApple("granny-smith").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"all": 1},
-				{"all": 2},
-				{"all": 2},
-				{"all": 2},
-			},
-		},
-		{
-			name: "multi-partition multi-user pagination",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1", "user2"),
-				newRequest("pagesize=1&page=2&revision=102", "user1"),
-				newRequest("pagesize=1&page=2&revision=103", "user2"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user2": "roleB",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user2": "roleB",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "green",
-					},
-				},
-				"user2": {
-					mockPartition{
-						name: "yellow",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "101",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-				"green": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "102",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-						newApple("bramley").Unstructured,
-					},
-				},
-				"yellow": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "103",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-						newApple("golden-delicious").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "103",
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("bramley").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "103",
-					Objects: []types.APIObject{
-						newApple("golden-delicious").toObj(),
-					},
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						cacheKey{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "103",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("crispin").Unstructured,
-								newApple("golden-delicious").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "103",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("crispin").Unstructured,
-								newApple("golden-delicious").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user2", "roleB"),
-							resourcePath: "/apples",
-							revision:     "103",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("crispin").Unstructured,
-								newApple("golden-delicious").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"green": 1, "yellow": 0},
-				{"green": 1, "yellow": 1},
-				{"green": 1, "yellow": 1},
-				{"green": 1, "yellow": 1},
-			},
-		},
-		{
-			name: "multi-partition access-change pagination",
-			apiOps: []*types.APIRequest{
-				newRequest("pagesize=1", "user1"),
-				newRequest("pagesize=1&page=2&revision=102", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleB",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "green",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"pink": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "101",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-					},
-				},
-				"green": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "102",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("granny-smith").Unstructured,
-						newApple("bramley").Unstructured,
-					},
-				},
-				"yellow": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "103",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("crispin").Unstructured,
-						newApple("golden-delicious").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("granny-smith").toObj(),
-					},
-				},
-				{
-					Count:    2,
-					Pages:    2,
-					Revision: "102",
-					Objects: []types.APIObject{
-						newApple("bramley").toObj(),
-					},
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						cacheKey{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-						{
-							chunkSize:    100000,
-							pageSize:     1,
-							accessID:     getAccessID("user1", "roleB"),
-							resourcePath: "/apples",
-							revision:     "102",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("granny-smith").Unstructured,
-								newApple("bramley").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"green": 1},
-				{"green": 2},
-			},
-		},
-		{
-			name: "pagination with or filters",
-			apiOps: []*types.APIRequest{
-				newRequest("filter=metadata.name=el,data.color=el&pagesize=2", "user1"),
-				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=2&revision=42", "user1"),
-				newRequest("filter=metadata.name=el,data.color=el&pagesize=2&page=3&revision=42", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"resourceVersion": "42",
-						},
-					},
-					Items: []unstructured.Unstructured{
-						newApple("fuji").Unstructured,
-						newApple("granny-smith").Unstructured,
-						newApple("red-delicious").Unstructured,
-						newApple("golden-delicious").Unstructured,
-						newApple("crispin").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count:    3,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("red-delicious").toObj(),
-						newApple("golden-delicious").toObj(),
-					},
-				},
-				{
-					Count:    3,
-					Pages:    2,
-					Revision: "42",
-					Objects: []types.APIObject{
-						newApple("crispin").toObj(),
-					},
-				},
-				{
-					Count:    3,
-					Pages:    2,
-					Revision: "42",
-				},
-			},
-			wantCache: []mockCache{
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							filters:      "data.color=el,metadata.name=el",
-							pageSize:     2,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("red-delicious").Unstructured,
-								newApple("golden-delicious").Unstructured,
-								newApple("crispin").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							filters:      "data.color=el,metadata.name=el",
-							pageSize:     2,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("red-delicious").Unstructured,
-								newApple("golden-delicious").Unstructured,
-								newApple("crispin").Unstructured,
-							},
-						},
-					},
-				},
-				{
-					contents: map[cacheKey]*unstructured.UnstructuredList{
-						{
-							chunkSize:    100000,
-							filters:      "data.color=el,metadata.name=el",
-							pageSize:     2,
-							accessID:     getAccessID("user1", "roleA"),
-							resourcePath: "/apples",
-							revision:     "42",
-						}: {
-							Items: []unstructured.Unstructured{
-								newApple("red-delicious").Unstructured,
-								newApple("golden-delicious").Unstructured,
-								newApple("crispin").Unstructured,
-							},
-						},
-					},
-				},
-			},
-			wantListCalls: []map[string]int{
-				{"all": 1},
-				{"all": 1},
-				{"all": 1},
-			},
-		},
-		{
-			name: "with project filters",
-			apiOps: []*types.APIRequest{
-				newRequest("projectsornamespaces=p-abcde", "user1"),
-				newRequest("projectsornamespaces=p-abcde,p-fghij", "user1"),
-				newRequest("projectsornamespaces=p-abcde,n2", "user1"),
-				newRequest("projectsornamespaces!=p-abcde", "user1"),
-				newRequest("projectsornamespaces!=p-abcde,p-fghij", "user1"),
-				newRequest("projectsornamespaces!=p-abcde,n2", "user1"),
-				newRequest("projectsornamespaces=foobar", "user1"),
-				newRequest("projectsornamespaces!=foobar", "user1"),
-			},
-			access: []map[string]string{
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-				{
-					"user1": "roleA",
-				},
-			},
-			partitions: map[string][]Partition{
-				"user1": {
-					mockPartition{
-						name: "all",
-					},
-				},
-			},
-			objects: map[string]*unstructured.UnstructuredList{
-				"all": {
-					Items: []unstructured.Unstructured{
-						newApple("fuji").withNamespace("n1").Unstructured,
-						newApple("granny-smith").withNamespace("n1").Unstructured,
-						newApple("bramley").withNamespace("n2").Unstructured,
-						newApple("crispin").withNamespace("n3").Unstructured,
-					},
-				},
-			},
-			want: []types.APIObjectList{
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("fuji").withNamespace("n1").toObj(),
-						newApple("granny-smith").withNamespace("n1").toObj(),
-					},
-				},
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").withNamespace("n1").toObj(),
-						newApple("granny-smith").withNamespace("n1").toObj(),
-						newApple("bramley").withNamespace("n2").toObj(),
-					},
-				},
-				{
-					Count: 3,
-					Objects: []types.APIObject{
-						newApple("fuji").withNamespace("n1").toObj(),
-						newApple("granny-smith").withNamespace("n1").toObj(),
-						newApple("bramley").withNamespace("n2").toObj(),
-					},
-				},
-				{
-					Count: 2,
-					Objects: []types.APIObject{
-						newApple("bramley").withNamespace("n2").toObj(),
-						newApple("crispin").withNamespace("n3").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("crispin").withNamespace("n3").toObj(),
-					},
-				},
-				{
-					Count: 1,
-					Objects: []types.APIObject{
-						newApple("crispin").withNamespace("n3").toObj(),
-					},
-				},
-				{
-					Count: 0,
-				},
-				{
-					Count: 4,
-					Objects: []types.APIObject{
-						newApple("fuji").withNamespace("n1").toObj(),
-						newApple("granny-smith").withNamespace("n1").toObj(),
-						newApple("bramley").withNamespace("n2").toObj(),
-						newApple("crispin").withNamespace("n3").toObj(),
-					},
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
-			stores := map[string]UnstructuredStore{}
-			for _, partitions := range test.partitions {
-				for _, p := range partitions {
-					stores[p.Name()] = &mockStore{
-						contents: test.objects[p.Name()],
-					}
 				}
-			}
-			asl := &mockAccessSetLookup{userRoles: test.access}
-			if !test.disableCache {
-				t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "false")
-			}
-			store := NewStore(mockPartitioner{
-				stores:     stores,
-				partitions: test.partitions,
-			}, asl, mockNamespaceCache{})
-			for i, req := range test.apiOps {
-				got, gotErr := store.List(req, schema)
-				assert.Nil(t, gotErr)
-				assert.Equal(t, test.want[i], got)
-				if test.disableCache {
-					assert.Nil(t, store.listCache)
-				}
-				if len(test.wantCache) > 0 {
-					assert.Equal(t, len(test.wantCache[i].contents), len(store.listCache.Keys()))
-					for k, v := range test.wantCache[i].contents {
-						cachedVal, _ := store.listCache.Get(k)
-						assert.Equal(t, v, cachedVal)
-					}
-				}
-				if len(test.wantListCalls) > 0 {
-					for name, _ := range store.Partitioner.(mockPartitioner).stores {
-						assert.Equal(t, test.wantListCalls[i][name], store.Partitioner.(mockPartitioner).stores[name].(*mockStore).called)
-					}
-				}
-			}
-		})
-	}
+				for _, test := range tests {
+					t.Run(test.name, func(t *testing.T) {
+						schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
+						stores := map[string]UnstructuredStore{}
+						for _, partitions := range test.partitions {
+							for _, p := range partitions {
+								stores[p.Name()] = &mockStore{
+									contents: test.objects[p.Name()],
+								}
+							}
+						}
+						asl := &mockAccessSetLookup{userRoles: test.access}
+						if !test.disableCache {
+							t.Setenv("CATTLE_REQUEST_CACHE_DISABLED", "false")
+						}
+						store := NewStore(mockPartitioner{
+							stores:     stores,
+							partitions: test.partitions,
+						}, mockNamespaceCache{})
+						for i, req := range test.apiOps {
+							got, gotErr := store.List(req, schema)
+							assert.Nil(t, gotErr)
+							assert.Equal(t, test.want[i], got)
+							/*
+								if test.disableCache {
+									assert.Nil(t, store.listCache)
+								}
+								if len(test.wantCache) > 0 {
+									assert.Equal(t, len(test.wantCache[i].contents), len(store.listCache.Keys()))
+									for k, v := range test.wantCache[i].contents {
+										cachedVal, _ := store.listCache.Get(k)
+										assert.Equal(t, v, cachedVal)
+									}
+								}
+							if len(test.wantListCalls) > 0 {
+								for name, _ := range store.Partitioner.(mockPartitioner).stores {
+									assert.Equal(t, test.wantListCalls[i][name], store.Partitioner.(mockPartitioner).stores[name].(*mockStore).called)
+								}
+							}
+						}
+					})
+		}*/
 }
 
 func TestListByRevision(t *testing.T) {
 
 	schema := &types.APISchema{Schema: &schemas.Schema{ID: "apple"}}
-	asl := &mockAccessSetLookup{userRoles: []map[string]string{
-		{
-			"user1": "roleA",
-		},
-		{
-			"user1": "roleA",
-		},
-	}}
 	store := NewStore(mockPartitioner{
 		stores: map[string]UnstructuredStore{
 			"all": &mockVersionedStore{
@@ -2138,7 +2572,7 @@ func TestListByRevision(t *testing.T) {
 				},
 			},
 		},
-	}, asl, mockNamespaceCache{})
+	}, mockNamespaceCache{})
 	req := newRequest("", "user1")
 
 	got, gotErr := store.List(req, schema)
@@ -2281,9 +2715,11 @@ func (m *mockVersionedStore) List(apiOp *types.APIRequest, schema *types.APISche
 	return contents, nil, nil
 }
 
+/*
 type mockCache struct {
 	contents map[cacheKey]*unstructured.UnstructuredList
 }
+*/
 
 var colorMap = map[string]string{
 	"fuji":             "pink",

--- a/pkg/stores/proxy/cache/cache.go
+++ b/pkg/stores/proxy/cache/cache.go
@@ -1,0 +1,137 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+var (
+	ErrNotFound = errors.New("key was not found in cache")
+)
+
+type SizedRevisionCache struct {
+	listRevisionCache *cache.LRUExpireCache
+	cacheLock         sync.Mutex
+	size              int
+	sizeLimit         int
+}
+
+type Cacher interface {
+	Get(key CacheKey) (*unstructured.UnstructuredList, error)
+	Add(key CacheKey, list *unstructured.UnstructuredList) error
+}
+
+type CacheKey struct {
+	resourcePath string
+	revision     string
+	namespace    string
+	cont         string
+}
+
+type cacheObj struct {
+	size int
+	obj  interface{}
+}
+
+func NewSizedRevisionCache(sizeLimit, maxElements int) *SizedRevisionCache {
+	return &SizedRevisionCache{
+		listRevisionCache: cache.NewLRUExpireCache(maxElements),
+		sizeLimit:         sizeLimit,
+	}
+}
+
+func (c CacheKey) String() string {
+	return fmt.Sprintf("resourcePath: %s, revision: %s, namespace: %s, cont: %s", c.resourcePath, c.revision, c.namespace, c.cont)
+}
+
+func (s *SizedRevisionCache) Get(key CacheKey) (*unstructured.UnstructuredList, error) {
+	s.cacheLock.Lock()
+	defer s.cacheLock.Unlock()
+	// check if cache stored all namespaces
+
+	obj, ok := s.listRevisionCache.Get(key)
+	if !ok {
+		return nil, ErrNotFound
+	}
+	uList, ok := obj.(cacheObj)
+	if !ok {
+		return nil, fmt.Errorf("could not assert object stored with key [%s] key as UnstructuredList", key)
+	}
+	return uList.obj.(*unstructured.UnstructuredList), nil
+}
+
+func (s *SizedRevisionCache) Add(key CacheKey, list *unstructured.UnstructuredList) error {
+	s.cacheLock.Lock()
+	defer s.cacheLock.Unlock()
+
+	objBytes, err := list.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	cacheListObj := cacheObj{
+		size: len(objBytes),
+		obj:  list,
+	}
+
+	currentSize := s.sizeOfCurrentEntry(key)
+
+	if err = s.adjustSize(cacheListObj.size - currentSize); err != nil {
+		return err
+	}
+	s.listRevisionCache.Add(key, cacheListObj, 30*time.Minute)
+
+	return nil
+}
+
+func (s *SizedRevisionCache) calculateSize() int {
+	var total int
+	for _, key := range s.listRevisionCache.Keys() {
+		total += s.sizeOfCurrentEntry(key)
+	}
+	return total
+}
+
+func (s *SizedRevisionCache) sizeOfCurrentEntry(key interface{}) int {
+	obj, ok := s.listRevisionCache.Get(key)
+	if !ok {
+		return 0
+	}
+
+	cacheObject, ok := obj.(cacheObj)
+	if !ok {
+		return 0
+	}
+
+	return cacheObject.size
+}
+
+func (s *SizedRevisionCache) adjustSize(diff int) error {
+	if !(s.size+diff > s.sizeLimit) {
+		s.size += diff
+		return nil
+	}
+
+	s.size = s.calculateSize()
+
+	if !(s.size+diff > s.sizeLimit) {
+		s.sizeLimit += diff
+		return nil
+	}
+
+	return fmt.Errorf("[steve proxy cache]: cache is near full with a size of [%d] and limit of [%d], cannot increment size by [%d]", s.size, s.sizeLimit, diff)
+}
+
+func GetCacheKey(resourcePath, revision, ns, cont string) CacheKey {
+	return CacheKey{
+		resourcePath: resourcePath,
+		revision:     revision,
+		namespace:    ns,
+		cont:         cont,
+	}
+}

--- a/pkg/stores/proxy/cache/cache_test.go
+++ b/pkg/stores/proxy/cache/cache_test.go
@@ -1,0 +1,305 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetCacheKey(t *testing.T) {
+	resourcePath := "asdf"
+	revision := "1234"
+	ns := "default"
+	cont := "abcdasdf"
+	key := GetCacheKey(resourcePath, revision, ns, cont)
+	assert.Equal(t, CacheKey{resourcePath: resourcePath, revision: revision, namespace: ns, cont: cont}, key)
+}
+
+func TestString(t *testing.T) {
+	key := CacheKey{resourcePath: "clusters", revision: "1000", namespace: "testns", cont: "asd"}
+	assert.Equal(t, "resourcePath: clusters, revision: 1000, namespace: testns, cont: asd", key.String())
+}
+
+func TestAdd(t *testing.T) {
+	type addRequest struct {
+		objectList  *unstructured.UnstructuredList
+		expectedErr bool
+		key         CacheKey
+	}
+	tests := []struct {
+		name        string
+		sizeLimit   int
+		addRequests []addRequest
+	}{
+		{
+			name:      "test adding an entry that does not exceed limit",
+			sizeLimit: 10000,
+			addRequests: []addRequest{
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+			},
+		},
+		{
+			name:      "update object already in cache", // this is not very likely to happen with a 30 minute expiration and always having a revision number
+			sizeLimit: 10000,
+			addRequests: []addRequest{
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj3": "asaasdfd",
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+			},
+		},
+		{
+			name:      "test adding an entry while above limit",
+			sizeLimit: 10000,
+			addRequests: []addRequest{
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj3": strings.Repeat("a", 10000),
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj2",
+						revision:     "1",
+					},
+					expectedErr: true,
+				},
+			},
+		},
+		{
+			name:      "add obj that does not exceed limit because it replaces current entry",
+			sizeLimit: 10000,
+			addRequests: []addRequest{
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj1": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj3": strings.Repeat("a", 7500),
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+				{
+					objectList: &unstructured.UnstructuredList{
+						Object: map[string]interface{}{
+							"somefakeobj": "asdf",
+						},
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"somefakeobj1": "asd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj2": "asaasdfd",
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"somefakeobj3": strings.Repeat("a", 7500),
+								},
+							},
+						},
+					},
+					key: CacheKey{
+						resourcePath: "obj1",
+						revision:     "1",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCache := NewSizedRevisionCache(test.sizeLimit, 10)
+			for _, ar := range test.addRequests {
+				err := testCache.Add(ar.key, ar.objectList)
+				obj, ok := testCache.listRevisionCache.Get(ar.key)
+				cObj, _ := obj.(cacheObj)
+				if !ar.expectedErr {
+					assert.Nil(t, err)
+					assert.True(t, ok)
+					assert.Equal(t, ar.objectList, cObj.obj)
+					continue
+				}
+				assert.NotNil(t, err)
+				if !ok {
+					continue
+				}
+				assert.NotEqual(t, ar.objectList, cObj.obj)
+
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	c := NewSizedRevisionCache(10000, 10)
+	key := GetCacheKey("something", "1000", "default", "")
+	addedList := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"somefakeobj": "asdf",
+		},
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"somefakeobj": "asd",
+				},
+			},
+		},
+	}
+	err := c.Add(key, addedList)
+	assert.Nil(t, err)
+
+	// get existing list
+	list, err := c.Get(key)
+	assert.Nil(t, err)
+	assert.Equal(t, addedList, list)
+
+	// get existing list at different revision
+	list, err = c.Get(GetCacheKey("somethingelse", "900", "default", ""))
+	assert.Nil(t, list)
+	assert.True(t, errors.Is(ErrNotFound, err))
+
+	// get existing list with different ns
+	list, err = c.Get(GetCacheKey("somethingelse", "1000", "asdf", ""))
+	assert.Nil(t, list)
+	assert.True(t, errors.Is(ErrNotFound, err))
+
+	// get existing list with different cont
+	list, err = c.Get(GetCacheKey("somethingelse", "1000", "default", "asdf"))
+	assert.Nil(t, list)
+	assert.True(t, errors.Is(ErrNotFound, err))
+
+	// get list that does not exist
+	list, err = c.Get(GetCacheKey("somethingelse", "1000", "default", ""))
+	assert.Nil(t, list)
+	assert.True(t, errors.Is(ErrNotFound, err))
+}


### PR DESCRIPTION
**Background info:**
Steve cache grew too large with original implementation. This caused agents to go oom. The aspects of the original implementation this PR focuses on is the redundant caching and the missing ability to constrain the cache by memory.

Although caching requests itself could yield performance/scaling benefits, the intention is to facilitate pagination in the UI which should itself yield performance/scaling benefits. We need caching in order to preserve requests for older resource versions. We want to do this without introducing new performance/scaling issues.

Prior, we were caching the sorted and filtered requests. The key contained parameters for sorting, filtering, and the users access. `accessID` is actually the asl (AccessSetLookup) cacheKey which contains the users current bindings. These different fields could lead too many unique cache entries.

Now, we are caching the proxy_store request. These entries are simply for requests of a certain resource, at a certain resource version, for a certain namespace or all namespaces. These entries should be useful for many requests by many users. We are also computing the size of the requests in bytes, these are approximate and not perfect measurements. This allows us to constrain the cache by total, approximate memory-size.

The theories behind this approach:
* the cacheKey containing these fields either have little benefit or are a detriment to the cache.
** the sorting and filtering are not a substantial amount of compute time relative to preventing a full request.
** removing these should increase gets from the cache and decrease cache updates
* moving the caching layer near the proxy_store _instead_ of where rbac is relevant which increase the amount of successful cache gets we are doing and reduce the amount of cache updating.
* we may see small benefits from no longer computing the asl cache key
* we should be bounding the total cache size by some sort of memory constraint.

Ways this approach could be improved:
* Cache sorting/filtering indexes. This would mean adding a small cache the sorting and filtering layer that would remember how request were rearranged to fulfill a request.
* Fulfilling namespaced requests with cache entries for entire list by filtering out the other namespaces. I intended on doing this but noticed the UI was not making many namespaced requests as far as I could tell. This appeared true even when filtering by namespace in the UI and refreshing.
* If evaluating the size of the cached list proves to increase the response time drastically, we can add it to the cache in a goroutine- I just did not want to do that preemptively.

Prior, our cache key looked like:
```
type cacheKey struct {
	chunkSize    int
	resume       string
	filters      string
	sort         string
	pageSize     int
	accessID     string
	resourcePath string
	revision     string
}
```

In this PR, our cache key looks like:
```
type CacheKey struct {
	listOptions  v1.ListOptions
	resourcePath string
	namespace    string
}
```

**Note**: ListOptions missing from the original cacheKey is an issue and was going to be added regardless of the rest of the changes included in this PR. List options includes some of the fields from the original cacheKey such as `revision` and therefore gives the illusion even more uniqueness has been removed from caching. AccessID, filters, sort, and pageSize are the main fields that are no longer in cacheKey that should cause Get to get a hit from the cache more often.

**Issue:**
https://github.com/rancher/rancher/issues/41378