### PR TITLE
[main] block UI until we receive requests from kube-apiserver

### DIFF
--- a/pkg/ext/apiserver.go
+++ b/pkg/ext/apiserver.go
@@ -155,12 +155,7 @@ func NewExtensionAPIServer(scheme *runtime.Scheme, codecs serializer.CodecFactor
 			switch a.GetUser().GetName() {
 			case "system:aggregator", "system:kube-aggregator":
 				once.Do(func() {
-					go func() {
-						time.Sleep(time.Minute * 1)
-
-						close(registered)
-					}()
-					// close(registered)
+					close(registered)
 				})
 			}
 

--- a/pkg/ext/apiserver.go
+++ b/pkg/ext/apiserver.go
@@ -333,6 +333,6 @@ func getDefinitionName(scheme *runtime.Scheme, replacements map[string]string) f
 	}
 }
 
-func (e *ExtensionAPIServer) Registered() <-chan struct{} {
-	return e.registeredChan
+func (s *ExtensionAPIServer) Registered() <-chan struct{} {
+	return s.registeredChan
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/50399#issue-3083889619

Route traffic on UI based URLs to `http.NotFound` until we can verify that the cluster is configured to support extension apis.