### PR TITLE
Add vai access-control for ext Tokens and Kubeconfigs

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -770,19 +770,18 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 			// restrict access
 			user, ok := request.UserFrom(apiOp.Request.Context())
 			if !ok {
-				logrus.Debugf("Failed to get user info")
-			} else {
-				username := user.GetName()
-				opts.Filters = append(opts.Filters, sqltypes.OrFilter{
-					Filters: []sqltypes.Filter{
-						{
-							Field:   []string{"metadata", "labels", "cattle.io/userId"},
-							Matches: []string{username},
-							Op:      sqltypes.Eq,
-						},
-					},
-				})
+				return nil, 0, "", errors.New("failed to get user info from the request.Context object")
 			}
+			username := user.GetName()
+			opts.Filters = append(opts.Filters, sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "labels", "cattle.io/userId"},
+						Matches: []string{username},
+						Op:      sqltypes.Eq,
+					},
+				},
+			})
 		}
 	}
 

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -776,7 +776,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 			opts.Filters = append(opts.Filters, sqltypes.OrFilter{
 				Filters: []sqltypes.Filter{
 					{
-						Field:   []string{"metadata", "labels", "cattle.io/userId"},
+						Field:   []string{"metadata", "labels", "cattle.io/user-id"},
 						Matches: []string{username},
 						Op:      sqltypes.Eq,
 					},

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -762,7 +762,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 	if err != nil {
 		return nil, 0, "", err
 	}
-	if gvk.Group == "ext.cattle.io" && gvk.Kind == "Token" {
+	if gvk.Group == "ext.cattle.io" && (gvk.Kind == "Token" || gvk.Kind == "Kubeconfig") {
 		// TODO: Check AccessSetAuthorizer
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
 		if accessSet == nil || !accessSet.Grants("list", schema.GroupResource{

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -763,7 +763,6 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		return nil, 0, "", err
 	}
 	if gvk.Group == "ext.cattle.io" && (gvk.Kind == "Token" || gvk.Kind == "Kubeconfig") {
-		// TODO: Check AccessSetAuthorizer
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
 		if accessSet == nil || !accessSet.Grants("list", schema.GroupResource{
 			Resource: "*",

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -764,6 +764,8 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 	}
 	if gvk.Group == "ext.cattle.io" && (gvk.Kind == "Token" || gvk.Kind == "Kubeconfig") {
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
+		// See https://github.com/rancher/rancher/blob/7266e5e624f0d610c76ab0af33e30f5b72e11f61/pkg/ext/stores/tokens/tokens.go#L1186C2-L1195C3
+		// for similar code on how we determine if a user is admin
 		if accessSet == nil || !accessSet.Grants("list", schema.GroupResource{
 			Resource: "*",
 		}, "", "") {

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -628,132 +628,69 @@ func TestListByPartitions(t *testing.T) {
 
 func TestListByPartitionWithUserAccess(t *testing.T) {
 	type testCase struct {
-		description string
-		test        func(t *testing.T)
+		description     string
+		accessSetSetter func(accessSet *accesscontrol.AccessSet)
+		orFilters       []sqltypes.OrFilter
 	}
 	var tests []testCase
 	tests = append(tests, testCase{
-		description: "client ListByPartitions(), with a specified user for a restricted resource should filter for that user",
-		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
-			cg := NewMockClientGetter(gomock.NewController(t))
-			cf := NewMockCacheFactory(gomock.NewController(t))
-			ri := NewMockResourceInterface(gomock.NewController(t))
-			bloi := NewMockByOptionsLister(gomock.NewController(t))
-			tb := NewMockTransformBuilder(gomock.NewController(t))
-			inf := &informer.Informer{
-				ByOptionsLister: bloi,
-			}
-			c := factory.Cache{
-				ByOptionsLister: inf,
-			}
-			s := &Store{
-				ctx:              context.Background(),
-				namespaceCache:   nsi,
-				clientGetter:     cg,
-				cacheFactory:     cf,
-				transformBuilder: tb,
-			}
-			var partitions []partition.Partition
-			username := "flip"
-			targetGroup := "ext.cattle.io"
-			targetKind := "Token"
-			accessSet := &accesscontrol.AccessSet{ID: username}
-			accessSet.Add("list",
-				schema2.GroupResource{Group: targetGroup, Resource: "token"},
-				accesscontrol.Access{Namespace: accesscontrol.All, ResourceName: "token"},
-			)
-			apiOpSchemas := &types.APISchemas{}
-			accesscontrol.SetAccessSetAttribute(apiOpSchemas, accessSet)
-			theRequest := &http.Request{
-				URL: &url.URL{},
-			}
-			userInfo := user.DefaultInfo{Name: username, UID: "Id"}
-			requestWithContext := krequest.WithUser(context.Background(), &userInfo)
-			theRequest = theRequest.WithContext(requestWithContext)
-			apiOp := &types.APIRequest{
-				Request: theRequest,
-				Schemas: apiOpSchemas,
-			}
-			theSchema := &types.APISchema{
-				Schema: &schemas.Schema{Attributes: map[string]interface{}{
-					"columns": []common.ColumnDefinition{
-						{
-							Field: "some.field",
-						},
-					},
-					"verbs": []string{"list", "watch"},
-				}},
-			}
-			gvk := schema2.GroupVersionKind{
-				Group: targetGroup,
-				Kind:  targetKind,
-			}
-			opts := &sqltypes.ListOptions{
-				Filters: []sqltypes.OrFilter{
+		description:     "client ListByPartitions(), with a specified user for a restricted resource should filter for that user",
+		accessSetSetter: func(accessSet *accesscontrol.AccessSet) {},
+		orFilters: []sqltypes.OrFilter{
+			{
+				Filters: []sqltypes.Filter{
 					{
-						Filters: []sqltypes.Filter{
-							{
-								Field:   []string{"metadata", "labels", "cattle.io/user-id"},
-								Matches: []string{"flip"},
-								Op:      sqltypes.Eq,
-							},
-						},
+						Field:   []string{"metadata", "labels", "cattle.io/user-id"},
+						Matches: []string{"flip"},
+						Op:      sqltypes.Eq,
 					},
 				},
-				Pagination: sqltypes.Pagination{
-					Page: 1,
-				},
-			}
-			attributes.SetGVK(theSchema, gvk)
-			cg.EXPECT().TableAdminClient(apiOp, theSchema, "", &WarningBuffer{}).Return(ri, nil)
-			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {"id"}, {"metadata", "state", "name"}}, gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(theSchema), attributes.Namespaced(theSchema), true).Return(c, nil)
-			tb.EXPECT().GetTransformFunc(attributes.GVK(theSchema)).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
-
-			listToReturn := &unstructured.UnstructuredList{
-				Items: make([]unstructured.Unstructured, 0, 0),
-			}
-			bloi.EXPECT().ListByOptions(apiOp.Context(), opts, partitions, "").Return(listToReturn, len(listToReturn.Items), "", nil)
-			_, _, _, err := s.ListByPartitions(apiOp, theSchema, partitions)
-			assert.Nil(t, err)
+			},
 		},
 	})
 	tests = append(tests, testCase{
 		description: "client ListByPartitions(), with an admin user for a restricted resource will return all items regardless of user",
-		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
-			cg := NewMockClientGetter(gomock.NewController(t))
-			cf := NewMockCacheFactory(gomock.NewController(t))
-			ri := NewMockResourceInterface(gomock.NewController(t))
-			bloi := NewMockByOptionsLister(gomock.NewController(t))
-			tb := NewMockTransformBuilder(gomock.NewController(t))
-			inf := &informer.Informer{
-				ByOptionsLister: bloi,
-			}
-			c := factory.Cache{
-				ByOptionsLister: inf,
-			}
-			s := &Store{
-				ctx:              context.Background(),
-				namespaceCache:   nsi,
-				clientGetter:     cg,
-				cacheFactory:     cf,
-				transformBuilder: tb,
-			}
-			var partitions []partition.Partition
-			username := "flip"
-			targetGroup := "ext.cattle.io"
-			targetKind := "Token"
-			accessSet := &accesscontrol.AccessSet{ID: username}
-			accessSet.Add("list",
-				schema2.GroupResource{Group: targetGroup, Resource: "token"},
-				accesscontrol.Access{Namespace: accesscontrol.All, ResourceName: "token"},
-			)
+		accessSetSetter: func(accessSet *accesscontrol.AccessSet) {
 			// admins also get this access-set
 			accessSet.Add("list",
 				schema2.GroupResource{Group: accesscontrol.All, Resource: accesscontrol.All},
 				accesscontrol.Access{Namespace: accesscontrol.All, ResourceName: accesscontrol.All},
 			)
+		},
+		orFilters: []sqltypes.OrFilter{},
+	})
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			nsi := NewMockCache(gomock.NewController(t))
+			cg := NewMockClientGetter(gomock.NewController(t))
+			cf := NewMockCacheFactory(gomock.NewController(t))
+			ri := NewMockResourceInterface(gomock.NewController(t))
+			bloi := NewMockByOptionsLister(gomock.NewController(t))
+			tb := NewMockTransformBuilder(gomock.NewController(t))
+			inf := &informer.Informer{
+				ByOptionsLister: bloi,
+			}
+			c := factory.Cache{
+				ByOptionsLister: inf,
+			}
+			s := &Store{
+				ctx:              context.Background(),
+				namespaceCache:   nsi,
+				clientGetter:     cg,
+				cacheFactory:     cf,
+				transformBuilder: tb,
+			}
+			var partitions []partition.Partition
+			username := "flip"
+			targetGroup := "ext.cattle.io"
+			targetKind := "Token"
+			accessSet := &accesscontrol.AccessSet{ID: username}
+			accessSet.Add("list",
+				schema2.GroupResource{Group: targetGroup, Resource: "token"},
+				accesscontrol.Access{Namespace: accesscontrol.All, ResourceName: "token"},
+			)
+			test.accessSetSetter(accessSet)
 			apiOpSchemas := &types.APISchemas{}
 			accesscontrol.SetAccessSetAttribute(apiOpSchemas, accessSet)
 			theRequest := &http.Request{
@@ -781,7 +718,7 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 				Kind:  targetKind,
 			}
 			opts := &sqltypes.ListOptions{
-				Filters: []sqltypes.OrFilter{},
+				Filters: test.orFilters,
 				Pagination: sqltypes.Pagination{
 					Page: 1,
 				},
@@ -797,11 +734,7 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 			bloi.EXPECT().ListByOptions(apiOp.Context(), opts, partitions, "").Return(listToReturn, len(listToReturn.Items), "", nil)
 			_, _, _, err := s.ListByPartitions(apiOp, theSchema, partitions)
 			assert.Nil(t, err)
-		},
-	})
-	t.Parallel()
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) { test.test(t) })
+		})
 	}
 }
 

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
-	"github.com/rancher/steve/pkg/sqlcache/store"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/listprocessor"
 	"github.com/rancher/steve/pkg/stores/sqlproxy/tablelistconvert"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -694,7 +694,7 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 					{
 						Filters: []sqltypes.Filter{
 							{
-								Field:   []string{"metadata", "labels", "cattle.io/userId"},
+								Field:   []string{"metadata", "labels", "cattle.io/user-id"},
 								Matches: []string{"flip"},
 								Op:      sqltypes.Eq,
 							},


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/50404

This change ensures vai returns only tokens and kubeconfigs a non-admin user has access to