### PR TITLE
refactor(accesscontrol): add unit tests for CacheKey

### DIFF
--- a/pkg/accesscontrol/access_store.go
+++ b/pkg/accesscontrol/access_store.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"hash"
 	"sort"
 	"time"
 
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -19,9 +21,20 @@ type AccessSetLookup interface {
 	PurgeUserData(id string)
 }
 
+type policyRules interface {
+	get(string) *AccessSet
+	getRoleBindings(string) []*rbacv1.RoleBinding
+	getClusterRoleBindings(string) []*rbacv1.ClusterRoleBinding
+}
+
+type roleRevisions interface {
+	roleRevision(string, string) string
+}
+
 type AccessStore struct {
-	users  *policyRuleIndex
-	groups *policyRuleIndex
+	users  policyRules
+	groups policyRules
+	roles  roleRevisions
 	cache  *cache.LRUExpireCache
 }
 
@@ -31,10 +44,10 @@ type roleKey struct {
 }
 
 func NewAccessStore(ctx context.Context, cacheResults bool, rbac v1.Interface) *AccessStore {
-	revisions := newRoleRevision(ctx, rbac)
 	as := &AccessStore{
-		users:  newPolicyRuleIndex(true, revisions, rbac),
-		groups: newPolicyRuleIndex(false, revisions, rbac),
+		users:  newPolicyRuleIndex(true, rbac),
+		groups: newPolicyRuleIndex(false, rbac),
+		roles:  newRoleRevision(ctx, rbac),
 	}
 	if cacheResults {
 		as.cache = cache.NewLRUExpireCache(50)
@@ -73,16 +86,34 @@ func (l *AccessStore) PurgeUserData(id string) {
 func (l *AccessStore) CacheKey(user user.Info) string {
 	d := sha256.New()
 
-	l.users.addRolesToHash(d, user.GetName())
-
 	groupBase := user.GetGroups()
 	groups := make([]string, len(groupBase))
 	copy(groups, groupBase)
 	sort.Strings(groups)
 
+	l.addRolesToHash(d, user.GetName(), l.users)
 	for _, group := range groups {
-		l.groups.addRolesToHash(d, group)
+		l.addRolesToHash(d, group, l.groups)
 	}
 
 	return hex.EncodeToString(d.Sum(nil))
+}
+
+var null = []byte{'\x00'}
+
+func (l *AccessStore) addRolesToHash(digest hash.Hash, subjectName string, rules policyRules) {
+	for _, crb := range rules.getClusterRoleBindings(subjectName) {
+		digest.Write([]byte(crb.RoleRef.Name))
+		digest.Write([]byte(l.roles.roleRevision("", crb.RoleRef.Name)))
+		digest.Write(null)
+	}
+
+	for _, rb := range rules.getRoleBindings(subjectName) {
+		digest.Write([]byte(rb.RoleRef.Name))
+		if rb.Namespace != "" {
+			digest.Write([]byte(rb.Namespace))
+		}
+		digest.Write([]byte(l.roles.roleRevision(rb.Namespace, rb.RoleRef.Name)))
+		digest.Write(null)
+	}
 }

--- a/pkg/accesscontrol/access_store.go
+++ b/pkg/accesscontrol/access_store.go
@@ -99,13 +99,10 @@ func (l *AccessStore) CacheKey(user user.Info) string {
 	return hex.EncodeToString(d.Sum(nil))
 }
 
-var null = []byte{'\x00'}
-
 func (l *AccessStore) addRolesToHash(digest hash.Hash, subjectName string, rules policyRules) {
 	for _, crb := range rules.getClusterRoleBindings(subjectName) {
 		digest.Write([]byte(crb.RoleRef.Name))
 		digest.Write([]byte(l.roles.roleRevision("", crb.RoleRef.Name)))
-		digest.Write(null)
 	}
 
 	for _, rb := range rules.getRoleBindings(subjectName) {
@@ -114,6 +111,5 @@ func (l *AccessStore) addRolesToHash(digest hash.Hash, subjectName string, rules
 			digest.Write([]byte(rb.Namespace))
 		}
 		digest.Write([]byte(l.roles.roleRevision(rb.Namespace, rb.RoleRef.Name)))
-		digest.Write(null)
 	}
 }

--- a/pkg/accesscontrol/access_store_test.go
+++ b/pkg/accesscontrol/access_store_test.go
@@ -27,7 +27,7 @@ func TestAccessStore_CacheKey(t *testing.T) {
 		{
 			name: "consistently produces the same value",
 			store: &AccessStore{
-				users: &policyRulesMock{
+				usersPolicyRules: &policyRulesMock{
 					getRBFunc: func(s string) []*rbacv1.RoleBinding {
 						return []*rbacv1.RoleBinding{
 							makeRB("testns", "testrb", testUser.Name, "testrole"),
@@ -39,7 +39,7 @@ func TestAccessStore_CacheKey(t *testing.T) {
 						}
 					},
 				},
-				groups: &policyRulesMock{},
+				groupsPolicyRules: &policyRulesMock{},
 				roles: roleRevisionsMock(func(ns, name string) string {
 					return fmt.Sprintf("%s%srev", ns, name)
 				}),
@@ -55,8 +55,8 @@ func TestAccessStore_CacheKey(t *testing.T) {
 		{
 			name: "group permissions are taken into account",
 			store: &AccessStore{
-				users: &policyRulesMock{},
-				groups: &policyRulesMock{
+				usersPolicyRules: &policyRulesMock{},
+				groupsPolicyRules: &policyRulesMock{
 					getRBFunc: func(s string) []*rbacv1.RoleBinding {
 						return []*rbacv1.RoleBinding{
 							makeRB("testns", "testrb", testUser.Name, "testrole"),
@@ -85,8 +85,8 @@ func TestAccessStore_CacheKey(t *testing.T) {
 		{
 			name: "different groups order produces the same value",
 			store: &AccessStore{
-				users: &policyRulesMock{},
-				groups: &policyRulesMock{
+				usersPolicyRules: &policyRulesMock{},
+				groupsPolicyRules: &policyRulesMock{
 					getRBFunc: func(s string) []*rbacv1.RoleBinding {
 						if s == testUser.Groups[0] {
 							return []*rbacv1.RoleBinding{
@@ -121,14 +121,14 @@ func TestAccessStore_CacheKey(t *testing.T) {
 		{
 			name: "role changes produce a different value",
 			store: &AccessStore{
-				users: &policyRulesMock{
+				usersPolicyRules: &policyRulesMock{
 					getRBFunc: func(s string) []*rbacv1.RoleBinding {
 						return []*rbacv1.RoleBinding{
 							makeRB("testns", "testrb", testUser.Name, "testrole"),
 						}
 					},
 				},
-				groups: &policyRulesMock{},
+				groupsPolicyRules: &policyRulesMock{},
 				roles: roleRevisionsMock(func(ns, name string) string {
 					return "rev1"
 				}),
@@ -146,8 +146,8 @@ func TestAccessStore_CacheKey(t *testing.T) {
 		{
 			name: "new groups produce a different value",
 			store: &AccessStore{
-				users: &policyRulesMock{},
-				groups: &policyRulesMock{
+				usersPolicyRules: &policyRulesMock{},
+				groupsPolicyRules: &policyRulesMock{
 					getRBFunc: func(s string) []*rbacv1.RoleBinding {
 						return []*rbacv1.RoleBinding{
 							makeRB("testns", "testrb", testUser.Name, "testrole"),

--- a/pkg/accesscontrol/access_store_test.go
+++ b/pkg/accesscontrol/access_store_test.go
@@ -1,0 +1,234 @@
+package accesscontrol
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestAccessStore_CacheKey(t *testing.T) {
+	testUser := &user.DefaultInfo{
+		Name: "user-12345",
+		Groups: []string{
+			"users",
+			"mygroup",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		store  *AccessStore
+		verify func(t *testing.T, store *AccessStore, res string)
+	}{
+		{
+			name: "consistently produces the same value",
+			store: &AccessStore{
+				users: &policyRulesMock{
+					getRBFunc: func(s string) []*rbacv1.RoleBinding {
+						return []*rbacv1.RoleBinding{
+							makeRB("testns", "testrb", testUser.Name, "testrole"),
+						}
+					},
+					getCRBFunc: func(s string) []*rbacv1.ClusterRoleBinding {
+						return []*rbacv1.ClusterRoleBinding{
+							makeCRB("testcrb", testUser.Name, "testclusterrole"),
+						}
+					},
+				},
+				groups: &policyRulesMock{},
+				roles: roleRevisionsMock(func(ns, name string) string {
+					return fmt.Sprintf("%s%srev", ns, name)
+				}),
+			},
+			verify: func(t *testing.T, store *AccessStore, res string) {
+				for range 5 {
+					if res != store.CacheKey(testUser) {
+						t.Fatal("CacheKey is not the same on consecutive runs")
+					}
+				}
+			},
+		},
+		{
+			name: "group permissions are taken into account",
+			store: &AccessStore{
+				users: &policyRulesMock{},
+				groups: &policyRulesMock{
+					getRBFunc: func(s string) []*rbacv1.RoleBinding {
+						return []*rbacv1.RoleBinding{
+							makeRB("testns", "testrb", testUser.Name, "testrole"),
+						}
+					},
+					getCRBFunc: func(s string) []*rbacv1.ClusterRoleBinding {
+						return []*rbacv1.ClusterRoleBinding{
+							makeCRB("testcrb", testUser.Name, "testclusterrole"),
+						}
+					},
+				},
+				roles: roleRevisionsMock(func(ns, name string) string {
+					return fmt.Sprintf("%s%srev", ns, name)
+				}),
+			},
+			verify: func(t *testing.T, store *AccessStore, res string) {
+				// remove users
+				testUserAlt := *testUser
+				testUserAlt.Groups = []string{}
+
+				if store.CacheKey(&testUserAlt) == res {
+					t.Fatal("CacheKey does not use groups for hashing")
+				}
+			},
+		},
+		{
+			name: "different groups order produces the same value",
+			store: &AccessStore{
+				users: &policyRulesMock{},
+				groups: &policyRulesMock{
+					getRBFunc: func(s string) []*rbacv1.RoleBinding {
+						if s == testUser.Groups[0] {
+							return []*rbacv1.RoleBinding{
+								makeRB("testns", "testrb", testUser.Name, "testrole"),
+							}
+						}
+						return nil
+					},
+					getCRBFunc: func(s string) []*rbacv1.ClusterRoleBinding {
+						if s == testUser.Groups[1] {
+							return []*rbacv1.ClusterRoleBinding{
+								makeCRB("testcrb", testUser.Name, "testclusterrole"),
+							}
+						}
+						return nil
+					},
+				},
+				roles: roleRevisionsMock(func(ns, name string) string {
+					return fmt.Sprintf("%s%srev", ns, name)
+				}),
+			},
+			verify: func(t *testing.T, store *AccessStore, res string) {
+				// swap order of groups
+				testUserAlt := &user.DefaultInfo{Name: testUser.Name, Groups: slices.Clone(testUser.Groups)}
+				slices.Reverse(testUserAlt.Groups)
+
+				if store.CacheKey(testUserAlt) != res {
+					t.Fatal("CacheKey varies depending on groups order")
+				}
+			},
+		},
+		{
+			name: "role changes produce a different value",
+			store: &AccessStore{
+				users: &policyRulesMock{
+					getRBFunc: func(s string) []*rbacv1.RoleBinding {
+						return []*rbacv1.RoleBinding{
+							makeRB("testns", "testrb", testUser.Name, "testrole"),
+						}
+					},
+				},
+				groups: &policyRulesMock{},
+				roles: roleRevisionsMock(func(ns, name string) string {
+					return "rev1"
+				}),
+			},
+			verify: func(t *testing.T, store *AccessStore, res string) {
+				store.roles = roleRevisionsMock(func(ns, name string) string {
+					return "rev2"
+
+				})
+				if store.CacheKey(testUser) == res {
+					t.Fatal("CacheKey did not change when on role change")
+				}
+			},
+		},
+		{
+			name: "new groups produce a different value",
+			store: &AccessStore{
+				users: &policyRulesMock{},
+				groups: &policyRulesMock{
+					getRBFunc: func(s string) []*rbacv1.RoleBinding {
+						return []*rbacv1.RoleBinding{
+							makeRB("testns", "testrb", testUser.Name, "testrole"),
+						}
+					},
+					getCRBFunc: func(s string) []*rbacv1.ClusterRoleBinding {
+						if s == "newgroup" {
+							return []*rbacv1.ClusterRoleBinding{
+								makeCRB("testcrb", testUser.Name, "testclusterrole"),
+							}
+						}
+						return nil
+					},
+				},
+				roles: roleRevisionsMock(func(ns, name string) string {
+					return fmt.Sprintf("%s%srev", ns, name)
+				}),
+			},
+			verify: func(t *testing.T, store *AccessStore, res string) {
+				testUserAlt := &user.DefaultInfo{
+					Name:   testUser.Name,
+					Groups: append(slices.Clone(testUser.Groups), "newgroup"),
+				}
+				if store.CacheKey(testUserAlt) == res {
+					t.Fatal("CacheKey did not change when new group was added")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.verify(t, tt.store, tt.store.CacheKey(testUser))
+		})
+	}
+}
+
+func makeRB(ns, name, user, role string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Subjects: []rbacv1.Subject{
+			{Name: user},
+		},
+		RoleRef: rbacv1.RoleRef{Name: role},
+	}
+}
+
+func makeCRB(name, user, role string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects: []rbacv1.Subject{
+			{Name: user},
+		},
+		RoleRef: rbacv1.RoleRef{Name: role},
+	}
+}
+
+type policyRulesMock struct {
+	getRBFunc  func(string) []*rbacv1.RoleBinding
+	getCRBFunc func(string) []*rbacv1.ClusterRoleBinding
+}
+
+func (p policyRulesMock) get(string) *AccessSet {
+	panic("implement me")
+}
+
+func (p policyRulesMock) getRoleBindings(s string) []*rbacv1.RoleBinding {
+	if p.getRBFunc == nil {
+		return nil
+	}
+	return p.getRBFunc(s)
+}
+
+func (p policyRulesMock) getClusterRoleBindings(s string) []*rbacv1.ClusterRoleBinding {
+	if p.getCRBFunc == nil {
+		return nil
+	}
+	return p.getCRBFunc(s)
+}
+
+type roleRevisionsMock func(ns, name string) string
+
+func (fn roleRevisionsMock) roleRevision(ns, name string) string {
+	return fn(ns, name)
+}

--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -2,7 +2,6 @@ package accesscontrol
 
 import (
 	"fmt"
-	"hash"
 	"sort"
 
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
@@ -20,13 +19,12 @@ type policyRuleIndex struct {
 	rCache              v1.RoleCache
 	crbCache            v1.ClusterRoleBindingCache
 	rbCache             v1.RoleBindingCache
-	revisions           *roleRevisionIndex
 	kind                string
 	roleIndexKey        string
 	clusterRoleIndexKey string
 }
 
-func newPolicyRuleIndex(user bool, revisions *roleRevisionIndex, rbac v1.Interface) *policyRuleIndex {
+func newPolicyRuleIndex(user bool, rbac v1.Interface) *policyRuleIndex {
 	key := "Group"
 	if user {
 		key = "User"
@@ -39,7 +37,6 @@ func newPolicyRuleIndex(user bool, revisions *roleRevisionIndex, rbac v1.Interfa
 		rbCache:             rbac.RoleBinding().Cache(),
 		clusterRoleIndexKey: "crb" + key,
 		roleIndexKey:        "rb" + key,
-		revisions:           revisions,
 	}
 
 	pi.crbCache.AddIndexer(pi.clusterRoleIndexKey, pi.clusterRoleBindingBySubjectIndexer)
@@ -70,30 +67,6 @@ func (p *policyRuleIndex) roleBindingBySubject(rb *rbacv1.RoleBinding) (result [
 		}
 	}
 	return
-}
-
-var null = []byte{'\x00'}
-
-func (p *policyRuleIndex) addRolesToHash(digest hash.Hash, subjectName string) {
-	for _, crb := range p.getClusterRoleBindings(subjectName) {
-		digest.Write([]byte(crb.RoleRef.Name))
-		digest.Write([]byte(p.revisions.roleRevision("", crb.RoleRef.Name)))
-		digest.Write(null)
-	}
-
-	for _, rb := range p.getRoleBindings(subjectName) {
-		switch rb.RoleRef.Kind {
-		case "Role":
-			digest.Write([]byte(rb.RoleRef.Name))
-			digest.Write([]byte(rb.Namespace))
-			digest.Write([]byte(p.revisions.roleRevision(rb.Namespace, rb.RoleRef.Name)))
-			digest.Write(null)
-		case "ClusterRole":
-			digest.Write([]byte(rb.RoleRef.Name))
-			digest.Write([]byte(p.revisions.roleRevision("", rb.RoleRef.Name)))
-			digest.Write(null)
-		}
-	}
 }
 
 func (p *policyRuleIndex) get(subjectName string) *AccessSet {


### PR DESCRIPTION
This is a follow up to https://github.com/rancher/steve/pull/244 with a small refactor to make the function easier to test, and adding unit tests for `CacheKey`.