### PR TITLE
Add watch filtering support for vai

### DIFF
--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -30,11 +30,18 @@ type Informer struct {
 }
 
 type WatchOptions struct {
+	Filter WatchFilter
+}
+
+type WatchFilter struct {
+	ID        string
+	Selector  string
+	Namespace string
 }
 
 type ByOptionsLister interface {
 	ListByOptions(ctx context.Context, lo *sqltypes.ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
-	Watch(ctx context.Context, opts WatchOptions, eventsCh chan<- watch.Event) error
+	Watch(ctx context.Context, options WatchOptions, eventsCh chan<- watch.Event) error
 }
 
 // this is set to a var so that it can be overridden by test code for mocking purposes

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -14,6 +14,7 @@ import (
 	sqlStore "github.com/rancher/steve/pkg/sqlcache/store"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -35,7 +36,7 @@ type WatchOptions struct {
 
 type WatchFilter struct {
 	ID        string
-	Selector  string
+	Selector  labels.Selector
 	Namespace string
 }
 

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -1076,7 +1076,7 @@ func toUnstructuredList(items []any) *unstructured.UnstructuredList {
 	return result
 }
 
-func matchWatch(filterName string, filterNamespace string, filterSelector string, oldObj any, obj any) bool {
+func matchWatch(filterName string, filterNamespace string, filterSelector labels.Selector, oldObj any, obj any) bool {
 	matchOld := false
 	if oldObj != nil {
 		matchOld = matchFilter(filterName, filterNamespace, filterSelector, oldObj)
@@ -1084,7 +1084,7 @@ func matchWatch(filterName string, filterNamespace string, filterSelector string
 	return matchOld || matchFilter(filterName, filterNamespace, filterSelector, obj)
 }
 
-func matchFilter(filterName string, filterNamespace string, filterSelector string, obj any) bool {
+func matchFilter(filterName string, filterNamespace string, filterSelector labels.Selector, obj any) bool {
 	if obj == nil {
 		return false
 	}
@@ -1098,12 +1098,8 @@ func matchFilter(filterName string, filterNamespace string, filterSelector strin
 	if filterNamespace != "" && filterNamespace != metadata.GetNamespace() {
 		return false
 	}
-	if filterSelector != "" {
-		selector, err := labels.Parse(filterSelector)
-		if err != nil {
-			return false
-		}
-		if !selector.Matches(labels.Set(metadata.GetLabels())) {
+	if filterSelector != nil {
+		if !filterSelector.Matches(labels.Set(metadata.GetLabels())) {
 			return false
 		}
 	}

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -1101,7 +1101,6 @@ func matchFilter(filterName string, filterNamespace string, filterSelector strin
 	if filterSelector != "" {
 		selector, err := labels.Parse(filterSelector)
 		if err != nil {
-			fmt.Println("error parsing selector", err)
 			return false
 		}
 		if !selector.Matches(labels.Set(metadata.GetLabels())) {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -1983,6 +1984,9 @@ func TestWatchFilter(t *testing.T) {
 		"app": "bar",
 	})
 
+	appSelector, err := labels.Parse("app=foo")
+	assert.NoError(t, err)
+
 	tests := []struct {
 		name           string
 		filter         WatchFilter
@@ -2007,7 +2011,7 @@ func TestWatchFilter(t *testing.T) {
 		},
 		{
 			name:   "selector filter",
-			filter: WatchFilter{Selector: "app=foo"},
+			filter: WatchFilter{Selector: appSelector},
 			setupStore: func(store cache.Store) error {
 				err := store.Add(foo)
 				if err != nil {


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

This PR depends on https://github.com/rancher/steve/pull/649 and https://github.com/rancher/steve/pull/653

Basically, we want the UI to be able to filter what they watch. We're okay with supporting three types of watches (that can work together):
- selector filter: This is the same mechanism as label selectors in Kubernetes (think the `-l` flag to `kubectl`)
- id filter: Filter for a specific object (namespace/name key)
- namespace filter: Filter for all objects in a specific namespace

## How to test

Here's how you can test this.

1. Run Steve with SQL cache enabled in one terminal. (Make sure `KUBECONFIG` env var points to a Kubernetes cluster)
```
go run . --sql-cache --debug
```
2. In another terminal, you can run [websocat](https://github.com/vi/websocat). This is similar to telnet where you'll be able to enter messages (separated by newlines (by pressing enter)).

Here's an example of how to watch configmaps.

**selector filter**

Watches all configmaps with `app=rancher` labels

```
$ websocat -k wss://localhost:9443/v1/subscribe
{"resourceType":"configmaps","selector":"app=rancher"}
```

**namespace filter**

Watches all configmaps in the namespace `my-namespace`

```
$ websocat -k wss://localhost:9443/v1/subscribe
{"resourceType":"configmaps","namespace":"my-namespace"}
```

**id filter**

Watches configmaps named `foo` in namespace `my-namespace`

```
$ websocat -k wss://localhost:9443/v1/subscribe
{"resourceType":"configmaps","id":"my-namespace/foo"}
```

That's it, the watch is configured and if you create, delete or update namespaces in yet another terminal you should see a json line appear.
