### PR TITLE
Generate SQL for searching in explicit arrays - part 2/4 (est) - generate SQL when we have a Contains op on labels

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -776,11 +776,10 @@ func (l *ListOptionIndexer) getLabelFilter(index int, filter sqltypes.Filter, db
 		if len(filter.Matches) != 1 {
 			return "", nil, fmt.Errorf("array checking works on exactly one field, %d were specified", len(filter.Matches))
 		}
-		clause := fmt.Sprintf(`(lt%d.label = ?) AND
-    (INSTR(CONCAT("|", lt%d.value, "|"), CONCAT("|", ?, "|")) > 0 OR
-    (INSTR("|", ?) > 0 AND INSTR(lt%d.value, ?) > 0))`,
-			index, index, index)
-		params := []any{labelName, filter.Matches[0], filter.Matches[0], filter.Matches[0]}
+		clause := fmt.Sprintf(`lt%d.label = ? AND
+    INSTR(CONCAT("|", lt%d.value, "|"), CONCAT("|", ?, "|")) > 0`,
+			index, index)
+		params := []any{labelName, filter.Matches[0]}
 		return clause, params, nil
 
 	case sqltypes.NotEq:

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -744,9 +744,8 @@ func (l *ListOptionIndexer) getSimpleFieldArrayFilter(filter sqltypes.Filter, co
 		return "", nil, err
 	}
 	needle := filter.Matches[0]
-	clause := fmt.Sprintf(`INSTR(CONCAT("|", f."%s", "|"), CONCAT("|", ?, "|")) > 0 OR
-     (INSTR("|", ?) > 0 AND INSTR(f."%s", ?) > 0)`, columnName, columnName)
-	matches := []any{needle, needle, needle}
+	clause := fmt.Sprintf(`INSTR(CONCAT("|", f."%s", "|"), CONCAT("|", ?, "|")) > 0`, columnName)
+	matches := []any{needle}
 	return clause, matches, nil
 }
 

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -546,6 +546,12 @@ func (l *ListOptionIndexer) buildORClauseFromFilters(orFilters sqltypes.OrFilter
 	var err error
 
 	for _, filter := range orFilters.Filters {
+		op := filter.Op
+		if op != sqltypes.Exists && op != sqltypes.NotExists {
+			if len(filter.Matches) == 0 {
+				return "", nil, fmt.Errorf("no target value given for %s %s", smartJoin(filter.Field), op)
+			}
+		}
 		if isLabelFilter(&filter) {
 			index, ok := joinTableIndexByLabelName[filter.Field[2]]
 			if !ok {
@@ -976,7 +982,7 @@ func extractSubFields(fields string) []string {
 }
 
 func isLabelFilter(f *sqltypes.Filter) bool {
-	return len(f.Field) >= 2 && f.Field[0] == "metadata" && f.Field[1] == "labels"
+	return len(f.Field) == 3 && f.Field[0] == "metadata" && f.Field[1] == "labels"
 }
 
 func hasLabelFilter(filters []sqltypes.OrFilter) bool {

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -766,6 +766,17 @@ func (l *ListOptionIndexer) getLabelFilter(index int, filter sqltypes.Filter, db
 		clause := fmt.Sprintf(`lt%d.label = ? AND lt%d.value %s ?%s`, index, index, opString, escapeString)
 		return clause, []any{labelName, formatMatchTargetWithFormatter(filter.Matches[0], matchFmtToUse)}, nil
 
+	case sqltypes.Contains:
+		if len(filter.Matches) != 1 {
+			return "", nil, fmt.Errorf("array checking works on exactly one field, %d were specified", len(filter.Matches))
+		}
+		clause := fmt.Sprintf(`(lt%d.label = ?) AND
+    (INSTR(CONCAT("|", lt%d.value, "|"), CONCAT("|", ?, "|")) > 0 OR
+    (INSTR("|", ?) > 0 AND INSTR(lt%d.value, ?) > 0))`,
+			index, index, index)
+		params := []any{labelName, filter.Matches[0], filter.Matches[0], filter.Matches[0]}
+		return clause, params, nil
+
 	case sqltypes.NotEq:
 		if filter.Partial {
 			opString = "NOT LIKE"

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -719,7 +719,7 @@ func (l *ListOptionIndexer) getFieldFilter(filter sqltypes.Filter) (string, []an
 }
 
 func (l *ListOptionIndexer) getFieldArrayFilter(filter sqltypes.Filter, columnName string) (string, []any, error) {
-	if len(filter.Matches) > 1 {
+	if len(filter.Matches) != 1 {
 		return "", nil, fmt.Errorf("array checking works on exactly one field, %d were specified", len(filter.Matches))
 	}
 	// Allow for a weird case where we can have both

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1739,7 +1739,7 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
-    (? IN (f.metadata.fields[1], f.metadata.fields[2], f.metadata.fields[3])) AND
+    (? IN (f.metadata.fields[1], f.metadata.fields[2], f.metadata.fields[3], f.metadata.fields[5])) AND
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
 		expectedStmtArgs: []any{"needle01"},
@@ -1832,9 +1832,6 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 			lii := &ListOptionIndexer{
 				Indexer:       i,
 				indexedFields: []string{"metadata.queryField1", "status.queryField2", "metadata.fields[1]", "metadata.fields[2]", "metadata.fields[3]", "metadata.fields[5]"},
-			}
-			if test.expectedErr == "glub3" {
-				fmt.Println("stop here")
 			}
 			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
 			if test.expectedErr != "" {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1763,11 +1763,10 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
-    (INSTR(CONCAT("|", f."metadata.queryField1", "|"), CONCAT("|", ?, "|")) > 0 OR
-     (INSTR("|", ?) > 0 AND INSTR(f."metadata.queryField1", ?) > 0)) AND
+    (INSTR(CONCAT("|", f."metadata.queryField1", "|"), CONCAT("|", ?, "|")) > 0) AND
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
-		expectedStmtArgs: []any{"needle02", "needle02", "needle02"},
+		expectedStmtArgs: []any{"needle02"},
 	})
 	tests = append(tests, testCase{
 		description: "TestConstructQuery: error CONTAIN statements on too many target strings",

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1738,8 +1738,8 @@ func TestConstructQueryErrors(t *testing.T) {
 			{
 				[]sqltypes.Filter{
 					{
-						Field:   []string{"metadata", "queryField1"},
-						Op:      sqltypes.Eq,
+						Field: []string{"metadata", "queryField1"},
+						Op:    sqltypes.Eq,
 					},
 				},
 			},
@@ -1943,12 +1943,11 @@ func TestConstructQueryWithLabelContainsOp(t *testing.T) {
   JOIN "something_fields" f ON o.key = f.key
   LEFT OUTER JOIN "something_labels" lt1 ON o.key = lt1.key
   WHERE
-    ((lt1.label = ?) AND
-    (INSTR(CONCAT("|", lt1.value, "|"), CONCAT("|", ?, "|")) > 0 OR
-    (INSTR("|", ?) > 0 AND INSTR(lt1.value, ?) > 0))) AND
+    (lt1.label = ? AND
+    INSTR(CONCAT("|", lt1.value, "|"), CONCAT("|", ?, "|")) > 0) AND
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
-		expectedStmtArgs: []any{"labelContains01", "needle03a", "needle03a", "needle03a"},
+		expectedStmtArgs: []any{"labelContains01", "needle03a"},
 	})
 	tests = append(tests, testCase{
 		description: "TestConstructQueryWithLabelContainsOp: error CONTAIN statements on too many target strings",

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1815,7 +1815,6 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 			},
 		},
 		},
-		//partitions: []partition.Partition{},
 		ns:          "",
 		expectedErr: "array checking works on exactly one field, 0 were specified",
 	})

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1782,7 +1782,6 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 			},
 		},
 		},
-		//partitions: []partition.Partition{},
 		ns:          "",
 		expectedErr: "array checking works on exactly one field, 3 were specified",
 	})
@@ -1800,7 +1799,6 @@ func TestConstructQueryWithContainsOp(t *testing.T) {
 			},
 		},
 		},
-		//partitions: []partition.Partition{},
 		ns:          "",
 		expectedErr: "column is invalid [bills.farm]: supplied column is invalid",
 	})

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -9,6 +9,7 @@ const (
 	NotExists Op = "NotExists"
 	In        Op = "In"
 	NotIn     Op = "NotIn"
+	Contains  Op = "Contains"
 	Lt        Op = "Lt"
 	Gt        Op = "Gt"
 )


### PR DESCRIPTION
## DO NOT MERGE

Depends on PR [#626](https://github.com/rancher/steve/pull/626)

Related to  [#49116](https://github.com/rancher/rancher/issues/49116)

Code gen for labels is slightly different than for non-label fields. Note also that we never assume there are array-like
labels with names `foo[1]`, `foo[2]`, etc.. Unlike internal fields, we don't know the names of the label fields in advance. So we only do `|`-split strings as arrays.