### PR TITLE
Fix the missing-apps problem for rancher 2.8

### DIFF
--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -204,12 +204,6 @@ func tableToObjects(obj map[string]interface{}) []unstructured.Unstructured {
 // With this filter, the request can be performed successfully, and only the allowed resources will
 // be returned in the list.
 func (s *Store) ByNames(apiOp *types.APIRequest, schema *types.APISchema, names sets.String) (*unstructured.UnstructuredList, []types.Warning, error) {
-	if apiOp.Namespace == "*" {
-		// This happens when you grant namespaced objects with "get" or "list "by name in a clusterrolebinding.
-		// We will treat this as an invalid situation instead of listing all objects in the cluster
-		// and filtering by name.
-		return &unstructured.UnstructuredList{}, nil, nil
-	}
 	buffer := WarningBuffer{}
 	adminClient, err := s.clientGetter.TableAdminClient(apiOp, schema, apiOp.Namespace, &buffer)
 	if err != nil {

--- a/pkg/stores/proxy/proxy_store_test.go
+++ b/pkg/stores/proxy/proxy_store_test.go
@@ -68,18 +68,6 @@ func TestWatchNamesErrReceive(t *testing.T) {
 	assert.Equal(t, 0, len(c.ResultChan()), "Expected all secrets to have been received")
 }
 
-func TestByNames(t *testing.T) {
-	s := Store{}
-	apiSchema := &types.APISchema{Schema: &schemas.Schema{}}
-	apiOp := &types.APIRequest{Namespace: "*", Schema: apiSchema, Request: &http.Request{}}
-	names := sets.NewString("some-resource", "some-other-resource")
-	result, warn, err := s.ByNames(apiOp, apiSchema, names)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Items, 0)
-	assert.Nil(t, err)
-	assert.Nil(t, warn)
-}
-
 func (t *testFactory) TableAdminClientForWatch(ctx *types.APIRequest, schema *types.APISchema, namespace string, warningHandler rest.WarningHandler) (dynamic.ResourceInterface, error) {
 	return t.fakeClient.Resource(schema2.GroupVersionResource{}), nil
 }


### PR DESCRIPTION
It doesn't make sense to return an empty list when all namespaces are selected. With this change
`curl https://DOMAIN/k8s/clusters/CLUSTER/v1/catalog.cattle.io.apps` shows all the apps the user has permission to see, but they don't show up in the UI.

Partial fix for issue https://github.com/rancher/rancher/issues/43036

There are build issues with rancher 2.9, and then I can't create a digital ocean cluster, so copying this PR from 182 for (`rancher release/v2.9` , `steve master`).