### PR TITLE
Generate SQL for searching in explicit arrays - part 1/4 (est) - generate SQL when we have a `Contains` op

### DIFF
--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -9,6 +9,7 @@ const (
 	NotExists Op = "NotExists"
 	In        Op = "In"
 	NotIn     Op = "NotIn"
+	Contains  Op = "Contains"
 	Lt        Op = "Lt"
 	Gt        Op = "Gt"
 )


### PR DESCRIPTION
The syntax will be `FIELD CONTAINS STRING`.

`FIELD` can either be a shorthand for `FIELD[1], FIELD[2], etc...` and we're looking for the row
where one of those values can be our search-string `STRING`.

Or `FIELD` can be a string representing a string array where the values are separated by or-bars (`"|"`)
and we want the row where one of those parts is `STRING`. We do this search by surrounding both
the `FIELD` and `STRING` with or-bars and looking for a substring match. This handles matching at
the start or end of `FIELD` as well as internally.