### PR TITLE
Fix not finding ClusterRoleBinding or RoleBinding for service accounts

### DIFF
--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -1,12 +1,12 @@
 package accesscontrol
 
 import (
-	"fmt"
 	"sort"
 
 	rbacv1controllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 )
 
 const (
@@ -72,7 +72,7 @@ func indexSubjects(kind string, subjects []rbacv1.Subject) []string {
 			result = append(result, subject.Name)
 		} else if kind == userKind && subjectIsServiceAccount(subject) {
 			// Index is for Users and this references a service account
-			result = append(result, fmt.Sprintf("serviceaccount:%s:%s", subject.Namespace, subject.Name))
+			result = append(result, serviceaccount.MakeUsername(subject.Namespace, subject.Name))
 		}
 	}
 	return result

--- a/pkg/accesscontrol/policy_rule_index_test.go
+++ b/pkg/accesscontrol/policy_rule_index_test.go
@@ -56,7 +56,7 @@ func Test_policyRuleIndex_roleBindingBySubject(t *testing.T) {
 					Namespace: "testns",
 				},
 			}),
-			want: []string{"serviceaccount:testns:mysvcaccount"},
+			want: []string{"system:serviceaccount:testns:mysvcaccount"},
 		},
 		{
 			name: "ignores svcaccounts in group mode",
@@ -166,7 +166,7 @@ func Test_policyRuleIndex_clusterRoleBindingBySubject(t *testing.T) {
 					Namespace: "testns",
 				},
 			}),
-			want: []string{"serviceaccount:testns:mysvcaccount"},
+			want: []string{"system:serviceaccount:testns:mysvcaccount"},
 		},
 		{
 			name: "ignores svcaccounts in group mode",


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/49342

Steve caches privileges of users to avoid making SAR request to kube-apiserver. Makes privilege check available via the [AccessSetLookup](https://github.com/rancher/steve/blob/f48690210021f1d5be996593caea9a6e476e8d46/pkg/accesscontrol/access_store.go#L17) (ASL) interface. That's used in Steve and it's now also [used in the extension API server](https://github.com/rancher/rancher/blob/af56e7fa886d35cb2f464422389c4a57e2f65a17/pkg/ext/extension_apiserver.go#L222-L244) (and given to the stores).

Debugging showed that the ASL doesn't see this cluster-admin being bound to this service account. The issue is that we're not constructing the correct full name of the service account [here](https://github.com/rancher/steve/blob/f48690210021f1d5be996593caea9a6e476e8d46/pkg/accesscontrol/policy_rule_index.go#L75). So when doing the lookup, we check for system:serviceaccount:cattle-system:rancher but when populating this ASL we add an index for serviceaccount:cattle-system:rancher. Those don't match so cluster-admin does not get added to this SA's privileges.

I'm fairly confident that this won't cause regression because I've never seen a service account without the `system:` prefix. 