### PR TITLE
Fix ExtensionAPIServer interface

### DIFF
--- a/pkg/ext/apiserver_test.go
+++ b/pkg/ext/apiserver_test.go
@@ -388,7 +388,7 @@ func TestDiscoveryAndOpenAPI(t *testing.T) {
 			path:               "/apis",
 			got:                &metav1.APIGroupList{},
 			expectedStatusCode: http.StatusOK,
-			// This is needed because the library loops over the apigroups
+			// This is needed because the k8s.io/apiserver library loops over the apigroups
 			compareFunc: func(t *testing.T, gotObj any) {
 				apiGroupList, ok := gotObj.(*metav1.APIGroupList)
 				require.True(t, ok)
@@ -628,7 +628,7 @@ func TestDiscoveryAndOpenAPI(t *testing.T) {
 	}
 }
 
-// Because the library has non-deterministic map iteration, changing the order of groups and versions
+// Because the k8s.io/apiserver library has non-deterministic map iteration, changing the order of groups and versions
 func sortAPIGroupList(list *metav1.APIGroupList) {
 	for _, group := range list.Groups {
 		sort.Slice(group.Versions, func(i, j int) bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/steve/pkg/client"
 	"github.com/rancher/steve/pkg/clustercache"
 	schemacontroller "github.com/rancher/steve/pkg/controllers/schema"
+	"github.com/rancher/steve/pkg/ext"
 	"github.com/rancher/steve/pkg/resources"
 	"github.com/rancher/steve/pkg/resources/common"
 	"github.com/rancher/steve/pkg/resources/schemas"
@@ -31,6 +32,8 @@ import (
 
 var ErrConfigRequired = errors.New("rest config is required")
 
+var _ ExtensionAPIServer = (*ext.ExtensionAPIServer)(nil)
+
 // ExtensionAPIServer will run an extension API server. The extension API server
 // will be accessible from Steve at the /ext endpoint and will be compatible with
 // the aggregate API server in Kubernetes.
@@ -38,7 +41,7 @@ type ExtensionAPIServer interface {
 	// The ExtensionAPIServer is served at /ext in Steve's mux
 	http.Handler
 	// Run configures the API server and make the HTTP handler available
-	Run(ctx context.Context)
+	Run(ctx context.Context) error
 }
 
 type Server struct {
@@ -253,7 +256,9 @@ func (c *Server) start(ctx context.Context) error {
 		}
 	}
 	if c.extensionAPIServer != nil {
-		c.extensionAPIServer.Run(ctx)
+		if err := c.extensionAPIServer.Run(ctx); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/47030

There wasn't a type assertion for the `ExtensionAPIServer` interface and unfortunately the interface did not match the "default" implementation.

We're fixing it here and adding an assertion to prevent the same problem happening in the future.