### PR TITLE
Support quoting values in queries.

### DIFF
--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -259,26 +259,51 @@ func TestParseQuery(t *testing.T) {
 		},
 	})
 	tests = append(tests, testCase{
-		description: "ParseQuery() with filter param set, with value in double quotes should return an error.",
+		description: "ParseQuery() with filter param set, with value in double quotes.",
 		req: &types.APIRequest{
 			Request: &http.Request{
 				URL: &url.URL{RawQuery: `filter=a1="c1"`},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a1"},
 							Matches: []string{"c1"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
+				Page: 1,
+			},
+		},
+	})
+	tests = append(tests, testCase{
+		description: "ParseQuery() with filter param set, with value in single quotes.",
+		req: &types.APIRequest{
+			Request: &http.Request{
+				URL: &url.URL{RawQuery: "filter=a1b='c1b'"},
+			},
+		},
+		expectedLO: sqltypes.ListOptions{
+			ChunkSize: defaultLimit,
+			Filters: []sqltypes.OrFilter{
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"a1b"},
+							Matches: []string{"c1b"},
+							Op:      sqltypes.Eq,
+						},
+					},
+				},
+			},
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -265,7 +265,23 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: `filter=a1="c1"`},
 			},
 		},
-		errExpected: true,
+		expectedLO: informer.ListOptions{
+			ChunkSize: defaultLimit,
+			Filters: []informer.OrFilter{
+				{
+					Filters: []informer.Filter{
+						{
+							Field:   []string{"a1"},
+							Matches: []string{"c1"},
+							Op:      informer.Eq,
+						},
+					},
+				},
+			},
+			Pagination: informer.Pagination{
+				Page: 1,
+			},
+		},
 	})
 	tests = append(tests, testCase{
 		description: "ParseQuery() with a labels filter param should create a labels-specific filter.",

--- a/pkg/stores/sqlpartition/queryparser/selector.go
+++ b/pkg/stores/sqlpartition/queryparser/selector.go
@@ -22,7 +22,7 @@ https://github.com/kubernetes/apimachinery/blob/90df4d1d2d40ea9b3a522bec6e357723
 /**
 Main changes:
 
-1. The upstream `selector.go` file does parsing and applying to the objects being test.
+1. The upstream `selector.go` file does parsing and applying to the objects being tested.
 We only care about the parser, so the selection part is dropped.
 
 2. I dropped label value validation in the parser
@@ -469,6 +469,31 @@ IdentifierLoop:
 	return IdentifierToken, s // otherwise is an identifier
 }
 
+func (l *Lexer) scanQuotedString(delim byte) (tok Token, lit string) {
+	var buffer []byte
+	inEscape := false
+StringLoop:
+	for {
+		switch ch := l.read(); {
+		case ch == 0:
+			s := string(buffer)
+			if len(s) > 12 {
+				s = s[0:10] + "..."
+			}
+			return ErrorToken, fmt.Sprintf("unterminated string starting with '%s'", s)
+		case inEscape:
+			buffer = append(buffer, ch)
+			inEscape = false
+		case ch == delim:
+			// Don't include the end-delimiter
+			break StringLoop
+		default:
+			buffer = append(buffer, ch)
+		}
+	}
+	return QuotedStringToken, string(buffer)
+}
+
 // scanSpecialSymbol scans string starting with special symbol.
 // special symbol identify non literal operators. "!=", "==", "=", "!~"
 func (l *Lexer) scanSpecialSymbol() (Token, string) {
@@ -521,6 +546,8 @@ func (l *Lexer) Lex() (Token, string) {
 	case isIdentifierStartChar(ch):
 		l.unread()
 		return l.scanIDOrKeyword()
+	case ch == '"' || ch == '\'':
+		return l.scanQuotedString(ch)
 	default:
 		return ErrorToken, fmt.Sprintf("unexpected character '%c'", ch)
 	}

--- a/pkg/stores/sqlpartition/queryparser/selector.go
+++ b/pkg/stores/sqlpartition/queryparser/selector.go
@@ -484,6 +484,8 @@ StringLoop:
 		case inEscape:
 			buffer = append(buffer, ch)
 			inEscape = false
+		case ch == '\\':
+			inEscape = true
 		case ch == delim:
 			// Don't include the end-delimiter
 			break StringLoop

--- a/pkg/stores/sqlpartition/queryparser/selector_test.go
+++ b/pkg/stores/sqlpartition/queryparser/selector_test.go
@@ -57,6 +57,8 @@ func TestSelectorParse(t *testing.T) {
 		`metadata.labels[k8s.io/meta-stuff] ~ "m!a@t#c$h%e^v&e*r(y)t-_i=n+g)t{o[$]c}o]m|m\\a:;'<.>"`,
 		`x="double quotes ok"`,
 		`x='single quotes ok'`,
+		`x="double quotes with \\ and \" ok"`,
+		`x='single quotes with \\ and \' ok'`,
 	}
 	testBadStrings := []string{
 		"!no-label-absence-test",


### PR DESCRIPTION
Related to [#49802](https://github.com/rancher/rancher/issues/49802)

I assume the client (i.e. the dashboard) will quote any search strings that contain non-identifier characters.