### PR TITLE
Sort-indirect PR broken into smaller parts: part 1/6 - put common types in their own package

### DIFF
--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rancher/steve/pkg/sqlcache/db"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	sqlStore "github.com/rancher/steve/pkg/sqlcache/store"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,7 +30,7 @@ type Informer struct {
 }
 
 type ByOptionsLister interface {
-	ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
+	ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 // this is set to a var so that it can be overridden by test code for mocking purposes
@@ -65,7 +66,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 	// copy of the known state of all objects (in an Indexer).
 	// The resync period option here is passed from Informer to Reflector to periodically (re)-push all known
 	// objects to the DeltaFIFO. That causes the periodic (re-)firing all registered handlers.
-	// In this case we are not registering any handlers to this particular informer, so re-syncing is a no-op.
+	// sqltypes.In this case we are not registering any handlers to this particular informer, so re-syncing is a no-op.
 	// We therefore just disable it right away.
 	resyncPeriod := time.Duration(0)
 
@@ -102,7 +103,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 //   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 //   - a continue token, if there are more pages after the returned one
 //   - an error instead of all of the above if anything went wrong
-func (i *Informer) ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
+func (i *Informer) ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
 	return i.ByOptionsLister.ListByOptions(ctx, lo, partitions, namespace)
 }
 

--- a/pkg/sqlcache/informer/informer_mocks_test.go
+++ b/pkg/sqlcache/informer/informer_mocks_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	partition "github.com/rancher/steve/pkg/sqlcache/partition"
+	sqltypes "github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	gomock "go.uber.org/mock/gomock"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -42,7 +43,7 @@ func (m *MockByOptionsLister) EXPECT() *MockByOptionsListerMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rancher/steve/pkg/sqlcache/db"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,7 +314,7 @@ func TestInformerListByOptions(t *testing.T) {
 		informer := &Informer{
 			ByOptionsLister: indexer,
 		}
-		lo := ListOptions{}
+		lo := sqltypes.ListOptions{}
 		var partitions []partition.Partition
 		ns := "somens"
 		expectedList := &unstructured.UnstructuredList{
@@ -336,7 +337,7 @@ func TestInformerListByOptions(t *testing.T) {
 		informer := &Informer{
 			ByOptionsLister: indexer,
 		}
-		lo := ListOptions{}
+		lo := sqltypes.ListOptions{}
 		var partitions []partition.Partition
 		ns := "somens"
 		indexer.EXPECT().ListByOptions(context.Background(), lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -1,4 +1,4 @@
-package informer
+package sqltypes
 
 type Op string
 
@@ -35,8 +35,8 @@ type ListOptions struct {
 // Filter represents a field to filter by.
 // A subfield in an object is represented in a request query using . notation, e.g. 'metadata.name'.
 // The subfield is internally represented as a slice, e.g. [metadata, name].
-// Complex subfields need to be expressed with square brackets, as in `metadata.labels[zombo.com/moose]`,
-// but are mapped to the string slice ["metadata", "labels", "zombo.com/moose"]
+// Complex subfields need to be expressed with square brackets, as in `metadata.labels[example.com/moose]`,
+// but are mapped to the string slice ["metadata", "labels", "example.com/moose"]
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
@@ -61,8 +61,18 @@ type Sort struct {
 	Orders []SortOrder
 }
 
+type SortList struct {
+	SortDirectives []Sort
+}
+
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
 	Page     int
+}
+
+func NewSortList() *SortList {
+	return &SortList{
+		SortDirectives: []Sort{},
+	}
 }

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/steve/pkg/sqlcache/informer"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,7 +23,7 @@ func TestParseQuery(t *testing.T) {
 		setupNSCache func() Cache
 		nsc          Cache
 		req          *types.APIRequest
-		expectedLO   informer.ListOptions
+		expectedLO   sqltypes.ListOptions
 		errExpected  bool
 		errorText    string
 	}
@@ -35,10 +35,10 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: ""},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -51,21 +51,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "namespace"},
 							Matches: []string{"ns1"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -82,19 +82,19 @@ func TestParseQuery(t *testing.T) {
 				},
 			}
 			nsc := NewMockCache(gomock.NewController(t))
-			nsc.EXPECT().ListByOptions(context.Background(), informer.ListOptions{
-				Filters: []informer.OrFilter{
+			nsc.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+				Filters: []sqltypes.OrFilter{
 					{
-						Filters: []informer.Filter{
+						Filters: []sqltypes.Filter{
 							{
 								Field:   []string{"metadata", "name"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 							{
 								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 						},
 					},
@@ -111,40 +111,40 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "namespace"},
 							Matches: []string{"ns1"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
 		errExpected: true,
 		setupNSCache: func() Cache {
 			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), informer.ListOptions{
-				Filters: []informer.OrFilter{
+			nsi.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+				Filters: []sqltypes.OrFilter{
 					{
-						Filters: []informer.Filter{
+						Filters: []sqltypes.Filter{
 							{
 								Field:   []string{"metadata", "name"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 							{
 								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 						},
 					},
@@ -161,21 +161,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "namespace"},
 							Matches: []string{"ns1"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -185,19 +185,19 @@ func TestParseQuery(t *testing.T) {
 				Items: []unstructured.Unstructured{},
 			}
 			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), informer.ListOptions{
-				Filters: []informer.OrFilter{
+			nsi.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+				Filters: []sqltypes.OrFilter{
 					{
-						Filters: []informer.Filter{
+						Filters: []sqltypes.Filter{
 							{
 								Field:   []string{"metadata", "name"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 							{
 								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
 								Matches: []string{"somethin"},
-								Op:      informer.Eq,
+								Op:      sqltypes.Eq,
 							},
 						},
 					},
@@ -213,21 +213,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a~c"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a"},
 							Matches: []string{"c"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: true,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -239,21 +239,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a=c"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a"},
 							Matches: []string{"c"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -274,21 +274,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=metadata.labels[grover.example.com/fish]~heads"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "labels", "grover.example.com/fish"},
 							Matches: []string{"heads"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: true,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -300,21 +300,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=metadata.annotations[chumley.example.com/fish]=seals"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "annotations", "chumley.example.com/fish"},
 							Matches: []string{"seals"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -326,20 +326,20 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=metadata.fields[3]<5"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "fields", "3"},
 							Matches: []string{"5"},
-							Op:      informer.Lt,
+							Op:      sqltypes.Lt,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -351,21 +351,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=metadata.labels[grover.example.com/fish]~heads"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "labels", "grover.example.com/fish"},
 							Matches: []string{"heads"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: true,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -377,31 +377,31 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a=c&filter=b=d"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a"},
 							Matches: []string{"c"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"b"},
 							Matches: []string{"d"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -413,31 +413,31 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a=c&filter=b=d"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a"},
 							Matches: []string{"c"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"b"},
 							Matches: []string{"d"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -449,27 +449,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=beer=pabst,metadata.labels[beer2.io/ale] ~schlitz"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"beer"},
 							Matches: []string{"pabst"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 						{
 							Field:   []string{"metadata", "labels", "beer2.io/ale"},
 							Matches: []string{"schlitz"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: true,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -481,27 +481,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=beer=natty-bo,metadata.labels.beer3~rainier"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"beer"},
 							Matches: []string{"natty-bo"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: false,
 						},
 						{
 							Field:   []string{"metadata", "labels", "beer3"},
 							Matches: []string{"rainier"},
-							Op:      informer.Eq,
+							Op:      sqltypes.Eq,
 							Partial: true,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -513,27 +513,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a1In in (x1),a2In IN (x2)"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a1In"},
 							Matches: []string{"x1"},
-							Op:      informer.In,
+							Op:      sqltypes.In,
 							Partial: false,
 						},
 						{
 							Field:   []string{"a2In"},
 							Matches: []string{"x2"},
-							Op:      informer.In,
+							Op:      sqltypes.In,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -545,21 +545,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a2In in (x2a, x2b)"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a2In"},
 							Matches: []string{"x2a", "x2b"},
-							Op:      informer.In,
+							Op:      sqltypes.In,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -571,27 +571,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a1NotIn notin (x1),a2NotIn NOTIN (x2)"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a1NotIn"},
 							Matches: []string{"x1"},
-							Op:      informer.NotIn,
+							Op:      sqltypes.NotIn,
 							Partial: false,
 						},
 						{
 							Field:   []string{"a2NotIn"},
 							Matches: []string{"x2"},
-							Op:      informer.NotIn,
+							Op:      sqltypes.NotIn,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -603,21 +603,21 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a3NotIn in (x3a, x3b)"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a3NotIn"},
 							Matches: []string{"x3a", "x3b"},
-							Op:      informer.In,
+							Op:      sqltypes.In,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -629,27 +629,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a4In iN (x4a),a4NotIn nOtIn (x4b)"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a4In"},
 							Matches: []string{"x4a"},
-							Op:      informer.In,
+							Op:      sqltypes.In,
 							Partial: false,
 						},
 						{
 							Field:   []string{"a4NotIn"},
 							Matches: []string{"x4b"},
-							Op:      informer.NotIn,
+							Op:      sqltypes.NotIn,
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -671,33 +671,33 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=metadata.labels.a5In1,!metadata.labels.a5In2, ! metadata.labels.a5In3"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"metadata", "labels", "a5In1"},
-							Op:      informer.Exists,
+							Op:      sqltypes.Exists,
 							Matches: []string{},
 							Partial: false,
 						},
 						{
 							Field:   []string{"metadata", "labels", "a5In2"},
-							Op:      informer.NotExists,
+							Op:      sqltypes.NotExists,
 							Matches: []string{},
 							Partial: false,
 						},
 						{
 							Field:   []string{"metadata", "labels", "a5In3"},
-							Op:      informer.NotExists,
+							Op:      sqltypes.NotExists,
 							Matches: []string{},
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -709,27 +709,27 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "filter=a<1,b>2"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters: []informer.OrFilter{
+			Filters: []sqltypes.OrFilter{
 				{
-					Filters: []informer.Filter{
+					Filters: []sqltypes.Filter{
 						{
 							Field:   []string{"a"},
-							Op:      informer.Lt,
+							Op:      sqltypes.Lt,
 							Matches: []string{"1"},
 							Partial: false,
 						},
 						{
 							Field:   []string{"b"},
-							Op:      informer.Gt,
+							Op:      sqltypes.Gt,
 							Matches: []string{"2"},
 							Partial: false,
 						},
 					},
 				},
 			},
-			Pagination: informer.Pagination{
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -742,15 +742,15 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "sort=metadata.name"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: informer.Sort{
+			Sort: sqltypes.Sort{
 				Fields: [][]string{
 					{"metadata", "name"}},
-				Orders: []informer.SortOrder{informer.ASC},
+				Orders: []sqltypes.SortOrder{sqltypes.ASC},
 			},
-			Filters: make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters: make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -763,14 +763,14 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "sort=-metadata.name"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: informer.Sort{
+			Sort: sqltypes.Sort{
 				Fields: [][]string{{"metadata", "name"}},
-				Orders: []informer.SortOrder{informer.DESC},
+				Orders: []sqltypes.SortOrder{sqltypes.DESC},
 			},
-			Filters: make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters: make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -783,20 +783,20 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "sort=-metadata.name,spec.something"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: informer.Sort{
+			Sort: sqltypes.Sort{
 				Fields: [][]string{
 					{"metadata", "name"},
 					{"spec", "something"},
 				},
-				Orders: []informer.SortOrder{
-					informer.DESC,
-					informer.ASC,
+				Orders: []sqltypes.SortOrder{
+					sqltypes.DESC,
+					sqltypes.ASC,
 				},
 			},
-			Filters: make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters: make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -809,17 +809,17 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "sort=-metadata.labels[beef.cattle.io/snort],metadata.labels.steer,metadata.labels[bossie.cattle.io/moo],spec.something"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: informer.Sort{
+			Sort: sqltypes.Sort{
 				Fields: [][]string{{"metadata", "labels", "beef.cattle.io/snort"},
 					{"metadata", "labels", "steer"},
 					{"metadata", "labels", "bossie.cattle.io/moo"},
 					{"spec", "something"}},
-				Orders: []informer.SortOrder{informer.DESC, informer.ASC, informer.ASC, informer.ASC},
+				Orders: []sqltypes.SortOrder{sqltypes.DESC, sqltypes.ASC, sqltypes.ASC, sqltypes.ASC},
 			},
-			Filters: make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters: make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -835,11 +835,11 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "continue=5"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
 			Resume:    "5",
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -852,11 +852,11 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "continue=5"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
 			Resume:    "5",
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -869,10 +869,10 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "limit=3"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: 3,
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
@@ -885,10 +885,10 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "page=3"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				Page: 3,
 			},
 		},
@@ -901,10 +901,10 @@ func TestParseQuery(t *testing.T) {
 				URL: &url.URL{RawQuery: "pagesize=20"},
 			},
 		},
-		expectedLO: informer.ListOptions{
+		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Filters:   make([]informer.OrFilter, 0),
-			Pagination: informer.Pagination{
+			Filters:   make([]sqltypes.OrFilter, 0),
+			Pagination: sqltypes.Pagination{
 				PageSize: 20,
 				Page:     1,
 			},

--- a/pkg/stores/sqlpartition/listprocessor/proxy_mocks_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/proxy_mocks_test.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	informer "github.com/rancher/steve/pkg/sqlcache/informer"
 	partition "github.com/rancher/steve/pkg/sqlcache/partition"
+	sqltypes "github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	gomock "go.uber.org/mock/gomock"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -43,7 +43,7 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockCache) ListByOptions(arg0 context.Context, arg1 informer.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockCache) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -14,9 +14,9 @@ import (
 	reflect "reflect"
 
 	types "github.com/rancher/apiserver/pkg/types"
-	informer "github.com/rancher/steve/pkg/sqlcache/informer"
 	factory "github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	partition "github.com/rancher/steve/pkg/sqlcache/partition"
+	sqltypes "github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	summary "github.com/rancher/wrangler/v3/pkg/summary"
 	gomock "go.uber.org/mock/gomock"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,7 +51,7 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockCache) ListByOptions(arg0 context.Context, arg1 informer.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockCache) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -36,6 +36,7 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/informer"
 	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/rancher/wrangler/v3/pkg/schemas"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
@@ -216,7 +217,7 @@ type Cache interface {
 	//   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 	//   - a continue token, if there are more pages after the returned one
 	//   - an error instead of all of the above if anything went wrong
-	ListByOptions(ctx context.Context, lo informer.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
+	ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 // WarningBuffer holds warnings that may be returned from the kubernetes api

--- a/pkg/stores/sqlproxy/sql_informer_mocks_test.go
+++ b/pkg/stores/sqlproxy/sql_informer_mocks_test.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	informer "github.com/rancher/steve/pkg/sqlcache/informer"
 	partition "github.com/rancher/steve/pkg/sqlcache/partition"
+	sqltypes "github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	gomock "go.uber.org/mock/gomock"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -43,7 +43,7 @@ func (m *MockByOptionsLister) EXPECT() *MockByOptionsListerMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 informer.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)


### PR DESCRIPTION
Related to [#49267](https://github.com/rancher/rancher/issues/49267)

The problem having these in the informer package is that eventually code in other packages will need to import `informer` only for constants or types, but some members of the informer package may already depend on those. Best to move type definitions into their own simpler package.

This is a replacement for PR 600 -- this is the first of at least 5 cascading PRs.

This one is large (+466 -450) but mechanical.  Moving types into its own `pkg/sqlcache/sqltypes/types.go` package.