### PR TITLE
sql: propagate and use contexts

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -187,7 +187,7 @@ func setup(ctx context.Context, server *Server) error {
 
 	var onSchemasHandler schemacontroller.SchemasHandlerFunc
 	if server.SQLCache {
-		s, err := sqlproxy.NewProxyStore(cols, cf, summaryCache, summaryCache, nil)
+		s, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sqlcache/db/client_test.go
+++ b/pkg/sqlcache/db/client_test.go
@@ -67,7 +67,7 @@ func TestQueryForRows(t *testing.T) {
 		c := SetupMockConnection(t)
 		client := SetupClient(t, c, nil, nil)
 		s := NewMockStmt(gomock.NewController(t))
-		ctx := context.TODO()
+		ctx := context.Background()
 		r := &sql.Rows{}
 		s.EXPECT().QueryContext(ctx).Return(r, nil)
 		rows, err := client.QueryForRows(ctx, s)
@@ -79,7 +79,7 @@ func TestQueryForRows(t *testing.T) {
 		c := SetupMockConnection(t)
 		client := SetupClient(t, c, nil, nil)
 		s := NewMockStmt(gomock.NewController(t))
-		ctx := context.TODO()
+		ctx := context.Background()
 		s.EXPECT().QueryContext(ctx).Return(nil, fmt.Errorf("error"))
 		_, err := client.QueryForRows(ctx, s)
 		assert.NotNil(t, err)

--- a/pkg/sqlcache/informer/factory/informer_factory_test.go
+++ b/pkg/sqlcache/informer/factory/informer_factory_test.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -73,7 +74,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -95,12 +96,12 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		// this sleep is critical to the test. It ensure there has been enough time for expected function like Run to be invoked in their go routines.
 		time.Sleep(1 * time.Second)
-		c2, err := f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c2, err := f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, c, c2)
 	}})
@@ -118,7 +119,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -138,7 +139,7 @@ func TestCacheFor(t *testing.T) {
 			close(f.stopCh)
 		}()
 		var err error
-		_, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		_, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.NotNil(t, err)
 		time.Sleep(2 * time.Second)
 	}})
@@ -160,7 +161,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -178,7 +179,7 @@ func TestCacheFor(t *testing.T) {
 		close(f.stopCh)
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)
@@ -199,7 +200,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -221,7 +222,7 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)
@@ -247,7 +248,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -269,7 +270,7 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)
@@ -294,7 +295,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -316,7 +317,7 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, nil, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)
@@ -341,7 +342,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*informer.Informer, error) {
 			// we can't test func == func, so instead we check if the output was as expected
 			input := "someinput"
 			ouput, err := transform(input)
@@ -371,7 +372,7 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
-		c, err = f.CacheFor(fields, transformFunc, dynamicClient, expectedGVK, false, true)
+		c, err = f.CacheFor(context.Background(), fields, transformFunc, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)

--- a/pkg/sqlcache/informer/indexer.go
+++ b/pkg/sqlcache/informer/indexer.go
@@ -74,10 +74,10 @@ type Store interface {
 }
 
 // NewIndexer returns a cache.Indexer backed by SQLite for objects of the given example type
-func NewIndexer(indexers cache.Indexers, s Store) (*Indexer, error) {
+func NewIndexer(ctx context.Context, indexers cache.Indexers, s Store) (*Indexer, error) {
 	dbName := db.Sanitize(s.GetName())
 
-	err := s.WithTransaction(context.Background(), true, func(tx transaction.Client) error {
+	err := s.WithTransaction(ctx, true, func(tx transaction.Client) error {
 		createTableQuery := fmt.Sprintf(createTableFmt, dbName)
 		_, err := tx.Exec(createTableQuery)
 		if err != nil {

--- a/pkg/sqlcache/informer/indexer_test.go
+++ b/pkg/sqlcache/informer/indexer_test.go
@@ -64,7 +64,7 @@ func TestNewIndexer(t *testing.T) {
 		store.EXPECT().Prepare(fmt.Sprintf(listByIndexFmt, storeName, storeName))
 		store.EXPECT().Prepare(fmt.Sprintf(listKeyByIndexFmt, storeName))
 		store.EXPECT().Prepare(fmt.Sprintf(listIndexValuesFmt, storeName))
-		indexer, err := NewIndexer(indexers, store)
+		indexer, err := NewIndexer(context.Background(), indexers, store)
 		assert.Nil(t, err)
 		assert.Equal(t, cache.Indexers(indexers), indexer.indexers)
 	}})
@@ -79,7 +79,7 @@ func TestNewIndexer(t *testing.T) {
 		}
 		store.EXPECT().GetName().AnyTimes().Return("someStoreName")
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error"))
-		_, err := NewIndexer(indexers, store)
+		_, err := NewIndexer(context.Background(), indexers, store)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewIndexer() with Client Exec() error on first call to Exec(), should return error", test: func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestNewIndexer(t *testing.T) {
 					t.Fail()
 				}
 			})
-		_, err := NewIndexer(indexers, store)
+		_, err := NewIndexer(context.Background(), indexers, store)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewIndexer() with Client Exec() error on second call to Exec(), should return error", test: func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestNewIndexer(t *testing.T) {
 				}
 			})
 
-		_, err := NewIndexer(indexers, store)
+		_, err := NewIndexer(context.Background(), indexers, store)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewIndexer() with Client Commit() error, should return error", test: func(t *testing.T) {
@@ -153,7 +153,7 @@ func TestNewIndexer(t *testing.T) {
 					t.Fail()
 				}
 			})
-		_, err := NewIndexer(indexers, store)
+		_, err := NewIndexer(context.Background(), indexers, store)
 		assert.NotNil(t, err)
 	}})
 	t.Parallel()

--- a/pkg/sqlcache/informer/indexer_test.go
+++ b/pkg/sqlcache/informer/indexer_test.go
@@ -177,6 +177,7 @@ func TestAfterUpsert(t *testing.T) {
 		deleteIndicesStmt := NewMockStmt(gomock.NewController(t))
 		addIndexStmt := NewMockStmt(gomock.NewController(t))
 		indexer := &Indexer{
+			ctx:               context.Background(),
 			Store: store,
 			indexers: map[string]cache.IndexFunc{
 				"a": func(obj interface{}) ([]string, error) {
@@ -199,6 +200,7 @@ func TestAfterUpsert(t *testing.T) {
 		objKey := "key"
 		deleteIndicesStmt := NewMockStmt(gomock.NewController(t))
 		indexer := &Indexer{
+			ctx:               context.Background(),
 			Store: store,
 
 			indexers: map[string]cache.IndexFunc{
@@ -221,6 +223,7 @@ func TestAfterUpsert(t *testing.T) {
 		addIndexStmt := NewMockStmt(gomock.NewController(t))
 		objKey := "key"
 		indexer := &Indexer{
+			ctx:               context.Background(),
 			Store: store,
 			indexers: map[string]cache.IndexFunc{
 				"a": func(obj interface{}) ([]string, error) {
@@ -258,6 +261,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -268,7 +272,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -283,6 +287,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -293,7 +298,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject, testObject}, nil)
@@ -308,6 +313,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -318,7 +324,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{}, nil)
@@ -332,6 +338,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -351,6 +358,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -361,7 +369,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
 		_, err := indexer.Index(indexName, testObject)
 		assert.NotNil(t, err)
 	}})
@@ -372,6 +380,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -382,7 +391,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, fmt.Errorf("error"))
@@ -396,6 +405,7 @@ func TestIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 			indexers: map[string]cache.IndexFunc{
@@ -409,7 +419,7 @@ func TestIndex(t *testing.T) {
 		store.EXPECT().GetName().Return("name")
 		stmt := &sql.Stmt{}
 		store.EXPECT().Prepare(fmt.Sprintf(selectQueryFmt, "name", ", ?")).Return(stmt)
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey, objKey+"2").Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey, objKey+"2").Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -439,12 +449,13 @@ func TestByIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -459,12 +470,13 @@ func TestByIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject, testObject}, nil)
@@ -479,12 +491,13 @@ func TestByIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{}, nil)
@@ -498,11 +511,12 @@ func TestByIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
 		_, err := indexer.ByIndex(indexName, objKey)
 		assert.NotNil(t, err)
 	}})
@@ -513,12 +527,13 @@ func TestByIndex(t *testing.T) {
 		objKey := "key"
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, fmt.Errorf("error"))
@@ -545,10 +560,11 @@ func TestListIndexFuncValues(t *testing.T) {
 		listStmt := &sql.Stmt{}
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
 		store.EXPECT().ReadStrings(rows).Return([]string{"somestrings"}, nil)
 		vals := indexer.ListIndexFuncValues(indexName)
 		assert.Equal(t, []string{"somestrings"}, vals)
@@ -558,10 +574,11 @@ func TestListIndexFuncValues(t *testing.T) {
 		listStmt := &sql.Stmt{}
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.Background(), indexer.listIndexValuesStmt, indexName).Return(nil, fmt.Errorf("error"))
 		assert.Panics(t, func() { indexer.ListIndexFuncValues(indexName) })
 	}})
 	tests = append(tests, testCase{description: "ListIndexFuncvalues() with ReadStrings() error returned from store, should panic", test: func(t *testing.T) {
@@ -570,10 +587,11 @@ func TestListIndexFuncValues(t *testing.T) {
 		listStmt := &sql.Stmt{}
 		indexName := "someindexname"
 		indexer := &Indexer{
+			ctx:             context.Background(),
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.Background(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
 		store.EXPECT().ReadStrings(rows).Return([]string{"somestrings"}, fmt.Errorf("error"))
 		assert.Panics(t, func() { indexer.ListIndexFuncValues(indexName) })
 	}})
@@ -599,6 +617,7 @@ func TestGetIndexers(t *testing.T) {
 			},
 		}
 		indexer := &Indexer{
+			ctx:      context.Background(),
 			indexers: expectedIndexers,
 		}
 		indexers := indexer.GetIndexers()

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -35,7 +35,7 @@ var newInformer = cache.NewSharedIndexInformer
 
 // NewInformer returns a new SQLite-backed Informer for the type specified by schema in unstructured.Unstructured form
 // using the specified client
-func NewInformer(client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*Informer, error) {
+func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*Informer, error) {
 	listWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			a, err := client.List(context.Background(), options)
@@ -69,7 +69,7 @@ func NewInformer(client dynamic.ResourceInterface, fields [][]string, transform 
 
 	name := informerNameFromGVK(gvk)
 
-	s, err := sqlStore.NewStore(example, cache.DeletionHandlingMetaNamespaceKeyFunc, db, shouldEncrypt, name)
+	s, err := sqlStore.NewStore(ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc, db, shouldEncrypt, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -38,11 +38,11 @@ var newInformer = cache.NewSharedIndexInformer
 func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool) (*Informer, error) {
 	listWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			a, err := client.List(context.Background(), options)
+			a, err := client.List(ctx, options)
 			return a, err
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return client.Watch(context.Background(), options)
+			return client.Watch(ctx, options)
 		},
 	}
 

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -73,7 +73,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 	if err != nil {
 		return nil, err
 	}
-	loi, err := NewListOptionIndexer(fields, s, namespaced)
+	loi, err := NewListOptionIndexer(ctx, fields, s, namespaced)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -324,8 +324,8 @@ func TestInformerListByOptions(t *testing.T) {
 		}
 		expectedTotal := len(expectedList.Items)
 		expectedContinueToken := "123"
-		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(expectedList, expectedTotal, expectedContinueToken, nil)
-		list, total, continueToken, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.Background(), lo, partitions, ns).Return(expectedList, expectedTotal, expectedContinueToken, nil)
+		list, total, continueToken, err := informer.ListByOptions(context.Background(), lo, partitions, ns)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedList, list)
 		assert.Equal(t, len(expectedList.Items), total)
@@ -339,8 +339,8 @@ func TestInformerListByOptions(t *testing.T) {
 		lo := ListOptions{}
 		var partitions []partition.Partition
 		ns := "somens"
-		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))
-		_, _, _, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.Background(), lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))
+		_, _, _, err := informer.ListByOptions(context.Background(), lo, partitions, ns)
 		assert.NotNil(t, err)
 	}})
 	t.Parallel()

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -79,7 +79,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		informer, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -103,7 +103,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewIndexer(), should return an error", test: func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewListOptionIndexer(), should return an error", test: func(t *testing.T) {
@@ -190,7 +190,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with transform func", test: func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		informer, err := NewInformer(dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -289,7 +289,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		_, err := NewInformer(dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
 		assert.Error(t, err)
 		newInformer = cache.NewSharedIndexInformer
 	}})

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -73,12 +73,12 @@ const (
 // NewListOptionIndexer returns a SQLite-backed cache.Indexer of unstructured.Unstructured Kubernetes resources of a certain GVK
 // ListOptionIndexer is also able to satisfy ListOption queries on indexed (sub)fields.
 // Fields are specified as slices (e.g. "metadata.resourceVersion" is ["metadata", "resourceVersion"])
-func NewListOptionIndexer(fields [][]string, s Store, namespaced bool) (*ListOptionIndexer, error) {
+func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, namespaced bool) (*ListOptionIndexer, error) {
 	// necessary in order to gob/ungob unstructured.Unstructured objects
 	gob.Register(map[string]interface{}{})
 	gob.Register([]interface{}{})
 
-	i, err := NewIndexer(cache.Indexers{}, s)
+	i, err := NewIndexer(ctx, cache.Indexers{}, s)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -114,7 +114,7 @@ func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, names
 	qmarks := make([]string, len(indexedFields))
 	setStatements := make([]string, len(indexedFields))
 
-	err = l.WithTransaction(context.Background(), true, func(tx transaction.Client) error {
+	err = l.WithTransaction(ctx, true, func(tx transaction.Client) error {
 		_, err = tx.Exec(fmt.Sprintf(createFieldsTableFmt, dbName, strings.Join(columnDefs, ", ")))
 		if err != nil {
 			return err

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -72,7 +72,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 				}
 			})
 
-		loi, err := NewListOptionIndexer(fields, store, true)
+		loi, err := NewListOptionIndexer(context.Background(), fields, store, true)
 		assert.Nil(t, err)
 		assert.NotNil(t, loi)
 	}})
@@ -93,7 +93,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 				}
 			})
 
-		_, err := NewListOptionIndexer(fields, store, false)
+		_, err := NewListOptionIndexer(context.Background(), fields, store, false)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewListOptionIndexer() with error returned from Begin(), should return an error", test: func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error"))
 
-		_, err := NewListOptionIndexer(fields, store, false)
+		_, err := NewListOptionIndexer(context.Background(), fields, store, false)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewListOptionIndexer() with error from Exec() when creating fields table, should return an error", test: func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 				}
 			})
 
-		_, err := NewListOptionIndexer(fields, store, true)
+		_, err := NewListOptionIndexer(context.Background(), fields, store, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewListOptionIndexer() with error from create-labels, should return an error", test: func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 				}
 			})
 
-		_, err := NewListOptionIndexer(fields, store, true)
+		_, err := NewListOptionIndexer(context.Background(), fields, store, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewListOptionIndexer() with error from Commit(), should return an error", test: func(t *testing.T) {
@@ -242,7 +242,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 				}
 			})
 
-		_, err := NewListOptionIndexer(fields, store, true)
+		_, err := NewListOptionIndexer(context.Background(), fields, store, true)
 		assert.NotNil(t, err)
 	}})
 

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -962,7 +962,7 @@ func TestListByOptions(t *testing.T) {
 				store.EXPECT().ReadInt(rows).Return(len(test.expectedList.Items), nil)
 				store.EXPECT().CloseStmt(stmt).Return(nil)
 			}
-			list, total, contToken, err := lii.executeQuery(context.TODO(), queryInfo)
+			list, total, contToken, err := lii.executeQuery(context.Background(), queryInfo)
 			if test.expectedErr == nil {
 				assert.Nil(t, err)
 			} else {

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -323,7 +323,7 @@ func (i *IntegrationSuite) createCacheAndFactory(fields [][]string, transformFun
 		Resource: "configmaps",
 	}
 	dynamicResource := dynamicClient.Resource(configMapGVR).Namespace(testNamespace)
-	cache, err := cacheFactory.CacheFor(fields, transformFunc, dynamicResource, configMapGVK, true, true)
+	cache, err := cacheFactory.CacheFor(context.Background(), fields, transformFunc, dynamicResource, configMapGVK, true, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to make cache: %w", err)
 	}

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -36,6 +36,7 @@ const (
 type Store struct {
 	db.Client
 
+	ctx           context.Context
 	name          string
 	typ           reflect.Type
 	keyFunc       cache.KeyFunc
@@ -61,8 +62,9 @@ type Store struct {
 var _ cache.Store = (*Store)(nil)
 
 // NewStore creates a SQLite-backed cache.Store for objects of the given example type
-func NewStore(example any, keyFunc cache.KeyFunc, c db.Client, shouldEncrypt bool, name string) (*Store, error) {
+func NewStore(ctx context.Context, example any, keyFunc cache.KeyFunc, c db.Client, shouldEncrypt bool, name string) (*Store, error) {
 	s := &Store{
+		ctx:           ctx,
 		name:          name,
 		typ:           reflect.TypeOf(example),
 		Client:        c,

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -726,7 +726,7 @@ func SetupMockDB(t *testing.T) (*MockClient, *MockTXClient) {
 	return dbC, txC
 }
 func SetupStore(t *testing.T, client *MockClient, shouldEncrypt bool) *Store {
-	store, err := NewStore(testStoreObject{}, testStoreKeyFunc, client, shouldEncrypt, "testStoreObject")
+	store, err := NewStore(context.Background(), testStoreObject{}, testStoreKeyFunc, client, shouldEncrypt, "testStoreObject")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -362,7 +362,7 @@ func TestList(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		items := store.List()
 		assert.Len(t, items, 0)
@@ -373,7 +373,7 @@ func TestList(t *testing.T) {
 		store := SetupStore(t, c, shouldEncrypt)
 		fakeItemsToReturn := []any{"something1", 2, false}
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(fakeItemsToReturn, nil)
 		items := store.List()
 		assert.Equal(t, fakeItemsToReturn, items)
@@ -383,7 +383,7 @@ func TestList(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		defer func() {
 			recover()
@@ -412,7 +412,7 @@ func TestListKeys(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{"a", "b", "c"}, nil)
 		keys := store.ListKeys()
 		assert.Len(t, keys, 3)
@@ -423,7 +423,7 @@ func TestListKeys(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
 		keys := store.ListKeys()
 		assert.Len(t, keys, 0)
@@ -449,7 +449,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{testObject}, nil)
 		item, exists, err := store.Get(testObject)
 		assert.Nil(t, err)
@@ -461,7 +461,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		item, exists, err := store.Get(testObject)
 		assert.Nil(t, err)
@@ -473,7 +473,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		_, _, err := store.Get(testObject)
 		assert.NotNil(t, err)
@@ -499,7 +499,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{testObject}, nil)
 		item, exists, err := store.GetByKey(testObject.Id)
 		assert.Nil(t, err)
@@ -511,7 +511,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		item, exists, err := store.GetByKey(testObject.Id)
 		assert.Nil(t, err)
@@ -523,7 +523,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		_, _, err := store.GetByKey(testObject.Id)
 		assert.NotNil(t, err)
@@ -554,7 +554,7 @@ func TestReplace(t *testing.T) {
 		stmt := NewMockStmt(gomock.NewController(t))
 
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(stmt)
-		c.EXPECT().QueryForRows(context.TODO(), stmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), stmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(stmt)
 		stmt.EXPECT().Exec(testObject.Id)
@@ -578,7 +578,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{}, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, testObject.Id, testObject, store.shouldEncrypt)
 
@@ -608,7 +608,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
 
 		c.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error")).Do(
@@ -631,7 +631,7 @@ func TestReplace(t *testing.T) {
 		deleteStmt := NewMockStmt(gomock.NewController(t))
 
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(deleteStmt)
 		deleteStmt.EXPECT().Exec(testObject.Id).Return(nil, fmt.Errorf("error"))
@@ -655,7 +655,7 @@ func TestReplace(t *testing.T) {
 		deleteStmt := NewMockStmt(gomock.NewController(t))
 
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.Background(), listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(deleteStmt)
 		deleteStmt.EXPECT().Exec(testObject.Id).Return(nil, nil)

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -263,18 +263,18 @@ func (m *MockCacheFactory) EXPECT() *MockCacheFactoryMockRecorder {
 }
 
 // CacheFor mocks base method.
-func (m *MockCacheFactory) CacheFor(arg0 [][]string, arg1 cache.TransformFunc, arg2 dynamic.ResourceInterface, arg3 schema.GroupVersionKind, arg4, arg5 bool) (factory.Cache, error) {
+func (m *MockCacheFactory) CacheFor(arg0 context.Context, arg1 [][]string, arg2 cache.TransformFunc, arg3 dynamic.ResourceInterface, arg4 schema.GroupVersionKind, arg5, arg6 bool) (factory.Cache, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheFor", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CacheFor", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(factory.Cache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CacheFor indicates an expected call of CacheFor.
-func (mr *MockCacheFactoryMockRecorder) CacheFor(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockCacheFactoryMockRecorder) CacheFor(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // Reset mocks base method.

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -293,7 +293,7 @@ func (s *Store) initializeNamespaceCache() error {
 	nsSchema := baseNSSchema
 
 	// make sure any relevant columns are set to the ns schema
-	if err := s.columnSetter.SetColumns(context.Background(), &nsSchema); err != nil {
+	if err := s.columnSetter.SetColumns(s.ctx, &nsSchema); err != nil {
 		return fmt.Errorf("failed to set columns for proxy stores namespace informer: %w", err)
 	}
 


### PR DESCRIPTION
Currently vai code uses `context.Background()` and `context.TODO()` because it was not developed with context awareness.

This PR propagates the main Steve context so that it can be used when interacting with SQL context-aware functions.

This PR removes all production-code use of `context.Background()` and `context.TODO()` and replaces test-code use of `TODO` with `Background`.

Contributes to https://github.com/rancher/rancher/issues/47825, specifically addressing feedback in https://github.com/rancher/lasso/pull/65#discussion_r1607250329

**Best reviewed commit-by-commit**