### PR TITLE
Fix panic due to concurrent map writes

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -464,7 +464,7 @@ func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, o
 
 		watcher.ch <- watch.Event{
 			Type:   eventType,
-			Object: obj.(runtime.Object),
+			Object: obj.(runtime.Object).DeepCopyObject(),
 		}
 	}
 	l.watchersLock.RUnlock()


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

When multiple users are watching a resource type, we send the same object (from the events) to each watchers. Each watcher is its own goroutine that may do further processing on the object and since we weren't DeepCopying the object, they would act on the same object. This causes a panic with the error below:

```
fatal error: concurrent map read and map write

goroutine 71715 [running]:
internal/runtime/maps.fatal({0xa5c7854?, 0xa?})
	/usr/lib64/go/1.24/src/runtime/panic.go:1058 +0x18
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.NestedFieldNoCopy(0xc004e84c38?, {0xc004e84cc0, 0x2, 0x2})
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/apis/meta/v1/unstructured/helpers.go:62 +0xb1
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.NestedString(0x419fc5?, {0xc004e84cc0, 0x2, 0x2})
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/apis/meta/v1/unstructured/helpers.go:76 +0x2f
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.getNestedString(0xd68979?, {0xc004e84cc0?, 0x0?, 0xedfdb4aee?})
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/apis/meta/v1/unstructured/helpers.go:302 +0x18
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetDeletionTimestamp(0xc001e21aa0)
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/apis/meta/v1/unstructured/unstructured.go:367 +0x7a
github.com/rancher/wrangler/v3/pkg/summary.Summarized({0xb42f838, 0xc001e21aa0})
	/root/.cache/go/modcache/github.com/rancher/wrangler/v3@v3.2.1/pkg/summary/summarized.go:38 +0x402
github.com/rancher/steve/pkg/summarycache.(*SummaryCache).SummaryAndRelationship(0xc002fc3770, {0xb42f838, 0xc001e21aa0})
	/root/.cache/go/modcache/github.com/rancher/steve@v0.6.10/pkg/summarycache/summarycache.go:109 +0xfc
github.com/rancher/steve/pkg/resources.DefaultSchemaTemplatesForStore.DefaultTemplateForStore.formatter.func4(0xc007bfed20, 0xc00776f4d0)
	/root/.cache/go/modcache/github.com/rancher/steve@v0.6.10/pkg/resources/common/formatter.go:146 +0x7ce

```

The fix is pretty simple: deepcopy the object before sending it to all requests.