### PR TITLE
Sort namespaces by the friendly name of the associated project.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -151,7 +151,9 @@ var (
 		gvkKey("management.cattle.io", "v3", "NodeTemplate"): {
 			{"spec", "clusterName"}},
 		gvkKey("management.cattle.io", "v3", "Project"): {
-			{"spec", "clusterName"}},
+			{"spec", "clusterName"},
+			{"spec", "displayName"},
+		},
 		gvkKey("networking.k8s.io", "v1", "Ingress"): {
 			{"spec", "rules", "host"},
 			{"spec", "ingressClassName"},


### PR DESCRIPTION
Related to [#48637](https://github.com/rancher/rancher/issues/48637)

So namespaces are linked to projects this way:

In a namespace object,
`metadata.labels[field.cattle.io/projectId]` => `p-XXX` - internal project name

Then basically do `select spec.displayName from management.cattle.io_v3_Project_fields where key == "p-XXX"`
to get the displayName.

*BUT*

- Some namespaces don't have this label. We still want to display them, but after all the namespaces that have one.

- And if `management.cattle.io.projects` hasn't been loaded into the sqlite database, the query will fail, trying to join a non-existent database. The check on `executeQuery` failing handles this case.