### PR TITLE
Make waiting for ExtensionAPIServer configurable

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -270,7 +270,7 @@ func setup(ctx context.Context, server *Server) error {
 		case <-server.extensionAPIServer.Registered():
 			server.next.ServeHTTP(rw, req)
 		default:
-			http.NotFoundHandler().ServeHTTP(rw, req)
+			http.Error(rw, "API Aggregation not ready", http.StatusServiceUnavailable)
 		}
 	})
 


### PR DESCRIPTION
Related to rancher/rancher#50399

Add a new option to the Steve server to make it configurable whether to block serving requests until the ExtensionAPIServer is contacted ("on" by default).

It also replaces the `404 NotFound` HTTP code with a more appropriate `503 Service Unavailable`.