### PR TITLE
sql: encrypt Tokens by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Meaning and behavior are the same unless otherwise specified.
 
 Note that, if SQLite caching of resources is enabled, some of the data
 can be stored in disk, in either encrypted or plain text forms based on:
- - by default, Secrets are always encrypted
+ - by default, Secrets and Rancher Tokens (`management.cattle.io/v3, Kind=Token`) are always encrypted
  - if the environment variable `CATTLE_ENCRYPT_CACHE_ALL` is set to "true",
 all resources are encrypted
  - regardless of the setting's value, any filterable/sortable columns are stored
@@ -825,4 +825,3 @@ export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
 # Versioning
 
 See [VERSION.md](VERSION.md).
-

--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -65,6 +65,11 @@ var defaultEncryptedResourceTypes = map[schema.GroupVersionKind]struct{}{
 		Version: "v1",
 		Kind:    "Secret",
 	}: {},
+	{
+		Group:   "management.cattle.io",
+		Version: "v3",
+		Kind:    "Token",
+	}: {},
 }
 
 // NewCacheFactory returns an informer factory instance


### PR DESCRIPTION
Currently vai code encrypts Secrets by default. This PR extends the encryption-by-default to Tokens (note that [RFC 19](https://docs.google.com/document/d/15EYAD1rfH5Exg1hKiEMb3-5UD4Rys6hA1rYJmpkdVsM/edit?tab=t.0) will bring a different implementation).

Contributes to https://github.com/rancher/rancher/issues/47825
