### PR TITLE
Tweak array-indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Example, filtering by object name:
 /v1/{type}?filter=metadata.name=foo
 ```
 
-if a target value is surrounded by single-quotes, it succeeds only on an exact match:
+When SQLite caching is not enabled, matching works this way:
+
+If a target value is surrounded by single-quotes, it succeeds only on an exact match:
 
 Example, filtering by object name:
 
@@ -132,6 +134,11 @@ Example, filtering by object name:
 ```
 /v1/{type}?filter=metadata.name="can-be-a-substri"
 ```
+
+When SQLite caching is enabled, there are different operators.  `FIELD = VALUE` does exact matching,
+`FIELD ~ VALUE` does partial matching. You can use quotes around `VALUE` to delimit it; if it contains
+only alphanumeric characters and characters that aren't significant in filters (like '=', ',', etc.),
+they don't need to be quoted.
 
 One filter can list multiple possible fields to match, these are ORed together:
 
@@ -159,6 +166,10 @@ item is included in the list.
 ```
 /v1/{type}?filter=spec.containers.image=alpine
 ```
+
+When SQLite caching is enabled, multiple values are stored separated by "or-bars" (`|`),
+like `abc|def|ghi`. You'll need to use the partial-match operator `~` to match one member,
+like `/v1/{type}?filter=spec.containers.image ~ ghi`.
 
 **If SQLite caching is enabled** (`server.Options.SQLCache=true`),
 filtering is only supported for a subset of attributes:

--- a/README.md
+++ b/README.md
@@ -135,10 +135,72 @@ Example, filtering by object name:
 /v1/{type}?filter=metadata.name="can-be-a-substri"
 ```
 
-When SQLite caching is enabled, there are different operators.  `FIELD = VALUE` does exact matching,
-`FIELD ~ VALUE` does partial matching. You can use quotes around `VALUE` to delimit it; if it contains
-only alphanumeric characters and characters that aren't significant in filters (like '=', ',', etc.),
-they don't need to be quoted.
+When SQLite caching is enabled, equality is slightly different from non-sql-supported matching.
+Equality can be specified with either one or two '=' signs.
+
+The following matches objects called either 'cat' or 'cows':
+
+```
+filter=metadata.name=cat,metadata.name==cows
+```
+
+The following matches objects whose names contain either the substring 'cat' or 'cows':
+
+```
+filter=metadata.name~cat,metadata.name~cows
+```
+
+For example, this will match an object with `metadata.name=cowcatcher`
+
+Set membership is done with the `in` operator:
+
+```
+filter=metadata.name in (cat, cows)
+```
+
+When called via `http` the spaces will need to be encoded either as `+` or `%20`.
+
+There are negative forms of the above operators:
+
+```
+filter=metadata.name!=dog  # no dogs allowed
+filter=metadata.name!~x    # skip any names containing an 'x'
+filter=metadata.name notin (goldfish, silverfish) # ignore these
+```
+
+Labels can be tested with the implicit "EXISTS" operator:
+
+```
+filter=metadata.labels[cattle.io.fences/wooden]
+```
+
+This will select any objects that have the specified label.  Negate this test by
+preceding it with a `!`:
+
+```
+filter=!metadata.labels[cattle.io.fences/bamboo]
+```
+
+Existence tests only work for `metadata.labels`.
+
+If you need to do a numeric computation, you can use the `<` and `>` operators.
+
+```
+filter=metadata.fields[3]>10&metadata.fields[3]<20
+```
+
+This is specific to a particular kind of Kubernetes object.
+
+Finally, most values need to conform to specific syntaxes. But if the VALUE in an
+expression contains unusual characters, you can quote the value with either single
+or double quotes:
+
+```
+filter=metadata.name="oxford,metadata.labels.comma"
+```
+
+Without the quotes, the expression would be finding either objects called `oxford`,
+or that have the label "comma", which is very different from objects called `oxford,metadata.labels.comma`.
 
 One filter can list multiple possible fields to match, these are ORed together:
 

--- a/pkg/sqlcache/Readme.md
+++ b/pkg/sqlcache/Readme.md
@@ -27,8 +27,8 @@ ListOptions includes the following:
 * Match filters for indexed fields. Filters are for specifying the value a given field in an object should be in order to
 be included in the list. Filters can be set to equals or not equals. Filters can be set to look for partial matches or
 exact (strict) matches. Filters can be OR'd and AND'd with one another. Filters only work on fields that have been indexed.
-* Primary field and secondary field sorting order. Can choose up to two fields to sort on. Sort order can be ascending
-or descending. Default sorting is to sort on metadata.namespace in ascending first and then sort on metadata.name.
+* Sort order can be ascending
+or descending. Default sorting is to sort on metadata.namespace in ascending first and then sort on metadata.name. There can be any number of sort directives, comma-separated in a single `sort=` directive. Put a minus sign (`-`) before a field to sort DESC on that field (e.g. `sort=-metadata.namespace,metadata.name` sorts on the namespaces in descending order, and the names within each namespace in default ascending order).
 * Page size to specify how many items to include in a response.
 * Page number to specify offset. For example, a page size of 50 and a page number of 2, will return items starting at
 index 50. Index will be dependent on sort. Page numbers start at 1.
@@ -95,12 +95,13 @@ intended to be used as a way of enforcing RBAC.
 ## Technical Information
 
 ### SQL Tables
-There are three tables that are created for the ListOption informer:
+There are four tables that are created for the ListOption informer:
 * object table - this contains objects, including all their fields, as blobs. These blobs may be encrypted.
 * fields table - this contains specific fields of value for objects. These are specified on informer create and are fields
 that it is desired to filter or order on.
 * indices table - the indices table stores indexes created and objects' values for each index. This backs the generic indexer
 that contains the functionality needed to conform to cache.Indexer.
+*  labels table - stores any labels created for each object.
 
 ### SQLite Driver
 There are multiple SQLite drivers that this package could have used. One of the most, if not the most, popular SQLite golang
@@ -136,17 +137,12 @@ have the following indexes by default:
 
 ### ListOptions Behavior
 Defaults:
-* Sort.PrimaryField: `metadata.namespace`
-* Sort.SecondaryField: `metadata.name`
-* Sort.PrimaryOrder: `ASC` (ascending)
-* Sort.SecondaryOrder: `ASC` (ascending)
+* Sort `metadata.namespace,metadata.name` (both ASC)
 * All filters have partial matching set to false by default
 
 There are some uncommon ways someone could use ListOptions where it would be difficult to predict what the result would be.
 Below is a non-exhaustive list of some of these cases and what the behavior is:
 * Setting Pagination.Page but not Pagination.PageSize will cause Page to be ignored
-* Setting Sort.SecondaryField only will sort as though it was Sort.PrimaryField. Sort.SecondaryOrder will still be applied
-and Sort.PrimaryOrder will be ignored
 
 ### Writing Secure Queries
 Values should be supplied to SQL queries using placeholders, read [Avoiding SQL Injection Risk](https://go.dev/doc/database/sql-injection). Any other portions

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -57,7 +57,7 @@ const (
 	   )`
 	createFieldsIndexFmt = `CREATE INDEX "%s_%s_index" ON "%s_fields"("%s")`
 
-	failedToGetFromSliceFmt = "[listoption indexer] failed to get subfield [%s] from slice items: %w"
+	failedToGetFromSliceFmt = "[listoption indexer] failed to get subfield [%s] from slice items"
 
 	createLabelsTableFmt = `CREATE TABLE IF NOT EXISTS "%s_labels" (
 		key TEXT NOT NULL REFERENCES "%s"(key) ON DELETE CASCADE,
@@ -904,11 +904,11 @@ func getField(a any, field string) (any, error) {
 				for _, v := range t {
 					itemVal, ok := v.(map[string]interface{})
 					if !ok {
-						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
+						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField)
 					}
 					itemStr, ok := itemVal[subField].(string)
 					if !ok {
-						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
+						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField)
 					}
 					_, ok = resultMap[itemStr]
 					if !ok {

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -898,9 +898,10 @@ func getField(a any, field string) (any, error) {
 				}
 				obj = fmt.Sprintf("%v", t[key])
 			} else if i == len(subFields)-1 {
-				// If the last layer is an array, return array.map(a => a[subfield])
-				result := make([]string, len(t))
-				for index, v := range t {
+				// If the last layer is an array, return array.map(a => a[subfield]).uniq
+				result := make([]string, 0, len(t))
+				resultMap := make(map[string]bool)
+				for _, v := range t {
 					itemVal, ok := v.(map[string]interface{})
 					if !ok {
 						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
@@ -909,7 +910,11 @@ func getField(a any, field string) (any, error) {
 					if !ok {
 						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
 					}
-					result[index] = itemStr
+					_, ok = resultMap[itemStr]
+					if !ok {
+						result = append(result, itemStr)
+						resultMap[itemStr] = true
+					}
 				}
 				return result, nil
 			}


### PR DESCRIPTION
# DO NOT MERGE

From discussion with Richard Cox we don't want the feature where a test like `metadata.fields == SOME-VALUE" will match any entry in `metadata.fields[0]`, `metadata.fields[1]`, `metadata.fields[2]`. For example, if you have an object where `metadata.fields = [true, false]` then both tests `metadata.fields == true` and `metadata.fields == false` will select that row, but that might select the row based on the wrong member of the `metadata.fields` array (giving a literal false positive if you're searching for `true` with `metadata.fields[1]` in mind, not `[0]`.

I think I'll move the updated README to a separate PR and close this issue.

Related to [#49116](https://github.com/rancher/rancher/issues/49116)

Updating the main steve readme to reflect the state of Sqlite-based caching and searching

I also updated a bit of code to avoid storing duplicate values when mapping multi-value string arrays
to a single string field in the database (the values are separated by "|", a character that isn't allowed
in the fields we index).