### PR TITLE
[TECH DEBT] Continue indexing sqlite fields

### DIFF
--- a/pkg/resources/virtual/common/common_test.go
+++ b/pkg/resources/virtual/common/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rancher/steve/pkg/resources/virtual/common"
+	"github.com/rancher/steve/pkg/resources/virtual/testutil"
 	"github.com/rancher/steve/pkg/summarycache"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func TestTransformCommonObjects(t *testing.T) {
+func TestTransformCommon(t *testing.T) {
 	tests := []struct {
 		name             string
 		input            any
@@ -159,7 +160,7 @@ func TestTransformCommonObjects(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeCache := common.FakeSummaryCache{
+			fakeCache := testutil.FakeSummaryCache{
 				SummarizedObject: test.hasSummary,
 				Relationships:    test.hasRelationships,
 			}

--- a/pkg/resources/virtual/testutil/testutil.go
+++ b/pkg/resources/virtual/testutil/testutil.go
@@ -1,4 +1,4 @@
-package common
+package testutil
 
 import (
 	"github.com/rancher/steve/pkg/summarycache"

--- a/pkg/resources/virtual/virtual_test.go
+++ b/pkg/resources/virtual/virtual_test.go
@@ -1,17 +1,18 @@
 package virtual_test
 
 import (
-	"github.com/rancher/steve/pkg/resources/virtual"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
 	"testing"
 
+	"github.com/rancher/steve/pkg/resources/virtual"
 	"github.com/rancher/steve/pkg/resources/virtual/common"
+	"github.com/rancher/steve/pkg/resources/virtual/testutil"
 	"github.com/rancher/steve/pkg/summarycache"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestTransformChain(t *testing.T) {
@@ -179,7 +180,7 @@ func TestTransformChain(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeCache := common.FakeSummaryCache{
+			fakeCache := testutil.FakeSummaryCache{
 				SummarizedObject: test.hasSummary,
 				Relationships:    test.hasRelationships,
 			}


### PR DESCRIPTION
Related Issue:  [#46642](https://github.com/rancher/rancher/issues/46642)

Carry over tasks from #271 :

- [ ] https://github.com/rancher/steve/pull/271#discussion_r1804818371 

Regarding `TransformEventObject` in `pkg/resources/virtual/events/events.go`:

> However, there's been reports that this may not be fully working as expected: rancher/dashboard#12262 - so for that reason, we can keep this as-is and file a follow-up issue to complete the work.

- [ ] Test typeless events: https://github.com/rancher/steve/pull/271#discussion_r1804821711
- [ ] Is the non-default-group-event test useless? ( https://github.com/rancher/steve/pull/271#discussion_r1804824544 )
- [ ] Order of conversion: https://github.com/rancher/steve/pull/271#discussion_r1804836218

My thoughts here is that given a loop of converters, we should run them in increasing order of generality, running the common one last. This might turn out to be unnecessary, but I think this way gives us the most flexibility going forward.

- [ ] Drop assertions that should be covered by testing another package - https://github.com/rancher/steve/pull/271#discussion_r1804892935