### PR TITLE
#50687 - Added Timestamp Parsing Support

### DIFF
--- a/pkg/resources/common/duration.go
+++ b/pkg/resources/common/duration.go
@@ -6,10 +6,19 @@ import (
 	"time"
 )
 
-func ParseHumanReadableDuration(s string) (time.Duration, error) {
+// ParseTimestampOrHumanReadableDuration can do one of three things with an incoming string:
+// 1. Recognize it's an absolute timestamp and calculate a relative `time.Duration`
+// 2. Recognize it's a human-readable duration (like 3m) and convert to a relative `time.Duration`
+// 3. Return an error because it doesn't recognize the input
+func ParseTimestampOrHumanReadableDuration(s string) (time.Duration, error) {
 	var total time.Duration
 	var val int
 	var unit byte
+
+	parsedTime, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return time.Since(parsedTime), nil
+	}
 
 	r := strings.NewReader(s)
 	for r.Len() > 0 {

--- a/pkg/resources/common/duration_test.go
+++ b/pkg/resources/common/duration_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseHumanDuration(t *testing.T) {
+func TestParseHumanReadableDuration(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       string
@@ -63,7 +63,7 @@ func TestParseHumanDuration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := ParseHumanReadableDuration(tc.input)
+			output, err := ParseTimestampOrHumanReadableDuration(tc.input)
 			if tc.expectedErr {
 				assert.Error(t, err)
 			} else {
@@ -71,4 +71,8 @@ func TestParseHumanDuration(t *testing.T) {
 			}
 		})
 	}
+
+	// Testing timestamp parsing separately
+	_, err := ParseTimestampOrHumanReadableDuration("2024-02-12T15:19:21Z")
+	assert.NoError(t, err)
 }

--- a/pkg/resources/virtual/virtual.go
+++ b/pkg/resources/virtual/virtual.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/steve/pkg/resources/virtual/clusters"
 	"github.com/rancher/steve/pkg/resources/virtual/common"
 	"github.com/rancher/steve/pkg/resources/virtual/events"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
@@ -64,9 +65,11 @@ func (t *TransformBuilder) GetTransformFunc(gvk schema.GroupVersionKind, columns
 				if !cast {
 					return nil, fmt.Errorf("could not cast metadata.fields %d to string", index)
 				}
-				duration, err := rescommon.ParseHumanReadableDuration(value)
+
+				duration, err := rescommon.ParseTimestampOrHumanReadableDuration(value)
 				if err != nil {
-					return nil, err
+					logrus.Errorf("parse timestamp %s, failed with error: %s", value, err)
+					return obj, nil
 				}
 
 				curValue[index] = fmt.Sprintf("%d", now.Add(-duration).UnixMilli())


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/50687

The date fields parser added at https://github.com/rancher/rancher/issues/48673 was only expecting k8s HumanDuration timestamps but as we could verify it can be dangerous, so now it also supports timestamps represented in RFC3339 and if it can't parse, it returns the value 'as is'.
