### PR TITLE
WatchNames: return errors via WebSocket

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -370,6 +370,7 @@ func (s *Store) WatchNames(apiOp *types.APIRequest, schema *types.APISchema, w t
 				} else {
 					logrus.Debugf("WatchNames received error: %v", item)
 				}
+				result <- item
 				continue
 			}
 


### PR DESCRIPTION
Align behavior with plain `Watch`, which also does the same. UI code actually expects the same behavior in both cases.

Fixes https://github.com/rancher/rancher/issues/41809