### PR TITLE
Add support for modifying the created Factory clients

### DIFF
--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func TestWithQPSAndBurst(t *testing.T) {
+	fo := defaultFactoryOptions()
+
+	assert.Equal(t, defaultQPS, fo.qps)
+	assert.Equal(t, defaultBurst, fo.burst)
+
+	WithQPSAndBurst(50, 20)(fo)
+
+	assert.Equal(t, float32(50.0), fo.qps)
+	assert.Equal(t, 20, fo.burst)
+}
+
+func TestNewFactoryWithOptions(t *testing.T) {
+	cfg := &rest.Config{
+		QPS:   5.0,
+		Burst: 10,
+	}
+	f, err := NewFactory(cfg, false, WithQPSAndBurst(50, 20))
+	assert.NoError(t, err)
+
+	assert.Equal(t, float32(50.0), f.clientCfg.QPS)
+	assert.Equal(t, 20, f.clientCfg.Burst)
+}


### PR DESCRIPTION
This adds support for modifying the rest.Config used by the client factory.

Initial support for modifying the QPS/Burst values is provided.