### PR TITLE
Prevent unnecessary list queries in the SQL Proxy.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -608,24 +608,6 @@ func (s *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 	return obj, buffer, nil
 }
 
-func schemaAllowsVerb(verb string, schema *types.APISchema) bool {
-	attr, ok := schema.Schema.Attributes["verbs"]
-	if !ok {
-		// If we can't determine whether nor not the verb is allowed, we might
-		// as well allow K8s to decide.
-		return true
-	}
-
-	verbs, ok := attr.([]string)
-	if !ok {
-		// Again, if we can't determine whether nor not the verb is allowed, we might
-		// as well allow K8s to decide.
-		return true
-	}
-
-	return slices.Contains(verbs, verb)
-}
-
 // ListByPartitions returns:
 //   - an unstructured list of resources belonging to any of the specified partitions
 //   - the total number of resources (returned list might be a subset depending on pagination options in apiOp)
@@ -712,4 +694,15 @@ func (s *Store) watchByPartition(partition partition.Partition, apiOp *types.API
 		return s.Watch(apiOp, schema, wr)
 	}
 	return s.WatchNames(apiOp, schema, wr, partition.Names)
+}
+
+func schemaAllowsVerb(verb string, schema *types.APISchema) bool {
+	verbs := attributes.Verbs(schema)
+	if len(verbs) == 0 {
+		// Again, if we can't determine whether nor not the verb is allowed, we might
+		// as well allow K8s to decide.
+		return true
+	}
+
+	return slices.Contains(verbs, verb)
 }

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -503,6 +503,43 @@ func TestListByPartitions(t *testing.T) {
 			assert.NotNil(t, err)
 		},
 	})
+	tests = append(tests, testCase{
+		description: "client ListByPartitions() with schema that doesn't allow listing should get an empty response",
+		test: func(t *testing.T) {
+			nsi := NewMockCache(gomock.NewController(t))
+			cg := NewMockClientGetter(gomock.NewController(t))
+			cf := NewMockCacheFactory(gomock.NewController(t))
+
+			s := &Store{
+				namespaceCache: nsi,
+				clientGetter:   cg,
+				cacheFactory:   cf,
+			}
+			var partitions []partition.Partition
+			req := &types.APIRequest{
+				Request: &http.Request{
+					URL: &url.URL{},
+				},
+			}
+			schema := &types.APISchema{
+				Schema: &schemas.Schema{Attributes: map[string]interface{}{
+					"columns": []common.ColumnDefinition{
+						{
+							Field: "some.field",
+						},
+					},
+					"verbs": []string{"create"},
+				}},
+			}
+
+			items, count, token, err := s.ListByPartitions(req, schema, partitions)
+			assert.Nil(t, items)
+			assert.Equal(t, count, 0)
+			assert.Empty(t, token)
+			assert.Nil(t, err)
+		},
+	})
+
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) { test.test(t) })


### PR DESCRIPTION
When list queries are not allowed by the Schema, this short-cuts the query to the Kubernetes API which prevents warnings about the verb.

Fixes https://github.com/rancher/rancher/issues/46030