### PR TITLE
Re-adding formatter when SQL cache is enabled (#300)

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -49,7 +49,7 @@ func DefaultSchemaTemplates(cf *client.Factory,
 	discovery discovery.DiscoveryInterface,
 	namespaceCache corecontrollers.NamespaceCache) []schema.Template {
 	return []schema.Template{
-		common.DefaultTemplate(cf, summaryCache, lookup, namespaceCache, false),
+		common.DefaultTemplate(cf, summaryCache, lookup, namespaceCache),
 		apigroups.Template(discovery),
 		{
 			ID:        "configmap",
@@ -79,7 +79,7 @@ func DefaultSchemaTemplatesForStore(store types.Store,
 	discovery discovery.DiscoveryInterface) []schema.Template {
 
 	return []schema.Template{
-		common.DefaultTemplateForStore(store, summaryCache, true),
+		common.DefaultTemplateForStore(store, summaryCache),
 		apigroups.Template(discovery),
 		{
 			ID:        "configmap",


### PR DESCRIPTION
Previously, the formatter for state/relationships was disabled when the sql cache was enabled, since a transform function was adding those values before they were added to the cache. However, the get/watch calls currently don't use the cache, causing the state/relationships to be missing.

Backport of #300 