### PR TITLE
Ensure complex accessors from schema don't result in double-bracketing.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/steve/pkg/stores/queryhelper"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -353,7 +354,7 @@ func getFieldsFromSchema(schema *types.APISchema) [][]string {
 	}
 	for _, colDef := range colDefs {
 		field := strings.TrimPrefix(colDef.Field, "$.")
-		fields = append(fields, strings.Split(field, "."))
+		fields = append(fields, queryhelper.SafeSplit(field))
 	}
 	return fields
 }


### PR DESCRIPTION
Another issue related to [#48965](https://github.com/rancher/rancher/issues/48965) 

To test: Add the events from the shar archive in https://github.com/rancher/rancher/issues/46333#issuecomment-2680569164

Compile the PR and run `./bin/steve --http-listen-port 5112 --https-listen-port 5111 --debug --sql-cache`

Then run commands like:

`curl -gskL https://localhost:5111/v1/events'?filter=_type=Gorniplatz&sort=-metadata.fields[6],metadata.name' | jq '.data[].metadata | [.fields[6], .name]'`

