### PR TITLE
Revert "Fix not finding ClusterRoleBinding or RoleBinding for service accounts"

### DIFF
--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -1,12 +1,12 @@
 package accesscontrol
 
 import (
+	"fmt"
 	"sort"
 
 	rbacv1controllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 )
 
 const (
@@ -72,7 +72,7 @@ func indexSubjects(kind string, subjects []rbacv1.Subject) []string {
 			result = append(result, subject.Name)
 		} else if kind == userKind && subjectIsServiceAccount(subject) {
 			// Index is for Users and this references a service account
-			result = append(result, serviceaccount.MakeUsername(subject.Namespace, subject.Name))
+			result = append(result, fmt.Sprintf("serviceaccount:%s:%s", subject.Namespace, subject.Name))
 		}
 	}
 	return result

--- a/pkg/accesscontrol/policy_rule_index_test.go
+++ b/pkg/accesscontrol/policy_rule_index_test.go
@@ -56,7 +56,7 @@ func Test_policyRuleIndex_roleBindingBySubject(t *testing.T) {
 					Namespace: "testns",
 				},
 			}),
-			want: []string{"system:serviceaccount:testns:mysvcaccount"},
+			want: []string{"serviceaccount:testns:mysvcaccount"},
 		},
 		{
 			name: "ignores svcaccounts in group mode",
@@ -166,7 +166,7 @@ func Test_policyRuleIndex_clusterRoleBindingBySubject(t *testing.T) {
 					Namespace: "testns",
 				},
 			}),
-			want: []string{"system:serviceaccount:testns:mysvcaccount"},
+			want: []string{"serviceaccount:testns:mysvcaccount"},
 		},
 		{
 			name: "ignores svcaccounts in group mode",


### PR DESCRIPTION
Reverts rancher/steve#539

With tokens being pulled out of 2.11, we can avoid doing QA work on that fix. We'll bring back an improved fix in 2.12.0 / 2.11.X.