### PR TITLE
fix(accesscontrol): CacheKey could not be stable

### DIFF
--- a/pkg/accesscontrol/access_store.go
+++ b/pkg/accesscontrol/access_store.go
@@ -76,11 +76,11 @@ func (l *AccessStore) CacheKey(user user.Info) string {
 	l.users.addRolesToHash(d, user.GetName())
 
 	groupBase := user.GetGroups()
-	groups := make([]string, 0, len(groupBase))
+	groups := make([]string, len(groupBase))
 	copy(groups, groupBase)
-
 	sort.Strings(groups)
-	for _, group := range user.GetGroups() {
+
+	for _, group := range groups {
 		l.groups.addRolesToHash(d, group)
 	}
 


### PR DESCRIPTION
While understanding how this code works, we realized (actually it was @bigkevmcd, kudos to him) 2 problems:
- According to the `copy` [godoc](https://pkg.go.dev/builtin#copy):
  > Copy returns the number of elements copied, which will be the minimum of len(src) and len(dst).

  This makes the following code to produce an empty slice, since only the length is taken into account, not the capacity:
  ```
  groups := make([]string, 0, len(groupBase))
  copy(groups, groupBase)
  ```
 - The `groups` variable is not actually used, since we `range` over `user.GetGroups()` (the unused variable warning was probably masked by using `sort.Strings`).

I have no evidence this could be currently causing any problems though. It depends on the underlying implementation of `GetGroups()`. For our use case, it does not really matter if the slice is actually sorted, the only requirement would be to be stable.

Unit tests added in follow-up PR containing a small refactoring to make it easier to test:
https://github.com/rancher/steve/pull/245