### PR TITLE
Index 'md.Ann[prov.cattle.io/MCDN]' on provisioning.cattle.io.clusters

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -41,7 +41,7 @@ type ListOptionIndexer struct {
 var (
 	defaultIndexedFields   = []string{"metadata.name", "metadata.creationTimestamp"}
 	defaultIndexNamespaced = "metadata.namespace"
-	subfieldRegex          = regexp.MustCompile(`([a-zA-Z]+)|(\[[a-zA-Z./]+])|(\[[0-9]+])`)
+	subfieldRegex          = regexp.MustCompile(`([a-zA-Z]+)|(\[[-a-zA-Z./]+])|(\[[0-9]+])`)
 
 	ErrInvalidColumn = errors.New("supplied column is invalid")
 )

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -157,6 +157,7 @@ var (
 			{"spec", "ingressClassName"},
 		},
 		gvkKey("provisioning.cattle.io", "v1", "Cluster"): {
+			{"metadata", "annotations", "provisioning.cattle.io/management-cluster-display-name"},
 			{"metadata", "labels", "provider.cattle.io"},
 			{"status", "clusterName"},
 			{"status", "provider"},


### PR DESCRIPTION
Related to [#49288](https://github.com/rancher/rancher/issues/49288)

In long form:

Add `metadata.annotations[provisioning.cattle.io/management-cluster-display-name]`
to `provisioning.cattle.io` as an indexable field 