### PR TITLE
Support filter/sort secrets by '_type'.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -87,6 +87,9 @@ var (
 			{"spec", "nodeName"}},
 		gvkKey("", "v1", "ReplicationController"): {
 			{"spec", "template", "spec", "containers", "image"}},
+		gvkKey("", "v1", "Secret"): {
+			{"_type"},
+		},
 		gvkKey("", "v1", "Service"): {
 			{"spec", "clusterIP"},
 			{"spec", "type"},


### PR DESCRIPTION
Related to [#42767](https://github.com/rancher/rancher/issues/42767)

In 2.11 this can be done by referring to `metadata.fields[1]`, as in

```
curl -skLg https://DOMAIN:PORT/v1/secrets'?filter=metadata.fields[1]=...
```

Similar with `sort`