### PR TITLE
Adding APIGroups back to the schema

### DIFF
--- a/pkg/resources/apigroups/apigroup.go
+++ b/pkg/resources/apigroups/apigroup.go
@@ -7,9 +7,21 @@ import (
 
 	"github.com/rancher/apiserver/pkg/store/empty"
 	"github.com/rancher/apiserver/pkg/types"
+	wschemas "github.com/rancher/wrangler/v3/pkg/schemas"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 )
+
+var BaseSchema = types.APISchema{
+	Schema: &wschemas.Schema{
+		ID: "apigroup",
+		Attributes: map[string]interface{}{
+			"group":   "",
+			"kind":    "APIGroup",
+			"version": "v1",
+		},
+	},
+}
 
 func Template(discovery discovery.DiscoveryInterface) schema.Template {
 	return schema.Template{

--- a/pkg/schema/converter/k8stonorman.go
+++ b/pkg/schema/converter/k8stonorman.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/steve/pkg/attributes"
+	"github.com/rancher/steve/pkg/resources/apigroups"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -82,6 +84,8 @@ func GetGVKForKind(kind *proto.Kind) *schema.GroupVersionKind {
 func ToSchemas(crd v1.CustomResourceDefinitionClient, client discovery.DiscoveryInterface) (map[string]*types.APISchema, error) {
 	result := map[string]*types.APISchema{}
 
+	addTemplateBased(result)
+
 	if err := addDiscovery(client, result); err != nil {
 		return nil, err
 	}
@@ -95,4 +99,11 @@ func ToSchemas(crd v1.CustomResourceDefinitionClient, client discovery.Discovery
 	}
 
 	return result, nil
+}
+
+// some schemas are not based on real resources but are filled-in by a template later on. This function adds the base
+// schema so that these endpoints are still recognizable in the api
+func addTemplateBased(schemas map[string]*types.APISchema) {
+	apiGroupGVK := attributes.GVK(&apigroups.BaseSchema)
+	schemas[GVKToVersionedSchemaID(apiGroupGVK)] = &apigroups.BaseSchema
 }


### PR DESCRIPTION
## Overview 

Related to rancher/rancher#45955. Previous changes changed the order that schemas were evaluated in (used to be `models`, then `ServerGroupsAndResources`, is now `ServerGroupsAndResources`, then `models`). The APIGroups resource, which is not itself a server group/resource, but is a model, was omitted because of this. This re-adds this custom schema first (so that the description later on can fill in more detail), making the endpoint visible again in steve.

## Solution Detail
- Adds a `BaseSchema` to the `apigroup` package.
  - This package defines the template (which is applied to customize the schema later) for the apigroup schema.
- Changes schema generation functionality to add the `BaseSchema` for `apigroup`.
  - This is done first so that `addDescription` will add a description for this schema.   