### PR TITLE
Fix overriding update and remove links with the wrong link

### DIFF
--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -107,8 +107,6 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 		if hasUpdate {
 			if attributes.DisallowMethods(resource.Schema)[http.MethodPut] {
 				resource.Links["update"] = "blocked"
-			} else {
-				resource.Links["update"] = u
 			}
 		} else {
 			delete(resource.Links, "update")
@@ -116,8 +114,6 @@ func formatter(summarycache *summarycache.SummaryCache, asl accesscontrol.Access
 		if hasDelete {
 			if attributes.DisallowMethods(resource.Schema)[http.MethodDelete] {
 				resource.Links["remove"] = "blocked"
-			} else {
-				resource.Links["remove"] = u
 			}
 		} else {
 			delete(resource.Links, "remove")

--- a/pkg/resources/common/formatter_test.go
+++ b/pkg/resources/common/formatter_test.go
@@ -775,8 +775,8 @@ func Test_formatterLinks(t *testing.T) {
 			},
 			currentLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "../api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "../api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 			},
 			wantLinks: map[string]string{
 				"default": "defaultVal",
@@ -810,12 +810,12 @@ func Test_formatterLinks(t *testing.T) {
 			},
 			currentLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "../api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "../api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 			},
 			wantLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "/api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
 				"view":    "/api/v1/namespaces/example-ns/pods/example-pod",
 			},
 		},
@@ -846,12 +846,12 @@ func Test_formatterLinks(t *testing.T) {
 			},
 			currentLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "../api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "../api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 			},
 			wantLinks: map[string]string{
 				"default": "defaultVal",
-				"remove":  "/api/v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 				"view":    "/api/v1/namespaces/example-ns/pods/example-pod",
 			},
 		},
@@ -883,13 +883,13 @@ func Test_formatterLinks(t *testing.T) {
 			},
 			currentLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "../api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "../api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 			},
 			wantLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "/api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "/api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 				"view":    "/api/v1/namespaces/example-ns/pods/example-pod",
 			},
 		},
@@ -925,8 +925,8 @@ func Test_formatterLinks(t *testing.T) {
 			},
 			currentLinks: map[string]string{
 				"default": "defaultVal",
-				"update":  "../api/v1/namespaces/example-ns/pods/example-pod",
-				"remove":  "../api/v1/namespaces/example-ns/pods/example-pod",
+				"update":  "../v1/namespaces/example-ns/pods/example-pod",
+				"remove":  "../v1/namespaces/example-ns/pods/example-pod",
 			},
 			wantLinks: map[string]string{
 				"default": "defaultVal",


### PR DESCRIPTION
Before https://github.com/rancher/steve/pull/308 we were not overriding the update / remove links, so they were pointing to the right path (`/v1/...`). The new code was now overriding those links but to the wrong path (`/api/...` or `/apis/...`) which points to the native k8s resource. This caused issue in the UI.

The fix is to not override the links that already exist, we either block or delete them.