### PR TITLE
changing permission for kubeconfig file inside the shell pod

### DIFF
--- a/pkg/podimpersonation/podimpersonation.go
+++ b/pkg/podimpersonation/podimpersonation.go
@@ -512,10 +512,12 @@ func (s *PodImpersonation) adminKubeConfig(user user.Info, role *rbacv1.ClusterR
 
 func (s *PodImpersonation) augmentPod(pod *v1.Pod, sa *v1.ServiceAccount, secret *v1.Secret, imageOverride string) *v1.Pod {
 	var (
-		zero = int64(0)
-		t    = true
-		f    = false
-		m    = int32(420)
+		zero      = int64(0)
+		t         = true
+		f         = false
+		m         = int32(0o644)
+		m2        = int32(0o600)
+		shellUser = 1000
 	)
 
 	pod = pod.DeepCopy()
@@ -536,10 +538,17 @@ func (s *PodImpersonation) augmentPod(pod *v1.Pod, sa *v1.ServiceAccount, secret
 		v1.Volume{
 			Name: "user-kubeconfig",
 			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
+		v1.Volume{
+			Name: "user-kube-configmap",
+			VolumeSource: v1.VolumeSource{
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{
 						Name: s.userConfigName(),
 					},
+					DefaultMode: &m2,
 				},
 			},
 		},
@@ -553,25 +562,50 @@ func (s *PodImpersonation) augmentPod(pod *v1.Pod, sa *v1.ServiceAccount, secret
 			},
 		})
 
+	image := imageOverride
+	if image == "" {
+		image = s.imageName()
+	}
+
 	for i, container := range pod.Spec.Containers {
 		for _, envvar := range container.Env {
 			if envvar.Name != "KUBECONFIG" {
 				continue
 			}
 
+			vmount := v1.VolumeMount{
+				Name:      "user-kubeconfig",
+				MountPath: "/tmp/.kube",
+			}
+			cfgVMount := v1.VolumeMount{
+				Name:      "user-kube-configmap",
+				MountPath: "/home/.kube/config",
+				SubPath:   "config",
+			}
+
+			pod.Spec.InitContainers = []v1.Container{
+				{
+					Name:            "init-kubeconfig-volume",
+					Image:           image,
+					Command:         []string{"sh", "-c", fmt.Sprintf("cp %s %s && chown %d %s/config", cfgVMount.MountPath, vmount.MountPath, shellUser, vmount.MountPath)},
+					Resources:       v1.ResourceRequirements{},
+					ResizePolicy:    nil,
+					ImagePullPolicy: v1.PullIfNotPresent,
+					SecurityContext: &v1.SecurityContext{
+						RunAsUser:  &zero,
+						RunAsGroup: &zero,
+					},
+					VolumeMounts: []v1.VolumeMount{cfgVMount, vmount},
+				},
+			}
+
 			pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
 				Name:      "user-kubeconfig",
-				ReadOnly:  true,
 				MountPath: envvar.Value,
 				SubPath:   "config",
 			})
 			break
 		}
-	}
-
-	image := imageOverride
-	if image == "" {
-		image = s.imageName()
 	}
 
 	pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{

--- a/pkg/podimpersonation/podimpersonation_test.go
+++ b/pkg/podimpersonation/podimpersonation_test.go
@@ -1,0 +1,91 @@
+package podimpersonation
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestAugmentPod(t *testing.T) {
+	var (
+		zero = int64(0)
+	)
+	testCases := []struct {
+		name          string
+		imageOverride string
+		envVars       []v1.EnvVar
+	}{
+		{
+			name:          "Should mount volume to container, create an init container and use regular image",
+			imageOverride: "",
+			envVars:       []v1.EnvVar{{Name: "KUBECONFIG", Value: ".kube/config"}},
+		},
+		{
+			name:          "Should mount volume to container, create an init container and use overridden image",
+			imageOverride: "rancher/notShell:v1.0.0",
+			envVars:       []v1.EnvVar{{Name: "KUBECONFIG", Value: ".kube/config"}},
+		},
+		{
+			name:          "Should not create init container if there's no KUBECONFIG envVar",
+			imageOverride: "",
+			envVars:       []v1.EnvVar{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newPod(tc.envVars)
+			impersonator := New("", nil, time.Minute, func() string { return "rancher/shell:v0.1.22" })
+			pod := impersonator.augmentPod(p, nil, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s"}}, tc.imageOverride)
+
+			assert.Len(t, pod.Spec.Volumes, len(p.Spec.Volumes)+4, "expected four new volumes")
+			if len(tc.envVars) != 0 {
+				assert.Len(t, pod.Spec.Containers[0].VolumeMounts, len(p.Spec.Containers[0].VolumeMounts)+1, "expected kubeconfig volume to be mounted")
+				assert.Len(t, pod.Spec.InitContainers, len(p.Spec.InitContainers)+1, "expected an init container to be created")
+				if tc.imageOverride != "" {
+					assert.Equal(t, pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1].Image, tc.imageOverride, "expected image to be the one received as parameter")
+				} else {
+					assert.Equal(t, pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1].Image, impersonator.imageName(), "expected image to be the impersonator image")
+				}
+				assert.Equal(t, pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1].SecurityContext.RunAsUser, &zero, "expected init container to run as user zero")
+				assert.Equal(t, pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1].SecurityContext.RunAsGroup, &zero, "expected init container to run as group zero")
+			} else {
+				assert.Len(t, pod.Spec.InitContainers, len(p.Spec.InitContainers), "expected no init container to be created")
+			}
+			assert.Equal(t, pod.Spec.Containers[len(pod.Spec.Containers)-1].Name, "proxy", "expected the container proxy to be created")
+		})
+	}
+}
+
+func newPod(env []v1.EnvVar) *v1.Pod {
+	return &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{{
+				Name: "volume1",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "cfgMap",
+						},
+					},
+				},
+			}},
+			Containers: []v1.Container{
+				{
+					Name:  "shell",
+					Image: "rancher/shell:v0.1.22",
+					Env:   env,
+					VolumeMounts: []v1.VolumeMount{{
+						Name:      "volume1",
+						MountPath: "/home/vol",
+					}},
+				},
+			},
+			ServiceAccountName:           "svc-account-1",
+			AutomountServiceAccountToken: nil,
+			SecurityContext:              nil,
+		},
+	}
+}


### PR DESCRIPTION
This PR changes the permission of the kubeconfig file used in the `shell` container used by the impersonator. It was using 0644 which was causing warnings when using helm. This changes the permission to 0600.

**Explanation:**
Kubernetes always [mounts](https://github.com/kubernetes/kubernetes/blob/46a2137c1ba017970c316c0ec10c074cb6450732/pkg/kubelet/kubelet_pods.go#L344) [configMaps](https://github.com/kubernetes/kubernetes/blob/46a2137c1ba017970c316c0ec10c074cb6450732/pkg/volume/configmap/configmap.go#L164) and `Secret` volumes as `readOnly`, regardless of the flag passed when creating the mount. This is [not reflected](https://github.com/kubernetes/api/blob/dd2e75089b339ee9b1b2aed2c275bf905079dde3/core/v1/types.go#L2155) in the documentation of the `readOnly` flag. To work around that, I'm using an `init-container` to copy the content to an `emptyDir` volume, changing the permission and using that volume in the `shell` container