### PR TITLE
Fix returning error for empty ingresses.spec.rules.host

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -905,11 +905,17 @@ func getField(a any, field string) (any, error) {
 					if !ok {
 						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
 					}
-					itemStr, ok := itemVal[subField].(string)
-					if !ok {
-						return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
+
+					_, found := itemVal[subField]
+					if found {
+						itemStr, ok := itemVal[subField].(string)
+						if !ok {
+							return nil, fmt.Errorf(failedToGetFromSliceFmt, subField, err)
+						}
+						result[index] = itemStr
+					} else {
+						result[index] = ""
 					}
-					result[index] = itemStr
 				}
 				return result, nil
 			}

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1790,3 +1790,163 @@ func TestBuildSortLabelsClause(t *testing.T) {
 		})
 	}
 }
+
+func TestGetField(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            any
+		field          string
+		expectedResult any
+		expectedErr    bool
+	}{
+		{
+			name: "simple",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"foo": "bar",
+				},
+			},
+			field:          "foo",
+			expectedResult: "bar",
+		},
+		{
+			name: "nested",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"foo": map[string]any{
+						"bar": "baz",
+					},
+				},
+			},
+			field:          "foo.bar",
+			expectedResult: "baz",
+		},
+		{
+			name: "array",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"theList": []any{
+						"foo", "bar", "baz",
+					},
+				},
+			},
+			field:          "theList[1]",
+			expectedResult: "bar",
+		},
+		{
+			name: "array of object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"theList": []any{
+						map[string]any{
+							"name": "foo",
+						},
+						map[string]any{
+							"name": "bar",
+						},
+						map[string]any{
+							"name": "baz",
+						},
+					},
+				},
+			},
+			field:          "theList.name",
+			expectedResult: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "annotation",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"annotations": map[string]any{
+						"with.dot.in.it/and-slash": "foo",
+					},
+				},
+			},
+			field:          "annotations[with.dot.in.it/and-slash]",
+			expectedResult: "foo",
+		},
+		{
+			name: "field not found",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"rules": []any{
+							map[string]any{},
+							map[string]any{
+								"host": "example.com",
+							},
+						},
+					},
+				},
+			},
+			field:          "spec.rules.host",
+			expectedResult: []string{"", "example.com"},
+		},
+		{
+			name: "array index invalid",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"theList": []any{
+						"foo", "bar", "baz",
+					},
+				},
+			},
+			field:       "theList[a]",
+			expectedErr: true,
+		},
+		{
+			name: "array index out of bound",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"theList": []any{
+						"foo", "bar", "baz",
+					},
+				},
+			},
+			field:       "theList[3]",
+			expectedErr: true,
+		},
+		{
+			name: "invalid array",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"rules": []any{
+							1,
+						},
+					},
+				},
+			},
+			field:       "spec.rules.host",
+			expectedErr: true,
+		},
+		{
+			name: "invalid array nested",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"rules": []any{
+							map[string]any{
+								"host": 1,
+							},
+						},
+					},
+				},
+			},
+			field:       "spec.rules.host",
+			expectedErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := getField(test.obj, test.field)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/50309

Basically, for an ingress like this:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: aaa
spec:
  rules:
  - 
```
with no "host" defined (yeah..) we weren't able to insert it in the DB so the UI isn't able to fetch it either.