### PR TITLE
Sort-indirect PR broken into smaller parts: part 2/6 - fix the Sort part of ListOptions

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"regexp"
 	"sort"
 	"strconv"

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"regexp"
 	"sort"
 	"strconv"
@@ -390,26 +389,24 @@ func (l *ListOptionIndexer) constructQuery(lo sqltypes.ListOptions, partitions [
 	countParams := params[:]
 
 	// 3- Sorting: ORDER BY clauses (from lo.Sort)
-	if len(lo.Sort.Fields) != len(lo.Sort.Orders) {
-		return nil, fmt.Errorf("sort fields length %d != sort orders length %d", len(lo.Sort.Fields), len(lo.Sort.Orders))
-	}
-	if len(lo.Sort.Fields) > 0 {
+	if len(lo.SortList.SortDirectives) > 0 {
 		orderByClauses := []string{}
-		for i, field := range lo.Sort.Fields {
-			if isLabelsFieldList(field) {
-				clause, sortParam, err := buildSortLabelsClause(field[2], joinTableIndexByLabelName, lo.Sort.Orders[i] == sqltypes.ASC)
+		for _, sortDirective := range lo.SortList.SortDirectives {
+			fields := sortDirective.Fields
+			if isLabelsFieldList(fields) {
+				clause, sortParam, err := buildSortLabelsClause(fields[2], joinTableIndexByLabelName, sortDirective.Order == sqltypes.ASC)
 				if err != nil {
 					return nil, err
 				}
 				orderByClauses = append(orderByClauses, clause)
 				params = append(params, sortParam)
 			} else {
-				columnName := toColumnName(field)
+				columnName := toColumnName(fields)
 				if err := l.validateColumn(columnName); err != nil {
 					return queryInfo, err
 				}
 				direction := "ASC"
-				if lo.Sort.Orders[i] == sqltypes.DESC {
+				if sortDirective.Order == sqltypes.DESC {
 					direction = "DESC"
 				}
 				orderByClauses = append(orderByClauses, fmt.Sprintf(`f."%s" %s`, columnName, direction))
@@ -597,13 +594,14 @@ func buildSortLabelsClause(labelName string, joinTableIndexByLabelName map[strin
 // created in Store.ListByPartitions, and that ends up calling ListOptionIndexer.ConstructQuery.
 // No other goroutines access this object.
 func ensureSortLabelsAreSelected(lo *sqltypes.ListOptions) {
-	if len(lo.Sort.Fields) == 0 {
+	if len(lo.SortList.SortDirectives) == 0 {
 		return
 	}
 	unboundSortLabels := make(map[string]bool)
-	for _, fieldList := range lo.Sort.Fields {
-		if isLabelsFieldList(fieldList) {
-			unboundSortLabels[fieldList[2]] = true
+	for _, sortDirective := range lo.SortList.SortDirectives {
+		fields := sortDirective.Fields
+		if isLabelsFieldList(fields) {
+			unboundSortLabels[fields[2]] = true
 		}
 	}
 	if len(unboundSortLabels) == 0 {

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -28,7 +28,7 @@ type ListOptions struct {
 	ChunkSize  int
 	Resume     string
 	Filters    []OrFilter
-	Sort       Sort
+	SortList   SortList
 	Pagination Pagination
 }
 
@@ -40,10 +40,10 @@ type ListOptions struct {
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
-	Field          []string
-	Matches        []string
-	Op             Op
-	Partial        bool
+	Field   []string
+	Matches []string
+	Op      Op
+	Partial bool
 }
 
 // OrFilter represents a set of possible fields to filter by, where an item may match any filter in the set to be included in the result.
@@ -57,8 +57,8 @@ type OrFilter struct {
 // The order is represented by prefixing the sort key by '-', e.g. sort=-metadata.name.
 // e.g. To sort internal clusters first followed by clusters in alpha order: sort=-spec.internal,spec.displayName
 type Sort struct {
-	Fields [][]string
-	Orders []SortOrder
+	Fields []string
+	Order  SortOrder
 }
 
 type SortList struct {
@@ -68,7 +68,7 @@ type SortList struct {
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
-	Page  int
+	Page     int
 }
 
 func NewSortList() *SortList {

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -76,9 +76,3 @@ func NewSortList() *SortList {
 		SortDirectives: []Sort{},
 	}
 }
-
-func NewSortList() *SortList {
-	return &SortList{
-		SortDirectives: []Sort{},
-	}
-}

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -40,10 +40,10 @@ type ListOptions struct {
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
-	Field   []string
-	Matches []string
-	Op      Op
-	Partial bool
+	Field          []string
+	Matches        []string
+	Op             Op
+	Partial        bool
 }
 
 // OrFilter represents a set of possible fields to filter by, where an item may match any filter in the set to be included in the result.
@@ -68,7 +68,13 @@ type SortList struct {
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
-	Page     int
+	Page  int
+}
+
+func NewSortList() *SortList {
+	return &SortList{
+		SortDirectives: []Sort{},
+	}
 }
 
 func NewSortList() *SortList {

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -744,10 +744,13 @@ func TestParseQuery(t *testing.T) {
 		},
 		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: sqltypes.Sort{
-				Fields: [][]string{
-					{"metadata", "name"}},
-				Orders: []sqltypes.SortOrder{sqltypes.ASC},
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "name"},
+						Order:  sqltypes.ASC,
+					},
+				},
 			},
 			Filters: make([]sqltypes.OrFilter, 0),
 			Pagination: sqltypes.Pagination{
@@ -765,9 +768,13 @@ func TestParseQuery(t *testing.T) {
 		},
 		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: sqltypes.Sort{
-				Fields: [][]string{{"metadata", "name"}},
-				Orders: []sqltypes.SortOrder{sqltypes.DESC},
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "name"},
+						Order:  sqltypes.DESC,
+					},
+				},
 			},
 			Filters: make([]sqltypes.OrFilter, 0),
 			Pagination: sqltypes.Pagination{
@@ -785,14 +792,16 @@ func TestParseQuery(t *testing.T) {
 		},
 		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: sqltypes.Sort{
-				Fields: [][]string{
-					{"metadata", "name"},
-					{"spec", "something"},
-				},
-				Orders: []sqltypes.SortOrder{
-					sqltypes.DESC,
-					sqltypes.ASC,
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "name"},
+						Order:  sqltypes.DESC,
+					},
+					{
+						Fields: []string{"spec", "something"},
+						Order:  sqltypes.ASC,
+					},
 				},
 			},
 			Filters: make([]sqltypes.OrFilter, 0),
@@ -811,12 +820,25 @@ func TestParseQuery(t *testing.T) {
 		},
 		expectedLO: sqltypes.ListOptions{
 			ChunkSize: defaultLimit,
-			Sort: sqltypes.Sort{
-				Fields: [][]string{{"metadata", "labels", "beef.cattle.io/snort"},
-					{"metadata", "labels", "steer"},
-					{"metadata", "labels", "bossie.cattle.io/moo"},
-					{"spec", "something"}},
-				Orders: []sqltypes.SortOrder{sqltypes.DESC, sqltypes.ASC, sqltypes.ASC, sqltypes.ASC},
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "labels", "beef.cattle.io/snort"},
+						Order:  sqltypes.DESC,
+					},
+					{
+						Fields: []string{"metadata", "labels", "steer"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields: []string{"metadata", "labels", "bossie.cattle.io/moo"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields: []string{"spec", "something"},
+						Order:  sqltypes.ASC,
+					},
+				},
 			},
 			Filters: make([]sqltypes.OrFilter, 0),
 			Pagination: sqltypes.Pagination{


### PR DESCRIPTION
# DO NOT MERGE (depends on PR #610 )

Related to [#49267](https://github.com/rancher/rancher/issues/49267)

This fixes the structure of `ListOptions.<SORT>` 

- Originally we hardwired a primary sort field and a secondary sort field -- this was awkward, as you could specify a secondary sort field with no primary sort field. And moving to SQL, we could support any number of sort fields.
- So I turned it into an array, but instead of implementing it as an array of Sort directives, I made it array-ish. This turned out to be awkward, so this PR fixes that.

