### PR TITLE
Sort-indirect PR broken into smaller parts: part 3/6 - pass listOptions by reference

### DIFF
--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -30,7 +30,7 @@ type Informer struct {
 }
 
 type ByOptionsLister interface {
-	ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
+	ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 // this is set to a var so that it can be overridden by test code for mocking purposes
@@ -66,7 +66,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 	// copy of the known state of all objects (in an Indexer).
 	// The resync period option here is passed from Informer to Reflector to periodically (re)-push all known
 	// objects to the DeltaFIFO. That causes the periodic (re-)firing all registered handlers.
-	// sqltypes.In this case we are not registering any handlers to this particular informer, so re-syncing is a no-op.
+	// In this case we are not registering any handlers to this particular informer, so re-syncing is a no-op.
 	// We therefore just disable it right away.
 	resyncPeriod := time.Duration(0)
 
@@ -103,7 +103,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 //   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 //   - a continue token, if there are more pages after the returned one
 //   - an error instead of all of the above if anything went wrong
-func (i *Informer) ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
+func (i *Informer) ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
 	return i.ByOptionsLister.ListByOptions(ctx, lo, partitions, namespace)
 }
 

--- a/pkg/sqlcache/informer/informer_mocks_test.go
+++ b/pkg/sqlcache/informer/informer_mocks_test.go
@@ -43,7 +43,7 @@ func (m *MockByOptionsLister) EXPECT() *MockByOptionsListerMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 *sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -325,8 +325,8 @@ func TestInformerListByOptions(t *testing.T) {
 		}
 		expectedTotal := len(expectedList.Items)
 		expectedContinueToken := "123"
-		indexer.EXPECT().ListByOptions(context.Background(), lo, partitions, ns).Return(expectedList, expectedTotal, expectedContinueToken, nil)
-		list, total, continueToken, err := informer.ListByOptions(context.Background(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.Background(), &lo, partitions, ns).Return(expectedList, expectedTotal, expectedContinueToken, nil)
+		list, total, continueToken, err := informer.ListByOptions(context.Background(), &lo, partitions, ns)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedList, list)
 		assert.Equal(t, len(expectedList.Items), total)
@@ -340,8 +340,8 @@ func TestInformerListByOptions(t *testing.T) {
 		lo := sqltypes.ListOptions{}
 		var partitions []partition.Partition
 		ns := "somens"
-		indexer.EXPECT().ListByOptions(context.Background(), lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))
-		_, _, _, err := informer.ListByOptions(context.Background(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.Background(), &lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))
+		_, _, _, err := informer.ListByOptions(context.Background(), &lo, partitions, ns)
 		assert.NotNil(t, err)
 	}})
 	t.Parallel()

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"regexp"
 	"sort"
 	"strconv"

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -248,7 +248,7 @@ func (l *ListOptionIndexer) deleteLabels(key string, tx transaction.Client) erro
 //   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 //   - a continue token, if there are more pages after the returned one
 //   - an error instead of all of the above if anything went wrong
-func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
+func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
 	queryInfo, err := l.constructQuery(lo, partitions, namespace, db.Sanitize(l.GetName()))
 	if err != nil {
 		return nil, 0, "", err
@@ -267,8 +267,8 @@ type QueryInfo struct {
 	offset      int
 }
 
-func (l *ListOptionIndexer) constructQuery(lo sqltypes.ListOptions, partitions []partition.Partition, namespace string, dbName string) (*QueryInfo, error) {
-	ensureSortLabelsAreSelected(&lo)
+func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string, dbName string) (*QueryInfo, error) {
+	ensureSortLabelsAreSelected(lo)
 	queryInfo := &QueryInfo{}
 	queryUsesLabels := hasLabelFilter(lo.Filters)
 	joinTableIndexByLabelName := make(map[string]int)

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"regexp"
 	"sort"
 	"strconv"

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -818,27 +818,6 @@ func TestListByOptions(t *testing.T) {
 	})
 
 	tests = append(tests, testCase{
-		description: "ListByOptions sorting when # fields != # sort orders should return an error",
-		listOptions: sqltypes.ListOptions{
-			Sort: sqltypes.Sort{
-				Fields: [][]string{{"metadata", "somefield"}, {"status", "someotherfield"}},
-				Orders: []sqltypes.SortOrder{sqltypes.DESC, sqltypes.ASC, sqltypes.ASC},
-			},
-		},
-		partitions: []partition.Partition{},
-		ns:         "",
-		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
-  JOIN "something_fields" f ON o.key = f.key
-  WHERE
-    (FALSE)
-  ORDER BY f."metadata.somefield" DESC, f."status.someotherfield" ASC`,
-		returnList:        []any{&unstructured.Unstructured{Object: unstrTestObjectMap}, &unstructured.Unstructured{Object: unstrTestObjectMap}},
-		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{unstrTestObjectMap, unstrTestObjectMap}}, Items: []unstructured.Unstructured{{Object: unstrTestObjectMap}, {Object: unstrTestObjectMap}}},
-		expectedContToken: "",
-		expectedErr:       fmt.Errorf("sort fields length 2 != sort orders length 3"),
-	})
-
-	tests = append(tests, testCase{
 		description: "ListByOptions with Pagination.PageSize set should set limit to PageSize in prepared sql.Stmt",
 		listOptions: sqltypes.ListOptions{
 			Pagination: sqltypes.Pagination{

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -818,6 +818,27 @@ func TestListByOptions(t *testing.T) {
 	})
 
 	tests = append(tests, testCase{
+		description: "ListByOptions sorting when # fields != # sort orders should return an error",
+		listOptions: sqltypes.ListOptions{
+			Sort: sqltypes.Sort{
+				Fields: [][]string{{"metadata", "somefield"}, {"status", "someotherfield"}},
+				Orders: []sqltypes.SortOrder{sqltypes.DESC, sqltypes.ASC, sqltypes.ASC},
+			},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  WHERE
+    (FALSE)
+  ORDER BY f."metadata.somefield" DESC, f."status.someotherfield" ASC`,
+		returnList:        []any{&unstructured.Unstructured{Object: unstrTestObjectMap}, &unstructured.Unstructured{Object: unstrTestObjectMap}},
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{unstrTestObjectMap, unstrTestObjectMap}}, Items: []unstructured.Unstructured{{Object: unstrTestObjectMap}, {Object: unstrTestObjectMap}}},
+		expectedContToken: "",
+		expectedErr:       fmt.Errorf("sort fields length 2 != sort orders length 3"),
+	})
+
+	tests = append(tests, testCase{
 		description: "ListByOptions with Pagination.PageSize set should set limit to PageSize in prepared sql.Stmt",
 		listOptions: sqltypes.ListOptions{
 			Pagination: sqltypes.Pagination{

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -978,7 +978,7 @@ func TestListByOptions(t *testing.T) {
 			if len(test.extraIndexedFields) > 0 {
 				lii.indexedFields = append(lii.indexedFields, test.extraIndexedFields...)
 			}
-			queryInfo, err := lii.constructQuery(test.listOptions, test.partitions, test.ns, "something")
+			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
 			if test.expectedErr != nil {
 				assert.Equal(t, test.expectedErr, err)
 				return
@@ -1667,7 +1667,7 @@ func TestConstructQuery(t *testing.T) {
 				Indexer:       i,
 				indexedFields: []string{"metadata.queryField1", "status.queryField2"},
 			}
-			queryInfo, err := lii.constructQuery(test.listOptions, test.partitions, test.ns, "something")
+			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
 			if test.expectedErr != nil {
 				assert.Equal(t, test.expectedErr, err)
 				return

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -284,7 +284,7 @@ func (i *IntegrationSuite) TestSQLCacheFilters() {
 			partitions := []partition.Partition{defaultPartition}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
-			cfgMaps, total, continueToken, err := cache.ListByOptions(ctx, options, partitions, testNamespace)
+			cfgMaps, total, continueToken, err := cache.ListByOptions(ctx, &options, partitions, testNamespace)
 			i.Require().NoError(err)
 			// since there's no additional pages, the continue token should be empty
 			i.Require().Equal("", continueToken)
@@ -338,7 +338,7 @@ func (i *IntegrationSuite) waitForCacheReady(readyResourceNames []string, namesp
 		partitions := []partition.Partition{defaultPartition}
 		cacheCtx, cacheCancel := context.WithTimeout(ctx, time.Second*5)
 		defer cacheCancel()
-		currentResources, total, _, err := cache.ListByOptions(cacheCtx, options, partitions, namespace)
+		currentResources, total, _, err := cache.ListByOptions(cacheCtx, &options, partitions, namespace)
 		if err != nil {
 			// note that we don't return the error since that would stop the polling
 			return false, nil

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -40,10 +40,10 @@ type ListOptions struct {
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
-	Field   []string
-	Matches []string
-	Op      Op
-	Partial bool
+	Field          []string
+	Matches        []string
+	Op             Op
+	Partial        bool
 }
 
 // OrFilter represents a set of possible fields to filter by, where an item may match any filter in the set to be included in the result.
@@ -65,10 +65,20 @@ type SortList struct {
 	SortDirectives []Sort
 }
 
+type SortList struct {
+	SortDirectives []Sort
+}
+
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
-	Page     int
+	Page  int
+}
+
+func NewSortList() *SortList {
+	return &SortList{
+		SortDirectives: []Sort{},
+	}
 }
 
 func NewSortList() *SortList {

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -40,10 +40,10 @@ type ListOptions struct {
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
-	Field          []string
-	Matches        []string
-	Op             Op
-	Partial        bool
+	Field   []string
+	Matches []string
+	Op      Op
+	Partial bool
 }
 
 // OrFilter represents a set of possible fields to filter by, where an item may match any filter in the set to be included in the result.
@@ -65,20 +65,10 @@ type SortList struct {
 	SortDirectives []Sort
 }
 
-type SortList struct {
-	SortDirectives []Sort
-}
-
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
-	Page  int
-}
-
-func NewSortList() *SortList {
-	return &SortList{
-		SortDirectives: []Sort{},
-	}
+	Page     int
 }
 
 func NewSortList() *SortList {

--- a/pkg/stores/sqlpartition/listprocessor/processor.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor.go
@@ -57,7 +57,7 @@ type Cache interface {
 	//   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 	//   - a continue token, if there are more pages after the returned one
 	//   - an error instead of all of the above if anything went wrong
-	ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
+	ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 func k8sOpToRancherOp(k8sOp selection.Operator) (sqltypes.Op, bool, error) {
@@ -202,7 +202,7 @@ func splitQuery(query string) []string {
 func parseNamespaceOrProjectFilters(ctx context.Context, projOrNS string, op sqltypes.Op, namespaceInformer Cache) ([]sqltypes.Filter, error) {
 	var filters []sqltypes.Filter
 	for _, pn := range strings.Split(projOrNS, ",") {
-		uList, _, _, err := namespaceInformer.ListByOptions(ctx, sqltypes.ListOptions{
+		uList, _, _, err := namespaceInformer.ListByOptions(ctx, &sqltypes.ListOptions{
 			Filters: []sqltypes.OrFilter{
 				{
 					Filters: []sqltypes.Filter{

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -82,7 +82,7 @@ func TestParseQuery(t *testing.T) {
 				},
 			}
 			nsc := NewMockCache(gomock.NewController(t))
-			nsc.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+			nsc.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
 				Filters: []sqltypes.OrFilter{
 					{
 						Filters: []sqltypes.Filter{
@@ -132,7 +132,7 @@ func TestParseQuery(t *testing.T) {
 		errExpected: true,
 		setupNSCache: func() Cache {
 			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+			nsi.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
 				Filters: []sqltypes.OrFilter{
 					{
 						Filters: []sqltypes.Filter{
@@ -185,7 +185,7 @@ func TestParseQuery(t *testing.T) {
 				Items: []unstructured.Unstructured{},
 			}
 			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), sqltypes.ListOptions{
+			nsi.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
 				Filters: []sqltypes.OrFilter{
 					{
 						Filters: []sqltypes.Filter{

--- a/pkg/stores/sqlpartition/listprocessor/proxy_mocks_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/proxy_mocks_test.go
@@ -43,7 +43,7 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockCache) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockCache) ListByOptions(arg0 context.Context, arg1 *sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -51,7 +51,7 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockCache) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockCache) ListByOptions(arg0 context.Context, arg1 *sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -217,7 +217,7 @@ type Cache interface {
 	//   - the total number of resources (returned list might be a subset depending on pagination options in lo)
 	//   - a continue token, if there are more pages after the returned one
 	//   - an error instead of all of the above if anything went wrong
-	ListByOptions(ctx context.Context, lo sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
+	ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 // WarningBuffer holds warnings that may be returned from the kubernetes api
@@ -784,7 +784,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, schema *types.APISchem
 		return nil, 0, "", err
 	}
 
-	list, total, continueToken, err := inf.ListByOptions(apiOp.Context(), opts, partitions, apiOp.Namespace)
+	list, total, continueToken, err := inf.ListByOptions(apiOp.Context(), &opts, partitions, apiOp.Namespace)
 	if err != nil {
 		if errors.Is(err, informer.ErrInvalidColumn) {
 			return nil, 0, "", apierror.NewAPIError(validation.InvalidBodyContent, err.Error())

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -244,7 +244,7 @@ func TestListByPartitions(t *testing.T) {
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(c, nil)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema)).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
-			bloi.EXPECT().ListByOptions(req.Context(), opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
+			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
 			list, total, contToken, err := s.ListByPartitions(req, schema, partitions)
 			assert.Nil(t, err)
 			assert.Equal(t, expectedItems, list)
@@ -461,7 +461,7 @@ func TestListByPartitions(t *testing.T) {
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), false).Return(c, nil)
 
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema)).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
-			bloi.EXPECT().ListByOptions(req.Context(), opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
+			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
 			list, total, contToken, err := s.ListByPartitions(req, schema, partitions)
 			assert.Nil(t, err)
 			assert.Equal(t, expectedItems, list)
@@ -610,7 +610,7 @@ func TestListByPartitions(t *testing.T) {
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(c, nil)
-			bloi.EXPECT().ListByOptions(req.Context(), opts, partitions, req.Namespace).Return(nil, 0, "", fmt.Errorf("error"))
+			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(nil, 0, "", fmt.Errorf("error"))
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema)).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 
 			_, _, _, err = s.ListByPartitions(req, schema, partitions)

--- a/pkg/stores/sqlproxy/sql_informer_mocks_test.go
+++ b/pkg/stores/sqlproxy/sql_informer_mocks_test.go
@@ -43,7 +43,7 @@ func (m *MockByOptionsLister) EXPECT() *MockByOptionsListerMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
+func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 *sqltypes.ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)


### PR DESCRIPTION
# DO NOT MERGE (depends on PR #611 )

Related to [#49267](https://github.com/rancher/rancher/issues/49267)

The `ListOptions` structure gets passed to a lot of functions (with more on the way),
so pass it by reference instead of making copies.