### PR TITLE
[Backport 2.7] WatchNames: return errors via WebSocket

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -370,6 +370,7 @@ func (s *Store) WatchNames(apiOp *types.APIRequest, schema *types.APISchema, w t
 				} else {
 					logrus.Debugf("WatchNames received error: %v", item)
 				}
+				result <- item
 				continue
 			}
 


### PR DESCRIPTION
Backports https://github.com/rancher/steve/pull/141

Corresponding issue https://github.com/rancher/rancher/issues/44640

All commits cherry picked without changes