### PR TITLE
Fix code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Example, filtering by object name:
 ```
 /v1/{type}?filter=metadata.name='match-this-exactly'
 ```
-```
 
 A target value can be delimited by double-quotes, but this will succeed on a partial match:
 


### PR DESCRIPTION
In the README an errant set of back-ticks broke quotes below. Am sure before, when rendered, GH showed the correct blocks. Maybe they've fixed something their side