### PR TITLE
Return `resourceversion too old` error to UI instead of logging

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -451,13 +451,6 @@ func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, o
 	}
 
 	latestRV := acc.GetResourceVersion()
-	// Append a -d suffix because the RV might be the same as the previous object
-	// in the following case:
-	// - Add obj1 with RV 100
-	// - Delete obj1 with RV 100
-	if eventType == watch.Deleted {
-		latestRV = latestRV + "-d"
-	}
 	_, err = tx.Stmt(l.upsertEventsStmt).Exec(latestRV, eventType, toBytes(obj))
 	if err != nil {
 		return &db.QueryError{QueryString: l.upsertEventsQuery, Err: err}

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -2190,13 +2190,11 @@ func TestWatchResourceVersion(t *testing.T) {
 		"app": "bar",
 	})
 
-	barNew := &unstructured.Unstructured{}
-	barNew.SetResourceVersion("160")
-	barNew.SetName("bar")
-	barNew.SetNamespace("bar")
-	barNew.SetLabels(map[string]string{
-		"app": "bar",
-	})
+	barDeleted := bar.DeepCopy()
+	barDeleted.SetResourceVersion("160")
+
+	barNew := bar.DeepCopy()
+	barNew.SetResourceVersion("170")
 
 	parentCtx := context.Background()
 
@@ -2225,7 +2223,7 @@ func TestWatchResourceVersion(t *testing.T) {
 	assert.NoError(t, err)
 	rv3 := getRV(t)
 
-	err = loi.Delete(bar)
+	err = loi.Delete(barDeleted)
 	assert.NoError(t, err)
 	rv4 := getRV(t)
 
@@ -2246,7 +2244,7 @@ func TestWatchResourceVersion(t *testing.T) {
 			expectedEvents: []watch.Event{
 				{Type: watch.Modified, Object: fooUpdated},
 				{Type: watch.Added, Object: bar},
-				{Type: watch.Deleted, Object: bar},
+				{Type: watch.Deleted, Object: barDeleted},
 				{Type: watch.Added, Object: barNew},
 			},
 		},
@@ -2254,14 +2252,14 @@ func TestWatchResourceVersion(t *testing.T) {
 			rv: rv2,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: bar},
-				{Type: watch.Deleted, Object: bar},
+				{Type: watch.Deleted, Object: barDeleted},
 				{Type: watch.Added, Object: barNew},
 			},
 		},
 		{
 			rv: rv3,
 			expectedEvents: []watch.Event{
-				{Type: watch.Deleted, Object: bar},
+				{Type: watch.Deleted, Object: barDeleted},
 				{Type: watch.Added, Object: barNew},
 			},
 		},
@@ -2344,9 +2342,11 @@ func TestWatchGarbageCollection(t *testing.T) {
 	bar.SetResourceVersion("150")
 	bar.SetName("bar")
 
-	barNew := &unstructured.Unstructured{}
-	barNew.SetResourceVersion("160")
-	barNew.SetName("bar")
+	barDeleted := bar.DeepCopy()
+	barDeleted.SetResourceVersion("160")
+
+	barNew := bar.DeepCopy()
+	barNew.SetResourceVersion("170")
 
 	parentCtx := context.Background()
 
@@ -2375,7 +2375,7 @@ func TestWatchGarbageCollection(t *testing.T) {
 	assert.NoError(t, err)
 	rv3 := getRV(t)
 
-	err = loi.Delete(bar)
+	err = loi.Delete(barDeleted)
 	assert.NoError(t, err)
 	rv4 := getRV(t)
 
@@ -2394,7 +2394,7 @@ func TestWatchGarbageCollection(t *testing.T) {
 		{
 			rv: rv3,
 			expectedEvents: []watch.Event{
-				{Type: watch.Deleted, Object: bar},
+				{Type: watch.Deleted, Object: barDeleted},
 			},
 		},
 		{

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -562,6 +562,8 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 
 	result := make(chan watch.Event)
 	go func() {
+		defer close(result)
+
 		ctx := apiOp.Context()
 		idNamespace, _ := kv.RSplit(w.ID, "/")
 		if idNamespace == "" {
@@ -578,10 +580,10 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 		}
 		err := inf.ByOptionsLister.Watch(ctx, opts, result)
 		if err != nil {
-			logrus.Error(err)
+			returnErr(err, result)
+			return
 		}
 		logrus.Debugf("closing watcher for %s", schema.ID)
-		close(result)
 	}()
 	return result, nil
 }


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

While testing with UI we discovered a few bugs:
- we're not returning the `resourceversion too old` error, we're only logging it.
- the `-d` suffix causes issue and is likely NOT needed, so we're removing it (UI assumes the resourceVersion to be a number and when it's not.. well it tries to parse it anyway because it's JS)
- it's better for the list to be sorted by resourceVersion as number, again because UI makes the assumption that it's a number and also keeps track of the "highest" number.

This PR addresses all these issues. Long-term we'll want to discuss with the UI team to see what we want to do with resourceVersion as they are supposed to be treated as opaque string.