### PR TITLE
[main&2.10.3] Add schema links and resource methods for resource verb patch

### DIFF
--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -98,6 +98,7 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 		}
 		hasUpdate := accessSet.Grants("update", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
 		hasDelete := accessSet.Grants("delete", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
+		hasPatch := accessSet.Grants("patch", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
 
 		selfLink := selfLink(gvr, meta)
 
@@ -117,6 +118,15 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 			}
 		} else {
 			delete(resource.Links, "remove")
+		}
+		if hasPatch {
+			if attributes.DisallowMethods(resource.Schema)[http.MethodPut] {
+				resource.Links["patch"] = "blocked"
+			} else {
+				resource.Links["patch"] = u
+			}
+		} else {
+			delete(resource.Links, "patch")
 		}
 
 		if unstr, ok := resource.APIObject.Object.(*unstructured.Unstructured); ok {

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -120,10 +120,8 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 			delete(resource.Links, "remove")
 		}
 		if hasPatch {
-			if attributes.DisallowMethods(resource.Schema)[http.MethodPut] {
+			if attributes.DisallowMethods(resource.Schema)[http.MethodPatch] {
 				resource.Links["patch"] = "blocked"
-			} else {
-				resource.Links["patch"] = u
 			}
 		} else {
 			delete(resource.Links, "patch")

--- a/pkg/resources/common/formatter_test.go
+++ b/pkg/resources/common/formatter_test.go
@@ -634,6 +634,7 @@ func Test_formatterLinks(t *testing.T) {
 		hasGet    bool
 		hasUpdate bool
 		hasRemove bool
+		hasPatch  bool
 	}
 	tests := []struct {
 		name         string
@@ -935,6 +936,81 @@ func Test_formatterLinks(t *testing.T) {
 				"view":    "/api/v1/namespaces/example-ns/pods/example-pod",
 			},
 		},
+		{
+			name:    "patch permissions",
+			hasUser: true,
+			permissions: &permissions{
+				hasPatch: true,
+			},
+			schema: &types.APISchema{
+				Schema: &schemas.Schema{
+					ID: "example",
+					Attributes: map[string]interface{}{
+						"group":    "apps",
+						"version":  "v1",
+						"resource": "deployments",
+					},
+				},
+			},
+			apiObject: types.APIObject{
+				ID: "example",
+				Object: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-deployment",
+						Namespace: "example-ns",
+					},
+				},
+			},
+			currentLinks: map[string]string{
+				"default": "defaultVal",
+				"patch":   "/v1/apps.deployments/example-ns/example-deployment",
+				"view":    "/apis/apps/v1/namespaces/example-ns/deployments/example-deployment",
+			},
+			wantLinks: map[string]string{
+				"default": "defaultVal",
+				"patch":   "/v1/apps.deployments/example-ns/example-deployment",
+				"view":    "/apis/apps/v1/namespaces/example-ns/deployments/example-deployment",
+			},
+		},
+		{
+			name:    "patch permissions, but blocked",
+			hasUser: true,
+			permissions: &permissions{
+				hasPatch: true,
+			},
+			schema: &types.APISchema{
+				Schema: &schemas.Schema{
+					ID: "example",
+					Attributes: map[string]interface{}{
+						"group":    "apps",
+						"version":  "v1",
+						"resource": "deployments",
+						"disallowMethods": map[string]bool{
+							http.MethodPatch: true,
+						},
+					},
+				},
+			},
+			apiObject: types.APIObject{
+				ID: "example",
+				Object: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-deployment",
+						Namespace: "example-ns",
+					},
+				},
+			},
+			currentLinks: map[string]string{
+				"default": "defaultVal",
+				"patch":   "/v1/apps.deployments/example-ns/example-deployment",
+				"view":    "/apis/apps/v1/namespaces/example-ns/deployments/example-deployment",
+			},
+			wantLinks: map[string]string{
+				"default": "defaultVal",
+				"patch":   "blocked",
+				"view":    "/apis/apps/v1/namespaces/example-ns/deployments/example-deployment",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -960,6 +1036,12 @@ func Test_formatterLinks(t *testing.T) {
 				}
 				if test.permissions.hasRemove {
 					accessSet.Add("delete", gvr.GroupResource(), accesscontrol.Access{
+						Namespace:    meta.GetNamespace(),
+						ResourceName: meta.GetName(),
+					})
+				}
+				if test.permissions.hasPatch {
+					accessSet.Add("patch", gvr.GroupResource(), accesscontrol.Access{
 						Namespace:    meta.GetNamespace(),
 						ResourceName: meta.GetName(),
 					})

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -157,6 +157,9 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 		if verbAccess.AnyVerb("create") {
 			s.CollectionMethods = append(s.CollectionMethods, allowed(http.MethodPost))
 		}
+		if verbAccess.AnyVerb("patch") {
+			s.ResourceMethods = append(s.ResourceMethods, allowed(http.MethodPatch))
+		}
 
 		if len(s.CollectionMethods) == 0 && len(s.ResourceMethods) == 0 {
 			continue

--- a/pkg/schema/factory_test.go
+++ b/pkg/schema/factory_test.go
@@ -38,6 +38,15 @@ func TestSchemas(t *testing.T) {
 				errDesired:             false,
 			},
 		},
+		{
+			name: "basic patch schema test",
+			config: schemaTestConfig{
+				permissionVerbs:        []string{"patch"},
+				desiredResourceVerbs:   []string{"PATCH"},
+				desiredCollectionVerbs: []string{},
+				errDesired:             false,
+			},
+		},
 	}
 	for _, test := range tests {
 		test := test
@@ -162,7 +171,7 @@ func makeSchema(resourceType string) *types.APISchema {
 				"group":    testGroup,
 				"version":  testVersion,
 				"resource": resourceType,
-				"verbs":    []string{"get", "list", "watch", "delete", "update", "create"},
+				"verbs":    []string{"get", "list", "watch", "delete", "update", "create", "patch"},
 			},
 		},
 	}


### PR DESCRIPTION
**NOTE:  overriding the apiserver version until https://github.com/rancher/apiserver/pull/128 is merged/tagged**

Issue:  https://github.com/rancher/rancher/issues/40712

Previously, we have not factored-in nor included the patch resource permission in our object links or schema for resource methods.

With this change, if a user has patch permission on an object, it will be reflected in both the links for an object as well as the resource methods on the schema.

-----
Testing:
Manual testing done
Unit tests added

--------

Helpful testing information:

To see the schema for something like apps.deployments, you can go to:  <rancher url>/v1/schemas/apps.deployments
In the resultant json, if the user has patch permissions, you should see something like...
```
"resourceMethods": [ 4 items
"GET",
"DELETE",
"PUT",
"PATCH"
],
```
included in the yaml blob.

Likewise, if you look at the api view for an object, you will see the patch link defined when a user has patch permissions on that object.
`{
  "patch": "https://localhost:9443/apis/apps/v1/namespaces/default/deployments/nginx-deployment",
  "self": "https://localhost:9443/v1/apps.deployments/default/nginx-deployment",
  "update": "https://localhost:9443/apis/apps/v1/namespaces/default/deployments/nginx-deployment",
  "view": "https://localhost:9443/apis/apps/v1/namespaces/default/deployments/nginx-deployment"
}
`

