### PR TITLE
Fold patch into update capabilities

### DIFF
--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -120,9 +120,10 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 		} else {
 			delete(resource.Links, "remove")
 		}
-
-		if _, ok := resource.Links["remove"]; !ok && slice.ContainsString(resource.Schema.ResourceMethods, "blocked-DELETE") {
-			resource.Links["remove"] = "blocked"
+		if _, ok := resource.Links["update"]; ok {
+			resource.Links["patch"] = resource.Links["update"]
+		} else {
+			delete(resource.Links, "patch")
 		}
 
 		if unstr, ok := resource.APIObject.Object.(*unstructured.Unstructured); ok {

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
@@ -12,7 +13,6 @@ import (
 	"github.com/rancher/steve/pkg/summarycache"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
-	"github.com/rancher/wrangler/v3/pkg/slice"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,15 +26,15 @@ func DefaultTemplate(clientGetter proxy.ClientGetter,
 	namespaceCache corecontrollers.NamespaceCache) schema.Template {
 	return schema.Template{
 		Store:     metricsStore.NewMetricsStore(proxy.NewProxyStore(clientGetter, summaryCache, asl, namespaceCache)),
-		Formatter: formatter(summaryCache),
+		Formatter: formatter(summaryCache, asl),
 	}
 }
 
 // DefaultTemplateForStore provides a default schema template which uses a provided, pre-initialized store. Primarily used when creating a Template that uses a Lasso SQL store internally.
-func DefaultTemplateForStore(store types.Store, summaryCache *summarycache.SummaryCache) schema.Template {
+func DefaultTemplateForStore(store types.Store, summaryCache *summarycache.SummaryCache, asl accesscontrol.AccessSetLookup) schema.Template {
 	return schema.Template{
 		Store:     store,
-		Formatter: formatter(summaryCache),
+		Formatter: formatter(summaryCache, asl),
 	}
 }
 
@@ -71,7 +71,7 @@ func selfLink(gvr schema2.GroupVersionResource, meta metav1.Object) (prefix stri
 	return buf.String()
 }
 
-func formatter(summarycache *summarycache.SummaryCache) types.Formatter {
+func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.AccessSetLookup) types.Formatter {
 	return func(request *types.APIRequest, resource *types.RawResource) {
 		if resource.Schema == nil {
 			return
@@ -86,17 +86,39 @@ func formatter(summarycache *summarycache.SummaryCache) types.Formatter {
 		if err != nil {
 			return
 		}
+		userInfo, ok := request.GetUserInfo()
+		if !ok {
+			return
+		}
+		accessSet := asl.AccessFor(userInfo)
+		if accessSet == nil {
+			return
+		}
+		hasUpdate := accessSet.Grants("update", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
+		hasDelete := accessSet.Grants("delete", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
+
 		selfLink := selfLink(gvr, meta)
 
 		u := request.URLBuilder.RelativeToRoot(selfLink)
 		resource.Links["view"] = u
 
-		if _, ok := resource.Links["update"]; !ok && slice.ContainsString(resource.Schema.CollectionMethods, "PUT") {
-			resource.Links["update"] = u
+		if hasUpdate {
+			if attributes.DisallowMethods(resource.Schema)[http.MethodPut] {
+				resource.Links["update"] = "blocked"
+			} else {
+				resource.Links["update"] = u
+			}
+		} else {
+			delete(resource.Links, "update")
 		}
-
-		if _, ok := resource.Links["update"]; !ok && slice.ContainsString(resource.Schema.ResourceMethods, "blocked-PUT") {
-			resource.Links["update"] = "blocked"
+		if hasDelete {
+			if attributes.DisallowMethods(resource.Schema)[http.MethodDelete] {
+				resource.Links["remove"] = "blocked"
+			} else {
+				resource.Links["remove"] = u
+			}
+		} else {
+			delete(resource.Links, "remove")
 		}
 
 		if _, ok := resource.Links["remove"]; !ok && slice.ContainsString(resource.Schema.ResourceMethods, "blocked-DELETE") {

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -76,10 +76,11 @@ func DefaultSchemaTemplates(cf *client.Factory,
 func DefaultSchemaTemplatesForStore(store types.Store,
 	baseSchemas *types.APISchemas,
 	summaryCache *summarycache.SummaryCache,
+	asl accesscontrol.AccessSetLookup,
 	discovery discovery.DiscoveryInterface) []schema.Template {
 
 	return []schema.Template{
-		common.DefaultTemplateForStore(store, summaryCache),
+		common.DefaultTemplateForStore(store, summaryCache, asl),
 		apigroups.Template(discovery),
 		{
 			ID:        "configmap",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/steve/pkg/stores/sqlpartition"
 	"github.com/rancher/steve/pkg/stores/sqlproxy"
 	"github.com/rancher/steve/pkg/summarycache"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
 
@@ -182,7 +183,7 @@ func setup(ctx context.Context, server *Server) error {
 		store := metricsStore.NewMetricsStore(errStore)
 		// end store setup code
 
-		for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, server.controllers.K8s.Discovery()) {
+		for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery()) {
 			sf.AddTemplate(template)
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rancher/steve/pkg/stores/sqlpartition"
 	"github.com/rancher/steve/pkg/stores/sqlproxy"
 	"github.com/rancher/steve/pkg/summarycache"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
 


### PR DESCRIPTION
# DO NOT MERGE

## DEPENDS ON PR 158

Related to [#40712](https://github.com/ericpromislow/steve/pull/new/40712-fold-patch-into-update-capabilities)

This is a limited change on top of PR #158 and is designed to allow PATCH operations from the UI if UPDATE operations are supported.