### PR TITLE
Keep track of events for SQL cache watches

### DIFF
--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -43,6 +43,7 @@ func TestNewInformer(t *testing.T) {
 		// is tested in depth in its own package.
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -154,6 +155,7 @@ func TestNewInformer(t *testing.T) {
 		// is tested in depth in its own package.
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -212,6 +214,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -431,8 +431,8 @@ func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, o
 	l.watchersLock.RUnlock()
 
 	l.latestRVLock.Lock()
-	l.latestRV = latestRV
 	defer l.latestRVLock.Unlock()
+	l.latestRV = latestRV
 	return nil
 }
 

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -300,7 +300,8 @@ func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, events
 				continue
 			}
 
-			if !matchFilter(opts.Filter.ID, opts.Filter.Namespace, opts.Filter.Selector, obj) {
+			filter := opts.Filter
+			if !matchFilter(filter.ID, filter.Namespace, filter.Selector, obj) {
 				continue
 			}
 

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -75,6 +75,7 @@ const (
 	strictMatchFmt           = `%s`
 	escapeBackslashDirective = ` ESCAPE '\'` // The leading space is crucial for unit tests only '
 
+	// RV stands for ResourceVersion
 	createEventsTableFmt = `CREATE TABLE "%s_events" (
                        rv TEXT NOT NULL,
                        type TEXT NOT NULL,

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -261,7 +261,7 @@ func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, events
 
 	var events []watch.Event
 	var key *watchKey
-	// Even though we're not writing in this transaction, we prevent other write to SQL
+	// Even though we're not writing in this transaction, we prevent other writes to SQL
 	// because we don't want to add more events while we're backfilling events, so we don't miss events
 	err := l.WithTransaction(ctx, true, func(tx transaction.Client) error {
 		rowIDRows, err := tx.Stmt(l.findEventsRowByRVStmt).QueryContext(ctx, targetRV)

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -1,11 +1,13 @@
 package informer
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -33,9 +35,15 @@ type ListOptionIndexer struct {
 	namespaced    bool
 	indexedFields []string
 
+	latestRVLock sync.RWMutex
+	latestRV     string
+
 	watchersLock sync.RWMutex
 	watchers     map[*watchKey]*watcher
 
+	upsertEventsQuery      string
+	findEventsRowByRVQuery string
+	listEventsQuery        string
 	addFieldsQuery         string
 	deleteFieldsByKeyQuery string
 	deleteFieldsQuery      string
@@ -43,6 +51,9 @@ type ListOptionIndexer struct {
 	deleteLabelsByKeyQuery string
 	deleteLabelsQuery      string
 
+	upsertEventsStmt      *sql.Stmt
+	findEventsRowByRVStmt *sql.Stmt
+	listEventsStmt        *sql.Stmt
 	addFieldsStmt         *sql.Stmt
 	deleteFieldsByKeyStmt *sql.Stmt
 	deleteFieldsStmt      *sql.Stmt
@@ -63,7 +74,23 @@ const (
 	matchFmt                 = `%%%s%%`
 	strictMatchFmt           = `%s`
 	escapeBackslashDirective = ` ESCAPE '\'` // The leading space is crucial for unit tests only '
-	createFieldsTableFmt     = `CREATE TABLE "%s_fields" (
+
+	createEventsTableFmt = `CREATE TABLE "%s_events" (
+                       rv TEXT NOT NULL,
+                       type TEXT NOT NULL,
+                       event BLOB NOT NULL,
+                       PRIMARY KEY (type, rv)
+          )`
+	listEventsAfterRVFmt = `SELECT type, rv, event
+	       FROM "%s_events"
+	       WHERE rowid > ?
+       `
+	findEventsRowByRVFmt = `SELECT rowid
+               FROM "%s_events"
+               WHERE rv = ?
+       `
+
+	createFieldsTableFmt = `CREATE TABLE "%s_fields" (
 			key TEXT NOT NULL PRIMARY KEY,
             %s
 	   )`
@@ -138,6 +165,12 @@ func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, names
 	setStatements := make([]string, len(indexedFields))
 
 	err = l.WithTransaction(ctx, true, func(tx transaction.Client) error {
+		createEventsTableQuery := fmt.Sprintf(createEventsTableFmt, dbName)
+		_, err = tx.Exec(createEventsTableQuery)
+		if err != nil {
+			return &db.QueryError{QueryString: createEventsTableFmt, Err: err}
+		}
+
 		_, err = tx.Exec(fmt.Sprintf(createFieldsTableFmt, dbName, strings.Join(columnDefs, ", ")))
 		if err != nil {
 			return err
@@ -179,6 +212,18 @@ func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, names
 		return nil, err
 	}
 
+	l.upsertEventsQuery = fmt.Sprintf(
+		`REPLACE INTO "%s_events"(rv, type, event) VALUES (?, ?, ?)`,
+		dbName,
+	)
+	l.upsertEventsStmt = l.Prepare(l.upsertEventsQuery)
+
+	l.listEventsQuery = fmt.Sprintf(listEventsAfterRVFmt, dbName)
+	l.listEventsStmt = l.Prepare(l.listEventsQuery)
+
+	l.findEventsRowByRVQuery = fmt.Sprintf(findEventsRowByRVFmt, dbName)
+	l.findEventsRowByRVStmt = l.Prepare(l.findEventsRowByRVQuery)
+
 	l.addFieldsQuery = fmt.Sprintf(
 		`INSERT INTO "%s_fields"(key, %s) VALUES (?, %s) ON CONFLICT DO UPDATE SET %s`,
 		dbName,
@@ -204,10 +249,94 @@ func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, names
 }
 
 func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, eventsCh chan<- watch.Event) error {
-	key := l.addWatcher(eventsCh, opts.Filter)
+	l.latestRVLock.RLock()
+	latestRV := l.latestRV
+	l.latestRVLock.RUnlock()
+
+	targetRV := opts.ResourceVersion
+	if opts.ResourceVersion == "" {
+		targetRV = latestRV
+	}
+
+	var events []watch.Event
+	var key *watchKey
+	// Even though we're not writing in this transaction, we prevent other write to SQL
+	// because we don't want to add more events while we're backfilling events, so we don't miss events
+	err := l.WithTransaction(ctx, true, func(tx transaction.Client) error {
+		rowIDRows, err := tx.Stmt(l.findEventsRowByRVStmt).QueryContext(ctx, targetRV)
+		if err != nil {
+			return &db.QueryError{QueryString: l.listEventsQuery, Err: err}
+		}
+		if !rowIDRows.Next() && targetRV != latestRV {
+			return fmt.Errorf("resourceversion too old")
+		}
+
+		var rowID int
+		rowIDRows.Scan(&rowID)
+
+		// Backfilling previous events from resourceVersion
+		rows, err := tx.Stmt(l.listEventsStmt).QueryContext(ctx, rowID)
+		if err != nil {
+			return &db.QueryError{QueryString: l.listEventsQuery, Err: err}
+		}
+
+		for rows.Next() {
+			var typ, rv string
+			var buf sql.RawBytes
+			err := rows.Scan(&typ, &rv, &buf)
+			if err != nil {
+				return fmt.Errorf("scanning event row: %w", err)
+			}
+
+			example := &unstructured.Unstructured{}
+			val, err := fromBytes(buf, reflect.TypeOf(example))
+			if err != nil {
+				return fmt.Errorf("decoding event object: %w", err)
+			}
+
+			obj, ok := val.Elem().Interface().(runtime.Object)
+			if !ok {
+				continue
+			}
+
+			if !matchFilter(opts.Filter.ID, opts.Filter.Namespace, opts.Filter.Selector, obj) {
+				continue
+			}
+
+			events = append(events, watch.Event{
+				Type:   watch.EventType(typ),
+				Object: val.Elem().Interface().(runtime.Object),
+			})
+		}
+
+		for _, event := range events {
+			eventsCh <- event
+		}
+
+		key = l.addWatcher(eventsCh, opts.Filter)
+		return nil
+	})
 	<-ctx.Done()
 	l.removeWatcher(key)
-	return nil
+	return err
+}
+
+func toBytes(obj any) []byte {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(obj)
+	if err != nil {
+		panic(fmt.Errorf("error while gobbing object: %w", err))
+	}
+	bb := buf.Bytes()
+	return bb
+}
+
+func fromBytes(buf sql.RawBytes, typ reflect.Type) (reflect.Value, error) {
+	dec := gob.NewDecoder(bytes.NewReader(buf))
+	singleResult := reflect.New(typ)
+	err := dec.DecodeValue(singleResult)
+	return singleResult, err
 }
 
 type watchKey struct {
@@ -268,6 +397,24 @@ func (l *ListOptionIndexer) notifyEventDeleted(key string, obj any, tx transacti
 }
 
 func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, obj any, tx transaction.Client) error {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	latestRV := acc.GetResourceVersion()
+	// Append a -d suffix because the RV might be the same as the previous object
+	// in the following case:
+	// - Add obj1 with RV 100
+	// - Delete obj1 with RV 100
+	if eventType == watch.Deleted {
+		latestRV = latestRV + "-d"
+	}
+	_, err = tx.Stmt(l.upsertEventsStmt).Exec(latestRV, eventType, toBytes(obj))
+	if err != nil {
+		return &db.QueryError{QueryString: l.upsertEventsQuery, Err: err}
+	}
+
 	l.watchersLock.RLock()
 	for _, watcher := range l.watchers {
 		if !matchWatch(watcher.filter.ID, watcher.filter.Namespace, watcher.filter.Selector, oldObj, obj) {
@@ -280,6 +427,10 @@ func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, o
 		}
 	}
 	l.watchersLock.RUnlock()
+
+	l.latestRVLock.Lock()
+	l.latestRV = latestRV
+	defer l.latestRVLock.Unlock()
 	return nil
 }
 
@@ -634,7 +785,11 @@ func (l *ListOptionIndexer) executeQuery(ctx context.Context, queryInfo *QueryIn
 		continueToken = fmt.Sprintf("%d", offset+limit)
 	}
 
-	return toUnstructuredList(items), total, continueToken, nil
+	l.latestRVLock.RLock()
+	latestRV := l.latestRV
+	l.latestRVLock.RUnlock()
+
+	return toUnstructuredList(items, latestRV), total, continueToken, nil
 }
 
 func (l *ListOptionIndexer) validateColumn(column string) error {
@@ -1063,11 +1218,14 @@ func isLabelsFieldList(fields []string) bool {
 }
 
 // toUnstructuredList turns a slice of unstructured objects into an unstructured.UnstructuredList
-func toUnstructuredList(items []any) *unstructured.UnstructuredList {
+func toUnstructuredList(items []any, resourceVersion string) *unstructured.UnstructuredList {
 	objectItems := make([]any, len(items))
 	result := &unstructured.UnstructuredList{
 		Items:  make([]unstructured.Unstructured, len(items)),
 		Object: map[string]interface{}{"items": objectItems},
+	}
+	if resourceVersion != "" {
+		result.SetResourceVersion(resourceVersion)
 	}
 	for i, item := range items {
 		result.Items[i] = *item.(*unstructured.Unstructured)

--- a/pkg/stores/sqlpartition/partition_mocks_test.go
+++ b/pkg/stores/sqlpartition/partition_mocks_test.go
@@ -143,10 +143,10 @@ func (mr *MockUnstructuredStoreMockRecorder) Delete(arg0, arg1, arg2 any) *gomoc
 }
 
 // ListByPartitions mocks base method.
-func (m *MockUnstructuredStore) ListByPartitions(arg0 *types.APIRequest, arg1 *types.APISchema, arg2 []partition.Partition) ([]unstructured.Unstructured, int, string, error) {
+func (m *MockUnstructuredStore) ListByPartitions(arg0 *types.APIRequest, arg1 *types.APISchema, arg2 []partition.Partition) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByPartitions", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]unstructured.Unstructured)
+	ret0, _ := ret[0].(*unstructured.UnstructuredList)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(string)
 	ret3, _ := ret[3].(error)

--- a/pkg/stores/sqlpartition/partitioner.go
+++ b/pkg/stores/sqlpartition/partitioner.go
@@ -29,7 +29,7 @@ type UnstructuredStore interface {
 	Update(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (*unstructured.Unstructured, []types.Warning, error)
 	Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (*unstructured.Unstructured, []types.Warning, error)
 
-	ListByPartitions(apiOp *types.APIRequest, schema *types.APISchema, partitions []partition.Partition) ([]unstructured.Unstructured, int, string, error)
+	ListByPartitions(apiOp *types.APIRequest, schema *types.APISchema, partitions []partition.Partition) (*unstructured.UnstructuredList, int, string, error)
 	WatchByPartitions(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest, partitions []partition.Partition) (chan watch.Event, error)
 }
 

--- a/pkg/stores/sqlpartition/store.go
+++ b/pkg/stores/sqlpartition/store.go
@@ -92,7 +92,7 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 
 	result.Count = total
 
-	for _, item := range list {
+	for _, item := range list.Items {
 		item := item.DeepCopy()
 		// the sql cache automatically adds the ID through a transformFunc. Because of this, we have a different set of reserved fields for the SQL cache
 		result.Objects = append(result.Objects, partition.ToAPI(schema, item, nil, s.sqlReservedFields))
@@ -100,6 +100,7 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 
 	result.Revision = ""
 	result.Continue = continueToken
+	result.Revision = list.GetResourceVersion()
 	return result, nil
 }
 

--- a/pkg/stores/sqlpartition/store_test.go
+++ b/pkg/stores/sqlpartition/store_test.go
@@ -51,16 +51,18 @@ func TestList(t *testing.T) {
 				Schema: &schemas.Schema{},
 			}
 			partitions := make([]partition.Partition, 0)
-			uListToReturn := []unstructured.Unstructured{
-				{
-					Object: map[string]interface{}{
-						"kind": "apple",
-						"metadata": map[string]interface{}{
-							"name":      "fuji",
-							"namespace": "fruitsnamespace",
-						},
-						"data": map[string]interface{}{
-							"color": "pink",
+			uListToReturn := &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind": "apple",
+							"metadata": map[string]interface{}{
+								"name":      "fuji",
+								"namespace": "fruitsnamespace",
+							},
+							"data": map[string]interface{}{
+								"color": "pink",
+							},
 						},
 					},
 				},
@@ -88,7 +90,7 @@ func TestList(t *testing.T) {
 			}
 			p.EXPECT().All(req, schema, "list", "").Return(partitions, nil)
 			p.EXPECT().Store().Return(us)
-			us.EXPECT().ListByPartitions(req, schema, partitions).Return(uListToReturn, len(uListToReturn), "", nil)
+			us.EXPECT().ListByPartitions(req, schema, partitions).Return(uListToReturn, len(uListToReturn.Items), "", nil)
 			l, err := s.List(req, schema)
 			assert.Nil(t, err)
 			assert.Equal(t, expectedAPIObjList, l)

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -569,6 +569,7 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 		}
 
 		opts := informer.WatchOptions{
+			ResourceVersion: w.Revision,
 			Filter: informer.WatchFilter{
 				ID:        w.ID,
 				Namespace: idNamespace,
@@ -737,7 +738,7 @@ func (s *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 //   - the total number of resources (returned list might be a subset depending on pagination options in apiOp)
 //   - a continue token, if there are more pages after the returned one
 //   - an error instead of all of the above if anything went wrong
-func (s *Store) ListByPartitions(apiOp *types.APIRequest, schema *types.APISchema, partitions []partition.Partition) ([]unstructured.Unstructured, int, string, error) {
+func (s *Store) ListByPartitions(apiOp *types.APIRequest, schema *types.APISchema, partitions []partition.Partition) (*unstructured.UnstructuredList, int, string, error) {
 	opts, err := listprocessor.ParseQuery(apiOp, s.namespaceCache)
 	if err != nil {
 		return nil, 0, "", err
@@ -768,7 +769,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, schema *types.APISchem
 		return nil, 0, "", err
 	}
 
-	return list.Items, total, continueToken, nil
+	return list, total, continueToken, nil
 }
 
 // WatchByPartitions returns a channel of events for a list or resource belonging to any of the specified partitions

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -249,7 +249,7 @@ func TestListByPartitions(t *testing.T) {
 			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
 			list, total, contToken, err := s.ListByPartitions(req, schema, partitions)
 			assert.Nil(t, err)
-			assert.Equal(t, expectedItems, list)
+			assert.Equal(t, expectedItems, list.Items)
 			assert.Equal(t, len(expectedItems), total)
 			assert.Equal(t, "", contToken)
 		},
@@ -466,7 +466,7 @@ func TestListByPartitions(t *testing.T) {
 			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
 			list, total, contToken, err := s.ListByPartitions(req, schema, partitions)
 			assert.Nil(t, err)
-			assert.Equal(t, expectedItems, list)
+			assert.Equal(t, expectedItems, list.Items)
 			assert.Equal(t, len(expectedItems), total)
 			assert.Equal(t, "", contToken)
 		},


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

This PR adds support for `ResourceVersion` to watch. Essentially, we're keeping track of events as they come in, and then the UI will be able to start a watch request at a specific `ResourceVersion`, which means at a specific point in time.

The UI will receive only events after the given `ResourceVersion`.

**Note:** This currently keeps all events on disk, ALWAYS. I'll add "garbage collection" in another PR.

## How to test

Here's how you can test this.

1. Run Steve with SQL cache enabled in one terminal. (Make sure `KUBECONFIG` env var points to a Kubernetes cluster)
```
go run . --sql-cache --debug
```

2. Make a list request and keep track of the resource version returned. For example, here I get back `985232` as the resource version.

```sh
$ curl -sk https://localhost:9443/v1/configmaps | jq -r '.revision'
985232
```

3. Make some configmaps modification

eg:

```sh
kubectl create configmap foo
```

4. In another terminal, you can run [websocat](https://github.com/vi/websocat). This is similar to telnet where you'll be able to enter messages (separated by newlines (by pressing enter)). **Note:** See I set the resourceVersion to the value gotten from the list request.

```
$ websocat -k wss://localhost:9443/v1/subscribe
{"resourceType":"configmaps","resourceVersion":"985232"}
```

You should receive events from the point of time where you made modifications (in step 3)


