### PR TITLE
Updating ByNames to not return nil, nil

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -205,9 +205,10 @@ func tableToObjects(obj map[string]interface{}) []unstructured.Unstructured {
 // be returned in the list.
 func (s *Store) ByNames(apiOp *types.APIRequest, schema *types.APISchema, names sets.String) (*unstructured.UnstructuredList, []types.Warning, error) {
 	if apiOp.Namespace == "*" {
-		// This happens when you grant namespaced objects with "get" by name in a clusterrolebinding. We will treat
-		// this as an invalid situation instead of listing all objects in the cluster and filtering by name.
-		return nil, nil, nil
+		// This happens when you grant namespaced objects with "get" or "list "by name in a clusterrolebinding.
+		// We will treat this as an invalid situation instead of listing all objects in the cluster
+		// and filtering by name.
+		return &unstructured.UnstructuredList{}, nil, nil
 	}
 	buffer := WarningBuffer{}
 	adminClient, err := s.clientGetter.TableAdminClient(apiOp, schema, apiOp.Namespace, &buffer)

--- a/pkg/stores/proxy/proxy_store_test.go
+++ b/pkg/stores/proxy/proxy_store_test.go
@@ -68,6 +68,18 @@ func TestWatchNamesErrReceive(t *testing.T) {
 	assert.Equal(t, 0, len(c.ResultChan()), "Expected all secrets to have been received")
 }
 
+func TestByNames(t *testing.T) {
+	s := Store{}
+	apiSchema := &types.APISchema{Schema: &schemas.Schema{}}
+	apiOp := &types.APIRequest{Namespace: "*", Schema: apiSchema, Request: &http.Request{}}
+	names := sets.NewString("some-resource", "some-other-resource")
+	result, warn, err := s.ByNames(apiOp, apiSchema, names)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Items, 0)
+	assert.Nil(t, err)
+	assert.Nil(t, warn)
+}
+
 func (t *testFactory) TableAdminClientForWatch(ctx *types.APIRequest, schema *types.APISchema, namespace string, warningHandler rest.WarningHandler) (dynamic.ResourceInterface, error) {
 	return t.fakeClient.Resource(schema2.GroupVersionResource{}), nil
 }


### PR DESCRIPTION
ByNames could previously return a nil value and a nil error. This caused issues when other parts of the application
(pkg/stores/partition/parallel.go) tried to use the result. Now this will return an empty list on the error condition, instead of nil.

Related to rancher/rancher#43030.

## Overview

Steve's [partion lister](https://github.com/rancher/steve/blob/811e0b3572fd1f5008ec3b151658c97d578deca6/pkg/stores/partition/parallel.go#L179) makes in internal call to a `Lister`, which is (in turn) a proxy/rbac store. After making this call, it attempts to set several values from the result of that call, including the ResourceVersion of the list (which is useful for future calls to these resources, potentially including paginated use cases). In the case where the user has a permission granting permissions on specific resourceNames in the entire cluster (see below for a production use-case) this will result in a panic - since the proxy store returns `nil` for both the err and the list in this case.

This results in a panic in steve and the binary using steve (in this case, the cluster agent), which causes the linked issue above.

This case is triggered in (at least) the monitoring v2 use case - the [monitoring-ui-view](https://github.com/rancher/charts/blob/706052fd6f93d216c55d6528bc5de3a5cf06d440/charts/rancher-monitoring/103.0.0%2Bup45.31.1/templates/rancher-monitoring/clusterrole.yaml#L123) cluster role grants permissions on specific resource names, and can be assigned to users at the cluster level using a cluster role binding (see rancher/dashboard#9792 for an example).

## Solution

Change the proxy store to return a valid value in the identified use case (user has permissions on all resources of a specific name at the cluster scope). Long term, we may want this to return valid values, but given the explicit warnings in the code I think this needs more investigation before we go that route. 