### PR TITLE
Resource schema improved cache

### DIFF
--- a/pkg/debounce/refresher.go
+++ b/pkg/debounce/refresher.go
@@ -1,0 +1,51 @@
+package debounce
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Refreshable represents an object which can be refreshed. This should be protected by a mutex for concurrent operation.
+type Refreshable interface {
+	Refresh() error
+}
+
+// DebounceableRefresher is used to debounce multiple attempts to refresh a refreshable type.
+type DebounceableRefresher struct {
+	sync.Mutex
+	// Refreshable is any type that can be refreshed. The refresh method should by protected by a mutex internally.
+	Refreshable Refreshable
+	current     context.CancelFunc
+}
+
+// RefreshAfter requests a refresh after a certain time has passed. Subsequent calls to this method will
+// delay the requested refresh by the new duration. Note that this is a total override of the previous calls - calling
+// RefreshAfter(time.Second * 2) and then immediately calling RefreshAfter(time.Microsecond * 1) will run a refresh
+// in one microsecond
+func (d *DebounceableRefresher) RefreshAfter(duration time.Duration) {
+	d.Lock()
+	defer d.Unlock()
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	if d.current != nil {
+		d.current()
+	}
+	d.current = cancel
+	go func() {
+		timer := time.NewTimer(duration)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			// this indicates that the context was cancelled. Do nothing.
+		case <-timer.C:
+			// note this can cause multiple refreshes to happen concurrently
+			err := d.Refreshable.Refresh()
+			if err != nil {
+				logrus.Errorf("failed to refresh with error: %v", err)
+			}
+		}
+	}()
+}

--- a/pkg/debounce/refresher_test.go
+++ b/pkg/debounce/refresher_test.go
@@ -1,0 +1,47 @@
+package debounce
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type refreshable struct {
+	wasRefreshed atomic.Bool
+	retErr       error
+}
+
+func (r *refreshable) Refresh() error {
+	r.wasRefreshed.Store(true)
+	return r.retErr
+}
+
+func TestRefreshAfter(t *testing.T) {
+	ref := refreshable{}
+	debounce := DebounceableRefresher{
+		Refreshable: &ref,
+	}
+	debounce.RefreshAfter(time.Millisecond * 2)
+	debounce.RefreshAfter(time.Microsecond * 2)
+	time.Sleep(time.Millisecond * 1)
+	// test that the second refresh call overrode the first - Micro < Milli so this should have ran
+	require.True(t, ref.wasRefreshed.Load())
+	ref.wasRefreshed.Store(false)
+	time.Sleep(time.Millisecond * 2)
+	// test that the call was debounced - though we called this twice only one refresh should be called
+	require.False(t, ref.wasRefreshed.Load())
+
+	ref = refreshable{
+		retErr: fmt.Errorf("Some error"),
+	}
+	debounce = DebounceableRefresher{
+		Refreshable: &ref,
+	}
+	debounce.RefreshAfter(time.Microsecond * 2)
+	// test the error case
+	time.Sleep(time.Millisecond * 1)
+	require.True(t, ref.wasRefreshed.Load())
+}

--- a/pkg/schema/definitions/openapi_test.go
+++ b/pkg/schema/definitions/openapi_test.go
@@ -82,6 +82,128 @@ definitions:
     - group: "management.cattle.io"
       version: "v2"
       kind: "GlobalRole"
+  io.cattle.noversion.v2.Resource:
+    description: "A No Version V2 resource is for a group with no preferred version"
+    type: "object"
+    properties:
+      apiVersion:
+        description: "The APIVersion of this resource"
+        type: "string"
+      kind:
+        description: "The kind"
+        type: "string"
+      metadata:
+        description: "The metadata"
+        $ref: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+      spec:
+        description: "The spec for the resource"
+        type: "object"
+        required:
+        - "name"
+        properties:
+          name:
+            description: "The name of the resource"
+            type: "string"
+          notRequired:
+            description: "Some field that isn't required"
+            type: "boolean"
+          newField:
+            description: "A new field not present in v1"
+            type: "string"
+    x-kubernetes-group-version-kind:
+    - group: "noversion.cattle.io"
+      version: "v2"
+      kind: "Resource"
+  io.cattle.noversion.v1.Resource:
+    description: "A No Version V1 resource is for a group with no preferred version"
+    type: "object"
+    properties:
+      apiVersion:
+        description: "The APIVersion of this resource"
+        type: "string"
+      kind:
+        description: "The kind"
+        type: "string"
+      metadata:
+        description: "The metadata"
+        $ref: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+      spec:
+        description: "The spec for the resource"
+        type: "object"
+        required:
+        - "name"
+        properties:
+          name:
+            description: "The name of the resource"
+            type: "string"
+          notRequired:
+            description: "Some field that isn't required"
+            type: "boolean"
+    x-kubernetes-group-version-kind:
+    - group: "noversion.cattle.io"
+      version: "v1"
+      kind: "Resource"
+  io.cattle.missinggroup.v2.Resource:
+    description: "A Missing Group V2 resource is for a group not listed by server groups"
+    type: "object"
+    properties:
+      apiVersion:
+        description: "The APIVersion of this resource"
+        type: "string"
+      kind:
+        description: "The kind"
+        type: "string"
+      metadata:
+        description: "The metadata"
+        $ref: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+      spec:
+        description: "The spec for the resource"
+        type: "object"
+        required:
+        - "name"
+        properties:
+          name:
+            description: "The name of the resource"
+            type: "string"
+          notRequired:
+            description: "Some field that isn't required"
+            type: "boolean"
+          newField:
+            description: "A new field not present in v1"
+            type: "string"
+    x-kubernetes-group-version-kind:
+    - group: "missinggroup.cattle.io"
+      version: "v2"
+      kind: "Resource"
+  io.cattle.missinggroup.v1.Resource:
+    description: "A Missing Group V1 resource is for a group not listed by server groups"
+    type: "object"
+    properties:
+      apiVersion:
+        description: "The APIVersion of this resource"
+        type: "string"
+      kind:
+        description: "The kind"
+        type: "string"
+      metadata:
+        description: "The metadata"
+        $ref: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+      spec:
+        description: "The spec for the resource"
+        type: "object"
+        required:
+        - "name"
+        properties:
+          name:
+            description: "The name of the resource"
+            type: "string"
+          notRequired:
+            description: "Some field that isn't required"
+            type: "boolean"
+    x-kubernetes-group-version-kind:
+    - group: "missinggroup.cattle.io"
+      version: "v1"
+      kind: "Resource"
   io.cattle.management.NotAKind:
     type: "string"
     description: "Some string which isn't a kind"

--- a/pkg/schema/definitions/openapi_test.go
+++ b/pkg/schema/definitions/openapi_test.go
@@ -82,7 +82,7 @@ definitions:
     - group: "management.cattle.io"
       version: "v2"
       kind: "GlobalRole"
-  io.management.cattle.NotAKind:
+  io.cattle.management.NotAKind:
     type: "string"
     description: "Some string which isn't a kind"
   io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta:

--- a/pkg/schema/definitions/refresh.go
+++ b/pkg/schema/definitions/refresh.go
@@ -1,0 +1,48 @@
+package definitions
+
+import (
+	"context"
+	"time"
+
+	"github.com/rancher/steve/pkg/debounce"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+// refreshHandler triggers refreshes for a Debounceable refresher after a CRD/APIService has been changed
+// intended to refresh the schema definitions after a CRD has been added and is hopefully available in k8s.
+type refreshHandler struct {
+	// debounceRef is the debounceableRefresher containing the Refreshable (typically the schema definition handler)
+	debounceRef *debounce.DebounceableRefresher
+	// debounceDuration is the duration that the handler should ask the DebounceableRefresher to wait before refreshing
+	debounceDuration time.Duration
+}
+
+// onChangeCRD refreshes the debounceRef after a CRD is added/changed
+func (r *refreshHandler) onChangeCRD(key string, crd *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
+	r.debounceRef.RefreshAfter(r.debounceDuration)
+	return crd, nil
+}
+
+// onChangeAPIService refreshes the debounceRef after an APIService is added/changed
+func (r *refreshHandler) onChangeAPIService(key string, api *apiregv1.APIService) (*apiregv1.APIService, error) {
+	r.debounceRef.RefreshAfter(r.debounceDuration)
+	return api, nil
+}
+
+// startBackgroundRefresh starts a force refresh that runs for every tick of duration. Can be stopped
+// by cancelling the context
+func (r *refreshHandler) startBackgroundRefresh(ctx context.Context, duration time.Duration) {
+	go func() {
+		ticker := time.NewTicker(duration)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.debounceRef.RefreshAfter(r.debounceDuration)
+			}
+		}
+	}()
+}

--- a/pkg/schema/definitions/refresh_test.go
+++ b/pkg/schema/definitions/refresh_test.go
@@ -1,0 +1,84 @@
+package definitions
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rancher/steve/pkg/debounce"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+type refreshable struct {
+	wasRefreshed atomic.Bool
+}
+
+func (r *refreshable) Refresh() error {
+	r.wasRefreshed.Store(true)
+	return nil
+}
+
+func Test_onChangeCRD(t *testing.T) {
+	internalRefresh := refreshable{}
+	refresher := debounce.DebounceableRefresher{
+		Refreshable: &internalRefresh,
+	}
+	refreshHandler := refreshHandler{
+		debounceRef:      &refresher,
+		debounceDuration: time.Microsecond * 5,
+	}
+	input := apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-crd",
+		},
+	}
+	output, err := refreshHandler.onChangeCRD("test-crd", &input)
+	require.Nil(t, err)
+	require.Equal(t, input, *output)
+	// waiting to allow the debouncer to refresh the refreshable
+	time.Sleep(time.Millisecond * 2)
+	require.True(t, internalRefresh.wasRefreshed.Load())
+}
+
+func Test_onChangeAPIService(t *testing.T) {
+	internalRefresh := refreshable{}
+	refresher := debounce.DebounceableRefresher{
+		Refreshable: &internalRefresh,
+	}
+	refreshHandler := refreshHandler{
+		debounceRef:      &refresher,
+		debounceDuration: time.Microsecond * 5,
+	}
+	input := apiregv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-apiservice",
+		},
+	}
+	output, err := refreshHandler.onChangeAPIService("test-apiservice", &input)
+	require.Nil(t, err)
+	require.Equal(t, input, *output)
+	// waiting to allow the debouncer to refresh the refreshable
+	time.Sleep(time.Millisecond * 2)
+	require.True(t, internalRefresh.wasRefreshed.Load())
+
+}
+
+func Test_startBackgroundRefresh(t *testing.T) {
+	internalRefresh := refreshable{}
+	refresher := debounce.DebounceableRefresher{
+		Refreshable: &internalRefresh,
+	}
+	refreshHandler := refreshHandler{
+		debounceRef:      &refresher,
+		debounceDuration: time.Microsecond * 5,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	refreshHandler.startBackgroundRefresh(ctx, time.Microsecond*10)
+	time.Sleep(time.Millisecond * 2)
+	require.True(t, internalRefresh.wasRefreshed.Load())
+	cancel()
+}

--- a/pkg/schema/definitions/schema.go
+++ b/pkg/schema/definitions/schema.go
@@ -1,36 +1,29 @@
 package definitions
 
 import (
+	"context"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/debounce"
+	apiextcontrollerv1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/apiextensions.k8s.io/v1"
+	v1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/apiregistration.k8s.io/v1"
 	"github.com/rancher/wrangler/v2/pkg/schemas"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/discovery"
 )
 
 const (
-	gvkExtensionName    = "x-kubernetes-group-version-kind"
-	gvkExtensionGroup   = "group"
-	gvkExtensionVersion = "version"
-	gvkExtensionKind    = "kind"
-	defaultDuration     = time.Second * 5
+	handlerKey     = "schema-definitions"
+	delayEnvVar    = "CATTLE_CRD_REFRESH_DELAY_SECONDS"
+	defaultDelay   = 2
+	delayUnit      = time.Second
+	refreshEnvVar  = "CATTLE_BACKGROUND_REFRESH_MINUTES"
+	defaultRefresh = 10
+	refreshUnit    = time.Minute
 )
-
-// Register registers the schemaDefinition schema.
-func Register(baseSchema *types.APISchemas, client discovery.DiscoveryInterface) {
-	handler := schemaDefinitionHandler{
-		client:       client,
-		refreshStale: defaultDuration,
-	}
-	baseSchema.MustAddSchema(types.APISchema{
-		Schema: &schemas.Schema{
-			ID:              "schemaDefinition",
-			PluralName:      "schemaDefinitions",
-			ResourceMethods: []string{"GET"},
-		},
-		ByIDHandler: handler.byIDHandler,
-	})
-}
 
 type schemaDefinition struct {
 	DefinitionType string                `json:"definitionType"`
@@ -48,4 +41,56 @@ type definitionField struct {
 	SubType     string `json:"subtype,omitempty"`
 	Description string `json:"description,omitempty"`
 	Required    bool   `json:"required,omitempty"`
+}
+
+// Register registers the schemaDefinition schema.
+func Register(ctx context.Context,
+	baseSchema *types.APISchemas,
+	client discovery.DiscoveryInterface,
+	crd apiextcontrollerv1.CustomResourceDefinitionController,
+	apiService v1.APIServiceController) {
+	handler := SchemaDefinitionHandler{
+		client: client,
+	}
+	baseSchema.MustAddSchema(types.APISchema{
+		Schema: &schemas.Schema{
+			ID:              "schemaDefinition",
+			PluralName:      "schemaDefinitions",
+			ResourceMethods: []string{"GET"},
+		},
+		ByIDHandler: handler.byIDHandler,
+	})
+
+	debounce := debounce.DebounceableRefresher{
+		Refreshable: &handler,
+	}
+	crdDebounce := getDurationEnvVarOrDefault(delayEnvVar, defaultDelay, delayUnit)
+	refHandler := refreshHandler{
+		debounceRef:      &debounce,
+		debounceDuration: crdDebounce,
+	}
+	crd.OnChange(ctx, handlerKey, refHandler.onChangeCRD)
+	apiService.OnChange(ctx, handlerKey, refHandler.onChangeAPIService)
+	refreshFrequency := getDurationEnvVarOrDefault(refreshEnvVar, defaultRefresh, refreshUnit)
+	// there's a delay between when a CRD is created and when it is available in the openapi/v2 endpoint
+	// the crd/apiservice controllers use a delay of 2 seconds to account for this, but it's possible that this isn't
+	// enough in certain environments, so we also use an infrequent background refresh to eventually correct any misses
+	refHandler.startBackgroundRefresh(ctx, refreshFrequency)
+}
+
+// getDurationEnvVarOrDefault gets the duration value for a given envVar. If not found, it returns the provided default.
+// unit is the unit of time (time.Second/time.Minute/etc.) that the returned duration should be in
+func getDurationEnvVarOrDefault(envVar string, defaultVal int, unit time.Duration) time.Duration {
+	defaultDuration := time.Duration(defaultVal) * unit
+	envValue, ok := os.LookupEnv(envVar)
+	if !ok {
+		return defaultDuration
+	}
+	parsed, err := strconv.Atoi(envValue)
+	if err != nil {
+		logrus.Errorf("Env var %s was specified, but could not be converted to an int, default of %d seconds will be used",
+			envVar, int64(defaultDuration.Seconds()))
+		return defaultDuration
+	}
+	return time.Duration(parsed) * unit
 }

--- a/pkg/schema/definitions/schema_test.go
+++ b/pkg/schema/definitions/schema_test.go
@@ -1,0 +1,76 @@
+package definitions
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/wrangler/v2/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+func TestRegister(t *testing.T) {
+	schemas := types.EmptyAPISchemas()
+	client := fakeDiscovery{}
+	ctrl := gomock.NewController(t)
+	crdController := fake.NewMockNonNamespacedControllerInterface[*apiextv1.CustomResourceDefinition, *apiextv1.CustomResourceDefinitionList](ctrl)
+	apisvcController := fake.NewMockNonNamespacedControllerInterface[*apiregv1.APIService, *apiregv1.APIServiceList](ctrl)
+	ctx, cancel := context.WithCancel(context.Background())
+	crdController.EXPECT().OnChange(ctx, handlerKey, gomock.Any())
+	apisvcController.EXPECT().OnChange(ctx, handlerKey, gomock.Any())
+	Register(ctx, schemas, &client, crdController, apisvcController)
+	registeredSchema := schemas.LookupSchema("schemaDefinition")
+	require.NotNil(t, registeredSchema)
+	require.Len(t, registeredSchema.ResourceMethods, 1)
+	require.Equal(t, registeredSchema.ResourceMethods[0], "GET")
+	require.NotNil(t, registeredSchema.ByIDHandler)
+	// Register will spawn a background thread, so we want to stop that to not impact other tests
+	cancel()
+}
+
+func Test_getDurationEnvVarOrDefault(t *testing.T) {
+	os.Setenv("VALID", "1")
+	os.Setenv("INVALID", "NOTANUMBER")
+	tests := []struct {
+		name         string
+		envVar       string
+		defaultValue int
+		unit         time.Duration
+		wantDuration time.Duration
+	}{
+		{
+			name:         "not found, use default",
+			envVar:       "NOT_FOUND",
+			defaultValue: 12,
+			unit:         time.Second,
+			wantDuration: time.Second * 12,
+		},
+		{
+			name:         "found but not an int",
+			envVar:       "INVALID",
+			defaultValue: 24,
+			unit:         time.Minute,
+			wantDuration: time.Minute * 24,
+		},
+		{
+			name:         "found and valid int",
+			envVar:       "VALID",
+			defaultValue: 30,
+			unit:         time.Hour,
+			wantDuration: time.Hour * 1,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := getDurationEnvVarOrDefault(test.envVar, test.defaultValue, test.unit)
+			require.Equal(t, test.wantDuration, got)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -142,7 +142,8 @@ func setup(ctx context.Context, server *Server) error {
 	if err = resources.DefaultSchemas(ctx, server.BaseSchemas, ccache, server.ClientFactory, sf, server.Version); err != nil {
 		return err
 	}
-	definitions.Register(server.BaseSchemas, server.controllers.K8s.Discovery())
+	definitions.Register(ctx, server.BaseSchemas, server.controllers.K8s.Discovery(),
+		server.controllers.CRD.CustomResourceDefinition(), server.controllers.API.APIService())
 
 	summaryCache := summarycache.New(sf, ccache)
 	summaryCache.Start(ctx)


### PR DESCRIPTION
## Overview

Followup to #139 and related to rancher/rancher#41301. This PR improves the caching mechanism used by the schema definitions endpoint to refresh once a CRD has been changed, rather than on request after a certain time period.

This also fixes a small bug in preferred versions - before, we selected the version that was preferred for a resource from the APIResourceList. We now source this information from the groups, like we do in other [areas of steve](https://github.com/rancher/steve/blob/641178e7cbc7edf18ff2c3dbc1f09ec863153d1a/pkg/schema/converter/discovery.go#L56).

## Solution Detail
- Adds a new `DebouncableRefresher` object and `Refreshable` interface. This allows a caller to queue multiple refreshes by repeated calls to "RefreshAfter" and only have the refresher run after the latest duration has elapsed.
- Adds a new "refreshHandler" which controls how often the schema definitions are refreshed. This triggers a refresh in 3 cases:
  - When a new CRD is added, mirroring what is currently done for [schemas](https://github.com/rancher/steve/blob/641178e7cbc7edf18ff2c3dbc1f09ec863153d1a/pkg/controllers/schema/schemas.go#L71).
  - When a new apiService is added, mirroring what is currently done for [schemas](https://github.com/rancher/steve/blob/641178e7cbc7edf18ff2c3dbc1f09ec863153d1a/pkg/controllers/schema/schemas.go#L70).
  - After a specified duration has passed (e.x. every 10 minutes).
- Wraps the schema definition handler in a `DebouncableRefresher`, and makes Refresh of the definitions exclusively handled by the refreshHandler. 
- Adds two new environment variables to allow for performance tuning on the refresh:
  - `CATTLE_CRD_REFRESH_DELAY_SECONDS` - the amount of time (in seconds) steve should wait after a CRD or API Service is created before attempting to refresh the schema definitions. Defaults to 2.
  - `CATTLE_BACKGROUND_REFRESH_MINUTES` - the amount of time (in minutes) steve should wait between force refreshes of the definitions (note that a force refresh is not delayed by the creation of a CRD/API Service, though it still does use the same debounce refresher when requesting a refresh). Defaults to 10.
- Changes the `indexSchemaNames` logic to derive preferredVersion from the group a resource belongs to. 
  - This no longer checks for a `ErrGroupDiscoveryFailed` - from what I saw in the source, this error seemed to be in cases where client-go could find information for a group but wasn't able to get information on resources in a group. Since we only need group information, this isn't necessary anymore. 
  - Since this doesn't return a partially-filled-in map anymore, some of the calling functions were changed to just bubble the error up.
- Tests were also added for the above. 