### PR TITLE
Pass the debug status to the dynamiclistener server

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,5 +38,5 @@ func run(_ *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return s.ListenAndServe(ctx, config.HTTPSListenPort, config.HTTPListenPort, nil)
+	return s.ListenAndServe(ctx, config.HTTPSListenPort, config.HTTPListenPort, debugconfig.Debug, nil)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -239,12 +239,15 @@ func (c *Server) StartAggregation(ctx context.Context) {
 		c.aggregationSecretName, c)
 }
 
-func (c *Server) ListenAndServe(ctx context.Context, httpsPort, httpPort int, opts *server.ListenOpts) error {
+func (c *Server) ListenAndServe(ctx context.Context, httpsPort, httpPort int, debugMode bool, opts *server.ListenOpts) error {
 	if opts == nil {
 		opts = &server.ListenOpts{}
 	}
 	if opts.Storage == nil && opts.Secrets == nil {
 		opts.Secrets = c.controllers.Core.Secret()
+	}
+	if debugMode {
+		opts.Debug = true
 	}
 
 	c.StartAggregation(ctx)


### PR DESCRIPTION
This PR works with https://github.com/rancher/dynamiclistener/pull/118 -- the logger is global, so if steve is setting it to debug-mode, the dynamiclistener server needs to know what log-level the logger is at.