### PR TITLE
Calculate AccessSets once per request instead of per resource

### DIFF
--- a/pkg/accesscontrol/access_control.go
+++ b/pkg/accesscontrol/access_control.go
@@ -55,6 +55,9 @@ func SetAccessSetAttribute(schemas *types.APISchemas, accessSet *AccessSet) {
 }
 
 func AccessSetFromAPIRequest(req *types.APIRequest) *AccessSet {
+	if req == nil || req.Schemas == nil {
+		return nil
+	}
 	if v, ok := req.Schemas.Attributes[accessSetAttribute]; ok {
 		return v.(*AccessSet)
 	}

--- a/pkg/accesscontrol/access_control.go
+++ b/pkg/accesscontrol/access_control.go
@@ -28,7 +28,7 @@ func (a *AccessControl) CanDo(apiOp *types.APIRequest, resource, verb, namespace
 	}
 	group, resource := kv.Split(resource, "/")
 	accessSet := AccessSetFromAPIRequest(apiOp)
-	if accessSet.Grants(verb, schema.GroupResource{
+	if accessSet != nil && accessSet.Grants(verb, schema.GroupResource{
 		Group:    group,
 		Resource: resource,
 	}, namespace, name) {

--- a/pkg/accesscontrol/access_control.go
+++ b/pkg/accesscontrol/access_control.go
@@ -47,6 +47,7 @@ func (a *AccessControl) CanWatch(apiOp *types.APIRequest, schema *types.APISchem
 	return a.SchemaBasedAccess.CanWatch(apiOp, schema)
 }
 
+// SetAccessSetAttribute stores the provided accessSet using a predefined attribute
 func SetAccessSetAttribute(schemas *types.APISchemas, accessSet *AccessSet) {
 	if schemas.Attributes == nil {
 		schemas.Attributes = map[string]interface{}{}
@@ -54,6 +55,8 @@ func SetAccessSetAttribute(schemas *types.APISchemas, accessSet *AccessSet) {
 	schemas.Attributes[accessSetAttribute] = accessSet
 }
 
+// AccessSetFromAPIRequest retrieves an AccessSet from the APIRequest Schemas attributes, if defined.
+// This attribute must have been previously set by using SetAccessSetAttribute
 func AccessSetFromAPIRequest(req *types.APIRequest) *AccessSet {
 	if req == nil || req.Schemas == nil {
 		return nil

--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -181,8 +181,9 @@ func (p *policyRuleIndex) getRoleBindings(subjectName string) []*rbacv1.RoleBind
 
 // getRoleRefs gathers rules from roles granted to a given subject through RoleBindings and ClusterRoleBindings
 func (p *policyRuleIndex) getRoleRefs(subjectName string) subjectGrants {
-	var clusterRoleBindings []roleRef
-	for _, crb := range p.getClusterRoleBindings(subjectName) {
+	crbs := p.getClusterRoleBindings(subjectName)
+	clusterRoleBindings := make([]roleRef, 0, len(crbs))
+	for _, crb := range crbs {
 		rules, resourceVersion := p.getRules(All, crb.RoleRef)
 		clusterRoleBindings = append(clusterRoleBindings, roleRef{
 			roleName:        crb.RoleRef.Name,
@@ -192,8 +193,9 @@ func (p *policyRuleIndex) getRoleRefs(subjectName string) subjectGrants {
 		})
 	}
 
-	var roleBindings []roleRef
-	for _, rb := range p.getRoleBindings(subjectName) {
+	rbs := p.getRoleBindings(subjectName)
+	roleBindings := make([]roleRef, 0, len(rbs))
+	for _, rb := range rbs {
 		rules, resourceVersion := p.getRules(rb.Namespace, rb.RoleRef)
 		roleBindings = append(roleBindings, roleRef{
 			roleName:        rb.RoleRef.Name,

--- a/pkg/accesscontrol/policy_rule_index.go
+++ b/pkg/accesscontrol/policy_rule_index.go
@@ -182,28 +182,28 @@ func (p *policyRuleIndex) getRoleBindings(subjectName string) []*rbacv1.RoleBind
 // getRoleRefs gathers rules from roles granted to a given subject through RoleBindings and ClusterRoleBindings
 func (p *policyRuleIndex) getRoleRefs(subjectName string) subjectGrants {
 	crbs := p.getClusterRoleBindings(subjectName)
-	clusterRoleBindings := make([]roleRef, 0, len(crbs))
-	for _, crb := range crbs {
+	clusterRoleBindings := make([]roleRef, len(crbs))
+	for x, crb := range crbs {
 		rules, resourceVersion := p.getRules(All, crb.RoleRef)
-		clusterRoleBindings = append(clusterRoleBindings, roleRef{
+		clusterRoleBindings[x] = roleRef{
 			roleName:        crb.RoleRef.Name,
 			resourceVersion: resourceVersion,
 			rules:           rules,
 			kind:            clusterRoleKind,
-		})
+		}
 	}
 
 	rbs := p.getRoleBindings(subjectName)
-	roleBindings := make([]roleRef, 0, len(rbs))
-	for _, rb := range rbs {
+	roleBindings := make([]roleRef, len(rbs))
+	for x, rb := range rbs {
 		rules, resourceVersion := p.getRules(rb.Namespace, rb.RoleRef)
-		roleBindings = append(roleBindings, roleRef{
+		roleBindings[x] = roleRef{
 			roleName:        rb.RoleRef.Name,
 			namespace:       rb.Namespace,
 			resourceVersion: resourceVersion,
 			rules:           rules,
 			kind:            roleKind,
-		})
+		}
 	}
 
 	return subjectGrants{

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -102,9 +102,12 @@ func formatter(summarycache common.SummaryCache, asl accesscontrol.AccessSetLook
 		if !ok {
 			return
 		}
-		accessSet := asl.AccessFor(userInfo)
+		accessSet := accesscontrol.AccessSetFromAPIRequest(request)
 		if accessSet == nil {
-			return
+			accessSet = asl.AccessFor(userInfo)
+			if accessSet == nil {
+				return
+			}
 		}
 		hasUpdate := accessSet.Grants("update", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())
 		hasDelete := accessSet.Grants("delete", gvr.GroupResource(), resource.APIObject.Namespace(), resource.APIObject.Name())

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -171,9 +171,7 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 		}
 	}
 
-	result.Attributes = map[string]interface{}{
-		"accessSet": access,
-	}
+	accesscontrol.SetAccessSetAttribute(result, access)
 	return result, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/50484

# Analysis

As mentioned in the parent issue, we used a new Rancher 2.11.2 installation to create 500 Projects (3 member users and 2 namespaces on each), using a single user (the default admin), which resulted in this user being referenced by ~4000 RoleBinding resources (both within the Projects' top-level and child namespaces).

We started observing up to 17s response times, just listing namespaces under `/v1/namespaces`.
CPU profiling showed a considerable amount of the time was spent calculating `AccessSet` for the user, especially listing RoleBindings (as they were much more numerous compared to ClusterRoleBindings), followed by GC:
![Screenshot 2025-05-29 at 17 35 42](https://github.com/user-attachments/assets/cc2b9345-448e-48ba-aad8-fdd5d4297cbb)

Adding some debug logs and attaching a debugger I realized it was not a matter of that code being resource intensive, but `AccessFor(user)` was being called >1500 times for every single request, which then makes the problem obvious, as the caller is a Formatter, meaning that the accessSet is being calculated for every single object being printed.

# Solution
Since a request-level AccessSet is already being calculated while processing the Schemas, and stored as attribute, I changed the formatter to use that if available (falling back to the previous behavior otherwise)

# Result

Speedup is really noticeable just by browsing through the UI. The diagnostic package shows approximately x15 speedup in response times:
 - Before:
![Screenshot 2025-05-29 at 16 26 16](https://github.com/user-attachments/assets/c9f056d4-596e-4698-a5a2-13b05f7a87de)
 - After:
![Screenshot 2025-05-29 at 16 29 04](https://github.com/user-attachments/assets/edc1fb66-4b3e-43bf-b07a-32a102dc704d)
