### PR TITLE
Handle transaction failure due to canceled context.Context

### DIFF
--- a/pkg/sqlcache/db/transaction/transaction.go
+++ b/pkg/sqlcache/db/transaction/transaction.go
@@ -41,4 +41,5 @@ type Stmt interface {
 	Exec(args ...any) (sql.Result, error)
 	Query(args ...any) (*sql.Rows, error)
 	QueryContext(ctx context.Context, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, args ...any) *sql.Row
 }

--- a/pkg/sqlcache/db/transaction_mocks_test.go
+++ b/pkg/sqlcache/db/transaction_mocks_test.go
@@ -155,3 +155,22 @@ func (mr *MockStmtMockRecorder) QueryContext(arg0 any, arg1 ...any) *gomock.Call
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryContext", reflect.TypeOf((*MockStmt)(nil).QueryContext), varargs...)
 }
+
+// QueryRowContext mocks base method.
+func (m *MockStmt) QueryRowContext(arg0 context.Context, arg1 ...any) *sql.Row {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryRowContext", varargs...)
+	ret0, _ := ret[0].(*sql.Row)
+	return ret0
+}
+
+// QueryRowContext indicates an expected call of QueryRowContext.
+func (mr *MockStmtMockRecorder) QueryRowContext(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRowContext", reflect.TypeOf((*MockStmt)(nil).QueryRowContext), varargs...)
+}

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -144,11 +144,11 @@ func NewListOptionIndexer(ctx context.Context, fields [][]string, s Store, names
 		watchers:      make(map[*watchKey]*watcher),
 	}
 	l.RegisterAfterAdd(l.addIndexFields)
+	l.RegisterAfterAdd(l.addLabels)
 	l.RegisterAfterAdd(l.notifyEventAdded)
 	l.RegisterAfterUpdate(l.addIndexFields)
-	l.RegisterAfterUpdate(l.notifyEventModified)
-	l.RegisterAfterAdd(l.addLabels)
 	l.RegisterAfterUpdate(l.addLabels)
+	l.RegisterAfterUpdate(l.notifyEventModified)
 	l.RegisterAfterDelete(l.deleteFieldsByKey)
 	l.RegisterAfterDelete(l.deleteLabelsByKey)
 	l.RegisterAfterDelete(l.notifyEventDeleted)

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -68,6 +68,7 @@ var (
 	subfieldRegex          = regexp.MustCompile(`([a-zA-Z]+)|(\[[-a-zA-Z./]+])|(\[[0-9]+])`)
 
 	ErrInvalidColumn = errors.New("supplied column is invalid")
+	ErrTooOld        = errors.New("resourceversion too old")
 )
 
 const (
@@ -273,7 +274,7 @@ func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, events
 		err := rowIDRow.Scan(&rowID)
 		if errors.Is(err, sql.ErrNoRows) {
 			if targetRV != latestRV {
-				return fmt.Errorf("resourceversion too old")
+				return ErrTooOld
 			}
 		} else if err != nil {
 			return fmt.Errorf("failed scan rowid: %w", err)

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -2199,6 +2199,7 @@ func TestWatchResourceVersion(t *testing.T) {
 	tests := []struct {
 		rv             string
 		expectedEvents []watch.Event
+		expectedErr    error
 	}{
 		{
 			rv: "",
@@ -2237,6 +2238,10 @@ func TestWatchResourceVersion(t *testing.T) {
 			rv:             rv5,
 			expectedEvents: nil,
 		},
+		{
+			rv:          "unknown",
+			expectedErr: ErrTooOld,
+		},
 	}
 
 	for _, test := range tests {
@@ -2245,11 +2250,14 @@ func TestWatchResourceVersion(t *testing.T) {
 			watcherCh, errCh := startWatcher(ctx, loi, test.rv)
 			gotEvents := receiveEvents(watcherCh)
 
-			assert.Equal(t, test.expectedEvents, gotEvents)
-
 			cancel()
 			err := waitStopWatcher(errCh)
-			assert.NoError(t, err)
+			if test.expectedErr != nil {
+				assert.ErrorIs(t, err, ErrTooOld)
+			} else {
+				assert.Equal(t, test.expectedEvents, gotEvents)
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -2255,8 +2255,8 @@ func TestWatchResourceVersion(t *testing.T) {
 			if test.expectedErr != nil {
 				assert.ErrorIs(t, err, ErrTooOld)
 			} else {
-				assert.Equal(t, test.expectedEvents, gotEvents)
 				assert.NoError(t, err)
+				assert.Equal(t, test.expectedEvents, gotEvents)
 			}
 		})
 	}

--- a/pkg/sqlcache/informer/transaction_mocks_test.go
+++ b/pkg/sqlcache/informer/transaction_mocks_test.go
@@ -99,6 +99,25 @@ func (mr *MockStmtMockRecorder) QueryContext(arg0 any, arg1 ...any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryContext", reflect.TypeOf((*MockStmt)(nil).QueryContext), varargs...)
 }
 
+// QueryRowContext mocks base method.
+func (m *MockStmt) QueryRowContext(arg0 context.Context, arg1 ...any) *sql.Row {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryRowContext", varargs...)
+	ret0, _ := ret[0].(*sql.Row)
+	return ret0
+}
+
+// QueryRowContext indicates an expected call of QueryRowContext.
+func (mr *MockStmtMockRecorder) QueryRowContext(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRowContext", reflect.TypeOf((*MockStmt)(nil).QueryRowContext), varargs...)
+}
+
 // MockTXClient is a mock of Client interface.
 type MockTXClient struct {
 	ctrl     *gomock.Controller

--- a/pkg/sqlcache/store/transaction_mocks_test.go
+++ b/pkg/sqlcache/store/transaction_mocks_test.go
@@ -99,6 +99,25 @@ func (mr *MockStmtMockRecorder) QueryContext(arg0 any, arg1 ...any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryContext", reflect.TypeOf((*MockStmt)(nil).QueryContext), varargs...)
 }
 
+// QueryRowContext mocks base method.
+func (m *MockStmt) QueryRowContext(arg0 context.Context, arg1 ...any) *sql.Row {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryRowContext", varargs...)
+	ret0, _ := ret[0].(*sql.Row)
+	return ret0
+}
+
+// QueryRowContext indicates an expected call of QueryRowContext.
+func (mr *MockStmtMockRecorder) QueryRowContext(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRowContext", reflect.TypeOf((*MockStmt)(nil).QueryRowContext), varargs...)
+}
+
 // MockTXClient is a mock of Client interface.
 type MockTXClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

This PR has a few thing.

**Better handle canceled context.Context**

From the docs:

```go
// BeginTx starts a transaction.
//
// The provided context is used until the transaction is committed or rolled back.
// If the context is canceled, the sql package will roll back
// the transaction. [Tx.Commit] will return an error if the context provided to
// BeginTx is canceled.
//
// The provided [TxOptions] is optional and may be nil if defaults should be used.
// If a non-default isolation level is used that the driver doesn't support,
// an error will be returned.
func (db *DB) BeginTx(ctx context.Context, opts *TxOptions) (*Tx, error) {
```

The context was getting canceled and we were getting the very misleading error `transaction has already been committed or rolled back`. This was due to the transaction being rolled back (via canceled context) and then rolled back again via WithTransaction. Instead, we now try to roll back or commit and detect the issue.

**~Send events directly to the channel~**

~rancher/apiserver seem to not be able to handle fast events due to this [piece of code](https://github.com/rancher/apiserver/blob/a5f8c8f8f1f8ce27a9590fc71348c1a0b886e5e0/pkg/subscribe/watcher.go#L120-L130):~

```go
			select {
			case result <- event:
			default:
				// handle slow consumer
				go func() {
					for range c {
						// continue to drain until close
					}
				}()
				return nil
			}
```

~Using a list of events and sending all of them through the channel was too fast, so we now send each of them to the channel and to a bit of processing in between each send, giving enough time for the "slow" consumer to keep up. I'll create an issue for properly fixing this in rancher/apiserver instead (eg: I think `default:` should be changed to `case <-time.After(200*time.Millisecond)` or something like this.~ I ended up fixing it in apiserver instead in https://github.com/rancher/apiserver/pull/163.