### PR TITLE
Convert tests to real SQL store

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -946,7 +946,7 @@ func isLabelsFieldList(fields []string) bool {
 
 // toUnstructuredList turns a slice of unstructured objects into an unstructured.UnstructuredList
 func toUnstructuredList(items []any) *unstructured.UnstructuredList {
-	objectItems := make([]map[string]any, len(items))
+	objectItems := make([]any, len(items))
 	result := &unstructured.UnstructuredList{
 		Items:  make([]unstructured.Unstructured, len(items)),
 		Object: map[string]interface{}{"items": objectItems},


### PR DESCRIPTION
The current ListByOptions tests aren't very useful and have a few flaws:
- The SQL store isn't even being used, instead we're using a mock, so no idea if the queries are valid. I found some that AREN'T.
- The "expected" list is taken directly from the "returnList" test cases. This means that it doesn't matter what the filtering / sorting / etc is done. So again we're testing basically nothing here.
- It's pretty tedious to have to edit the tests whenever the SQL queries changes. We shouldn't care about the query, but instead we should care about the results.
- I found a few issues where some tests shoudl work but fail. I have commented out these tests.
- The expected total vs got total is just wrong. It checks the returned items, but that's not what it should be when using pagination. It's supposed to check how many TOTAL items are in the DBs regardless of how many we ask for.

# Some issues

- It seems there are some issues with sorting on labels when the label doesn't exist
- Unclear if expected at this layer, but for sorting, no sort == default sorting on namespace and name, but if sort is set then we only sort on the given sorting params. Should we always try to sort on namespace, name in addition to what is given?
- Partitions with Namespace set doesn't seem to work

fyi @ericpromislow 