### PR TITLE
Stop bumping helm.sh on release/v0.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,8 @@
   "baseBranches": [
     "master"
   ],
+  "packageRules": {
+    "matchPackageNames": ["helm.sh/helm/v3"]
+  },
   "prHourlyLimit": 2
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,8 +5,11 @@
   "baseBranches": [
     "master"
   ],
-  "packageRules": {
-    "matchPackageNames": ["helm.sh/helm/v3"]
-  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["helm.sh/helm/v3"],
+      "enabled": false
+    }
+  ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
Further versions of helm.sh will require golang 1.23, and r/r 2.8 => r/steve v0.2 uses golang 1.22