### PR TITLE
Avoid connections leak from aggregation API server

### DIFF
--- a/pkg/aggregation/server.go
+++ b/pkg/aggregation/server.go
@@ -85,6 +85,7 @@ func serve(ctx context.Context, dialer websocket.Dialer, url string, headers htt
 			return ctx
 		},
 	}
+	server.SetKeepAlivesEnabled(false) // avoid reusing connections, not supported by the in-memory listener
 	go server.Serve(listener)
 	defer server.Shutdown(context.Background())
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/49592

We use a `http.Server` backed by an in-memory listener to serve the aggregation API through remotedialer.
This in-memory implementation does not support reusing connections (its [`Accept` implementation](https://pkg.go.dev/net#Listener.Accepthttps://pkg.go.dev/net#Listener.Accept) only ever returns new connections from `net.Pipe`).
The simplest approach is to [completely disable keep-alives at the `http.Server` level](https://pkg.go.dev/net/http#Server.SetKeepAlivesEnabled).

(Note: this change only applies to this specific usage, since this mechanism uses a dedicated `http.Server`. Other `http.Server` also running by the process won't be affected at all)