### PR TITLE
Re-adding formatter when SQL cache is enabled

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -49,7 +49,7 @@ func DefaultSchemaTemplates(cf *client.Factory,
 	discovery discovery.DiscoveryInterface,
 	namespaceCache corecontrollers.NamespaceCache) []schema.Template {
 	return []schema.Template{
-		common.DefaultTemplate(cf, summaryCache, lookup, namespaceCache, false),
+		common.DefaultTemplate(cf, summaryCache, lookup, namespaceCache),
 		apigroups.Template(discovery),
 		{
 			ID:        "configmap",
@@ -79,7 +79,7 @@ func DefaultSchemaTemplatesForStore(store types.Store,
 	discovery discovery.DiscoveryInterface) []schema.Template {
 
 	return []schema.Template{
-		common.DefaultTemplateForStore(store, summaryCache, true),
+		common.DefaultTemplateForStore(store, summaryCache),
 		apigroups.Template(discovery),
 		{
 			ID:        "configmap",


### PR DESCRIPTION
## Issue

This was the root cause of a few UI issues (at minimum rancher/dashboard#12262). 

Previously, the formatter for state/relationships was disabled when the sql cache was enabled, since a transform function was adding those values before they were added to the cache. However, the get/watch calls currently don't use the cache, causing the state/relationships to be missing.

## Solution

The formatter now runs even when the cache is enabled. This will cause some duplication (i.e. on list requests, the already existing state and relationships will be overridden and re-calculated), but that's acceptable in order to make sure that they are present on all request types.