### PR TITLE
Sort-indirect PR broken into smaller parts: part 4/6 - parse the indirect operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/golang/protobuf v1.5.4
 	github.com/google/gnostic-models v0.6.9
-	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/pborman/uuid v1.2.1
@@ -80,6 +79,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -65,10 +65,20 @@ type SortList struct {
 	SortDirectives []Sort
 }
 
+type SortList struct {
+	SortDirectives []Sort
+}
+
 // Pagination represents how to return paginated results.
 type Pagination struct {
 	PageSize int
 	Page     int
+}
+
+func NewSortList() *SortList {
+	return &SortList{
+		SortDirectives: []Sort{},
+	}
 }
 
 func NewSortList() *SortList {

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -40,10 +40,12 @@ type ListOptions struct {
 //
 // If more than one value is given for the `Match` field, we do an "IN (<values>)" test
 type Filter struct {
-	Field   []string
-	Matches []string
-	Op      Op
-	Partial bool
+	Field          []string
+	Matches        []string
+	Op             Op
+	Partial        bool
+	IsIndirect     bool
+	IndirectFields []string
 }
 
 // OrFilter represents a set of possible fields to filter by, where an item may match any filter in the set to be included in the result.
@@ -57,12 +59,10 @@ type OrFilter struct {
 // The order is represented by prefixing the sort key by '-', e.g. sort=-metadata.name.
 // e.g. To sort internal clusters first followed by clusters in alpha order: sort=-spec.internal,spec.displayName
 type Sort struct {
-	Fields []string
-	Order  SortOrder
-}
-
-type SortList struct {
-	SortDirectives []Sort
+	Fields         []string
+	Order          SortOrder
+	IsIndirect     bool
+	IndirectFields []string
 }
 
 type SortList struct {
@@ -73,12 +73,6 @@ type SortList struct {
 type Pagination struct {
 	PageSize int
 	Page     int
-}
-
-func NewSortList() *SortList {
-	return &SortList{
-		SortDirectives: []Sort{},
-	}
 }
 
 func NewSortList() *SortList {

--- a/pkg/stores/sqlpartition/listprocessor/processor.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor.go
@@ -73,11 +73,14 @@ func k8sRequirementToOrFilter(requirement queryparser.Requirement) (sqltypes.Fil
 	values := requirement.Values()
 	queryFields := splitQuery(requirement.Key())
 	op, usePartialMatch, err := k8sOpToRancherOp(requirement.Operator())
+	isIndirect, indirectFields := requirement.IndirectInfo()
 	return sqltypes.Filter{
-		Field:   queryFields,
-		Matches: values,
-		Op:      op,
-		Partial: usePartialMatch,
+		Field:          queryFields,
+		Matches:        values,
+		Op:             op,
+		Partial:        usePartialMatch,
+		IsIndirect:     isIndirect,
+		IndirectFields: indirectFields,
 	}, err
 }
 

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -371,6 +371,33 @@ func TestParseQuery(t *testing.T) {
 		},
 	})
 	tests = append(tests, testCase{
+		description: "ParseQuery() with an indirect labels filter param should create an indirect labels-specific filter.",
+		req: &types.APIRequest{
+			Request: &http.Request{
+				URL: &url.URL{RawQuery: "filter=metadata.labels[grover.example.com/fish]=>[_v1][Foods][foodCode][country]=japan"},
+			},
+		},
+		expectedLO: sqltypes.ListOptions{
+			ChunkSize: defaultLimit,
+			Filters: []sqltypes.OrFilter{
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:          []string{"metadata", "labels", "grover.example.com/fish"},
+							Matches:        []string{"japan"},
+							Op:             sqltypes.Eq,
+							IsIndirect:     true,
+							IndirectFields: []string{"_v1", "Foods", "foodCode", "country"},
+						},
+					},
+				},
+			},
+			Pagination: sqltypes.Pagination{
+				Page: 1,
+			},
+		},
+	})
+	tests = append(tests, testCase{
 		description: "ParseQuery() with multiple filter params, should include multiple or filters.",
 		req: &types.APIRequest{
 			Request: &http.Request{

--- a/pkg/stores/sqlpartition/queryparser/selector.go
+++ b/pkg/stores/sqlpartition/queryparser/selector.go
@@ -39,6 +39,9 @@ the array into a sql statement. So the set gives us no benefit apart from removi
 6.  We allow `lt` and `gt` as aliases for `<` and `>`.
 
 7. We added the '~' and '!~' operators to indicate partial match and non-match
+
+8. We added indirect field selection so we can base a filter or sort off a related value
+  (could be in a different table)
 */
 
 package queryparser
@@ -70,6 +73,7 @@ var (
 		string(selection.Equals), string(selection.DoubleEquals), string(selection.NotEquals),
 		string(selection.PartialEquals), string(selection.NotPartialEquals),
 		string(selection.GreaterThan), string(selection.LessThan),
+		string(selection.IndirectSelector),
 	}
 	validRequirementOperators = append(binaryOperators, unaryOperators...)
 	labelSelectorRegex        = regexp.MustCompile(`^metadata.labels(?:\.\w[-a-zA-Z0-9_./]*|\[.*])$`)
@@ -135,7 +139,9 @@ type Requirement struct {
 	// In huge majority of cases we have at most one value here.
 	// It is generally faster to operate on a single-element slice
 	// than on a single-element map, so we have a slice here.
-	strValues []string
+	strValues      []string
+	isIndirect     bool
+	indirectFields []string
 }
 
 // NewRequirement is the constructor for a Requirement.
@@ -183,7 +189,26 @@ func NewRequirement(key string, op selection.Operator, vals []string, opts ...fi
 	default:
 		allErrs = append(allErrs, field.NotSupported(path.Child("operator"), op, validRequirementOperators))
 	}
-	return &Requirement{key: key, operator: op, strValues: vals}, allErrs.ToAggregate()
+	agg := allErrs.ToAggregate()
+	var err error
+	if agg != nil {
+		err = errors.New(agg.Error())
+	}
+	return &Requirement{key: key, operator: op, strValues: vals}, err
+}
+
+func NewIndirectRequirement(key string, indirectFields []string, newOperator *selection.Operator, targetValues []string, opts ...field.PathOption) (*Requirement, error) {
+	if newOperator == nil {
+		operator := selection.Exists
+		newOperator = &operator
+	}
+	r, err := NewRequirement(key, *newOperator, targetValues)
+	if err != nil {
+		return nil, err
+	}
+	r.isIndirect = true
+	r.indirectFields = indirectFields
+	return r, nil
 }
 
 func (r *Requirement) hasValue(value string) bool {
@@ -212,6 +237,10 @@ func (r *Requirement) Values() []string {
 		ret.Insert(r.strValues[i])
 	}
 	return ret.List()
+}
+
+func (r *Requirement) IndirectInfo() (bool, []string) {
+	return r.isIndirect, r.indirectFields
 }
 
 // Equal checks the equality of requirement.
@@ -377,6 +406,8 @@ const (
 	NotPartialEqualsToken
 	// OpenParToken represents open parenthesis
 	OpenParToken
+	// IndirectAccessToken is =>, used to associate one table with a related one, and grab a different field
+	IndirectAccessToken
 )
 
 // string2token contains the mapping between lexer Token and token literal
@@ -395,6 +426,7 @@ var string2token = map[string]Token{
 	"!~":    NotPartialEqualsToken,
 	"notin": NotInToken,
 	"(":     OpenParToken,
+	"=>":    IndirectAccessToken,
 }
 
 // ScannedItem contains the Token and the literal produced by the lexer.
@@ -405,7 +437,7 @@ type ScannedItem struct {
 
 func isIdentifierStartChar(ch byte) bool {
 	r := rune(ch)
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || ch == '_'
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || ch == '_' || ch == '[' || ch == '-'
 }
 
 // isWhitespace returns true if the rune is a space, tab, or newline.
@@ -531,6 +563,7 @@ type Parser struct {
 	l            *Lexer
 	scannedItems []ScannedItem
 	position     int
+	parseType    string
 	path         *field.Path
 }
 
@@ -624,13 +657,18 @@ func (p *Parser) parseRequirement() (*Requirement, error) {
 	if err != nil {
 		return nil, err
 	}
+	fieldPath := field.WithPath(p.path)
 	if operator == selection.Exists || operator == selection.DoesNotExist { // operator found lookahead set checked
-		if !labelSelectorRegex.MatchString(key) {
+		if p.parseType == "filter" && !labelSelectorRegex.MatchString(key) {
 			return nil, fmt.Errorf("existence tests are valid only for labels; not valid for field '%s'", key)
 		}
-		return NewRequirement(key, operator, []string{}, field.WithPath(p.path))
+		return NewRequirement(key, operator, []string{}, fieldPath)
 	}
-	operator, err = p.parseOperator()
+	return p.parseOperatorAndValues(key, fieldPath, true)
+}
+
+func (p *Parser) parseOperatorAndValues(key string, fieldPath field.PathOption, allowIndirectSelector bool) (*Requirement, error) {
+	operator, err := p.parseOperator()
 	if err != nil {
 		return nil, err
 	}
@@ -640,12 +678,22 @@ func (p *Parser) parseRequirement() (*Requirement, error) {
 		values, err = p.parseValues()
 	case selection.Equals, selection.DoubleEquals, selection.NotEquals, selection.GreaterThan, selection.LessThan, selection.PartialEquals, selection.NotPartialEquals:
 		values, err = p.parseSingleValue()
+	case selection.IndirectSelector:
+		if !allowIndirectSelector {
+			return nil, fmt.Errorf("found a subsequent indirect selector (->)")
+		}
+		indirectFields, newOperator, targetValues, err := p.parseIndirectAccessorPart(key, fieldPath)
+		if err != nil {
+			return nil, err
+		} else if newOperator != nil && p.parseType == "sort" {
+			return nil, fmt.Errorf("found an operator (%s) in a sort expression )", *newOperator)
+		}
+		return NewIndirectRequirement(key, indirectFields, newOperator, targetValues.List(), fieldPath)
 	}
 	if err != nil {
 		return nil, err
 	}
 	return NewRequirement(key, operator, values.List(), field.WithPath(p.path))
-
 }
 
 // parseKeyAndInferOperator parses literals.
@@ -694,11 +742,15 @@ func (p *Parser) parseOperator() (op selection.Operator, err error) {
 		op = selection.NotEquals
 	case NotPartialEqualsToken:
 		op = selection.NotPartialEquals
+	case IndirectAccessToken:
+		op = selection.IndirectSelector
 	default:
 		if lit == "lt" {
 			op = selection.LessThan
 		} else if lit == "gt" {
 			op = selection.GreaterThan
+		} else if p.parseType == "sort" {
+			return "", fmt.Errorf("found unexpected token '%s' in sort parameter", lit)
 		} else {
 			return "", fmt.Errorf("found '%s', expected: %v", lit, strings.Join(binaryOperators, ", "))
 		}
@@ -727,8 +779,36 @@ func (p *Parser) parseValues() (sets.String, error) {
 		p.consume(Values)
 		return sets.NewString(""), nil
 	default:
-		return nil, fmt.Errorf("found '%s', expected: ',', ')' or identifier", lit)
+		return sets.NewString(""), fmt.Errorf("found '%s', expected: ',', ')' or identifier", lit)
 	}
+}
+
+func (p *Parser) parseIndirectAccessorPart(key string, fieldPath field.PathOption) ([]string, *selection.Operator, sets.String, error) {
+	//key string, indirectFields []string, newOperator selection.Operator, targetValues []string
+	values := sets.String{}
+	tok, lit := p.consume(Values)
+	if tok != IdentifierToken {
+		return nil, nil, values, fmt.Errorf("found '%s', expected: an indirect field specifier", lit)
+	}
+	matched, err := regexp.MatchString(`^(?:\[.*?\])+$`, lit)
+	if err != nil {
+		return nil, nil, values, err
+	} else if !matched {
+		return nil, nil, values, fmt.Errorf("found '%s', expected: a sequence of bracketed identifiers", lit)
+	}
+
+	indirectFields := strings.Split(lit[1:len(lit)-1], "][")
+	if len(indirectFields) != 4 {
+		return nil, nil, values, fmt.Errorf("found '%s', expected: a sequence of three bracketed identifiers", lit)
+	}
+	if p.parseType == "sort" {
+		return indirectFields, nil, sets.NewString(), nil
+	}
+	r, err := p.parseOperatorAndValues(key, fieldPath, false)
+	if err != nil {
+		return nil, nil, values, err
+	}
+	return indirectFields, &r.operator, sets.NewString(r.strValues...), nil
 }
 
 // parseIdentifiersList parses a (possibly empty) list of
@@ -814,9 +894,9 @@ func (p *Parser) parseSingleValue() (sets.String, error) {
 //  4. A requirement with just a KEY - as in "y" above - denotes that
 //     the KEY exists and can be any VALUE.
 //  5. A requirement with just !KEY requires that the KEY not exist.
-func Parse(selector string, opts ...field.PathOption) (Selector, error) {
+func Parse(selector string, parseType string, opts ...field.PathOption) (Selector, error) {
 	pathThing := field.ToPath(opts...)
-	parsedSelector, err := parse(selector, pathThing)
+	parsedSelector, err := parse(selector, parseType, pathThing)
 	if err == nil {
 		return parsedSelector, nil
 	}
@@ -827,8 +907,8 @@ func Parse(selector string, opts ...field.PathOption) (Selector, error) {
 // The callers of this method can then decide how to return the internalSelector struct to their
 // callers. This function has two callers now, one returns a Selector interface and the other
 // returns a list of requirements.
-func parse(selector string, path *field.Path) (internalSelector, error) {
-	p := &Parser{l: &Lexer{s: selector, pos: 0}, path: path}
+func parse(selector string, parseType string, path *field.Path) (internalSelector, error) {
+	p := &Parser{l: &Lexer{s: selector, pos: 0}, parseType: parseType, path: path}
 	items, err := p.parse()
 	if err != nil {
 		return nil, err
@@ -883,8 +963,8 @@ func SelectorFromValidatedSet(ls Set) Selector {
 // processing on selector requirements.
 // See the documentation for Parse() function for more details.
 // TODO: Consider exporting the internalSelector type instead.
-func ParseToRequirements(selector string, opts ...field.PathOption) ([]Requirement, error) {
-	return parse(selector, field.ToPath(opts...))
+func ParseToRequirements(selector string, parseType string, opts ...field.PathOption) ([]Requirement, error) {
+	return parse(selector, parseType, field.ToPath(opts...))
 }
 
 // ValidatedSetSelector wraps a Set, allowing it to implement the Selector interface. Unlike

--- a/pkg/stores/sqlpartition/selection/operator.go
+++ b/pkg/stores/sqlpartition/selection/operator.go
@@ -38,4 +38,5 @@ const (
 	Exists           Operator = "exists"
 	GreaterThan      Operator = "gt"
 	LessThan         Operator = "lt"
+	IndirectSelector Operator = "=>"
 )


### PR DESCRIPTION
Related to [#49267](https://github.com/rancher/rancher/issues/49267)

The syntax is like `filter=metadata.labels.foo => [_v1][Namespace][id][name] OP some-value` or
`sort=metadata.labels.foo => [_v1][Namespace][id][name]`

The general syntax to the right of the `=>` operator is `[APIVERSION][Kind][field to match the left side of the operator][field on that matched row to use]`