### PR TITLE
Update indexed fields

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -75,11 +75,11 @@ var (
 			{"spec", "containers", "image"},
 			{"spec", "nodeName"}},
 		gvkKey("", "v1", "Service"): {
-			{"spec", "targetPort"},
+			{"spec", "clusterIP"},
 			{"spec", "type"},
 		},
 		gvkKey("networking.k8s.io", "v1", "Ingress"): {
-			{"spec", "rules"},
+			{"spec", "rules", "host"},
 			{"spec", "ingressClassName"},
 		},
 		gvkKey("", "v1", "ConfigMap"): {
@@ -90,11 +90,10 @@ var (
 		},
 		gvkKey("", "v1", "PersistentVolumeClaim"): {
 			{"spec", "volumeName"}},
-		gvkKey("autoscaling", "v1", "HorizontalPodAutoscaler"): {
+		gvkKey("autoscaling", "v2", "HorizontalPodAutoscaler"): {
 			{"spec", "scaleTargetRef", "name"},
 			{"spec", "minReplicas"},
 			{"spec", "maxReplicas"},
-			{"spec", "currentReplicas"},
 		},
 		gvkKey("apps", "v1", "DaemonSet"): {
 			{"metadata", "annotations[field.cattle.io/publicEndpoints]"},

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -94,6 +94,7 @@ var (
 			{"spec", "scaleTargetRef", "name"},
 			{"spec", "minReplicas"},
 			{"spec", "maxReplicas"},
+			{"status", "currentReplicas"},
 		},
 		gvkKey("apps", "v1", "DaemonSet"): {
 			{"metadata", "annotations[field.cattle.io/publicEndpoints]"},


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/48473

**Added**

- networking.k8s.io.ingress
  - spec.rules.host
- service
  - spec.clusterIP

**Removed**

- service
  - spec.targetPort - UI Bug this was never sortable
- networking.k8s.io.ingress
  - spec.rules - incorrect given vai does not support objects in all array entries (need specific path in array)

**Changed**
- "autoscaling", "v1", "HorizontalPodAutoscaler" --> - "autoscaling", "v2", "HorizontalPodAutoscaler" 

# Unsure

@richard-cox Just want to make sure I got this right:

- `spec.targetPort` for Ingress was not there, so didn't have to remove it
- `spec.ingressClassName` for Ingress was already there so didn't have to add it
- Had to remove currentReplicas in HorizontalPodAutoscaler since it doesn't exist, but I see that it exists at `.status.currentReplicas`. Do we want it removed, or do we want `.status.currentReplicas` indexed?