### PR TITLE
vai: Rework events garbage collection delete query

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -98,9 +98,10 @@ const (
                WHERE rv = ?
        `
 	deleteEventsByCountFmt = `DELETE FROM "%s_events"
-	WHERE rowid
-	NOT IN (
-		SELECT rowid FROM "%s_events" ORDER BY rowid DESC LIMIT ?
+	WHERE rowid < (
+	    SELECT MIN(rowid) FROM (
+	        SELECT rowid FROM "%s_events" ORDER BY rowid DESC LIMIT ?
+	    ) q
 	)`
 
 	createFieldsTableFmt = `CREATE TABLE "%s_fields" (

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -348,8 +348,6 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		partitions  []partition.Partition
 		ns          string
 
-		items []*unstructured.Unstructured
-
 		extraIndexedFields [][]string
 		expectedList       *unstructured.UnstructuredList
 		expectedTotal      int


### PR DESCRIPTION
Rework the delete query introduced in #664 to avoid `NOT IN` that requires to keep the intermediate result set.