### PR TITLE
Fix sort field parsing

### DIFF
--- a/pkg/stores/sqlpartition/listprocessor/processor.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor.go
@@ -90,20 +90,24 @@ func ParseQuery(apiOp *types.APIRequest, namespaceCache Cache) (informer.ListOpt
 	if sortKeys != "" {
 		sortParts := strings.SplitN(sortKeys, ",", 2)
 		primaryField := sortParts[0]
-		if primaryField != "" && primaryField[0] == '-' {
-			sortOpts.Orders = append(sortOpts.Orders, informer.DESC)
-			primaryField = primaryField[1:]
-		}
 		if primaryField != "" {
+			if primaryField[0] == '-' {
+				sortOpts.Orders = append(sortOpts.Orders, informer.DESC)
+				primaryField = primaryField[1:]
+			} else {
+				sortOpts.Orders = append(sortOpts.Orders, informer.ASC)
+			}
 			sortOpts.Fields = append(sortOpts.Fields, strings.Split(primaryField, "."))
 		}
 		if len(sortParts) > 1 {
 			secondaryField := sortParts[1]
-			if secondaryField != "" && secondaryField[0] == '-' {
-				sortOpts.Orders = append(sortOpts.Orders, informer.DESC)
-				secondaryField = secondaryField[1:]
-			}
 			if secondaryField != "" {
+				if secondaryField[0] == '-' {
+					sortOpts.Orders = append(sortOpts.Orders, informer.DESC)
+					secondaryField = secondaryField[1:]
+				} else {
+					sortOpts.Orders = append(sortOpts.Orders, informer.ASC)
+				}
 				sortOpts.Fields = append(sortOpts.Fields, strings.Split(secondaryField, "."))
 			}
 		}

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -355,6 +355,9 @@ func TestParseQuery(t *testing.T) {
 				Fields: [][]string{
 					{"metadata", "name"},
 				},
+				Orders: []informer.SortOrder{
+					informer.ASC,
+				},
 			},
 			Filters: make([]informer.OrFilter, 0),
 			Pagination: informer.Pagination{
@@ -405,6 +408,7 @@ func TestParseQuery(t *testing.T) {
 				},
 				Orders: []informer.SortOrder{
 					informer.DESC,
+					informer.ASC,
 				},
 			},
 			Filters: make([]informer.OrFilter, 0),


### PR DESCRIPTION
Without this fix, queries with sort params will return the following error:

```
{"type":"error","links":{},"code":"ServerError","message":"sort fields length 1 != sort orders length 0","status":500,"type":"error"}
```