### PR TITLE
Fix parsing of metadata.fields when age is already a duration

### DIFF
--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -291,7 +291,7 @@ func convertMetadataTimestampFields(request *types.APIRequest, gvk schema2.Group
 }
 
 func isDuration(value string) (time.Duration, bool) {
-	d, err := time.ParseDuration(value)
+	d, err := ParseTimestampOrHumanReadableDuration(value)
 	return d, err == nil
 }
 

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -262,14 +262,17 @@ func convertMetadataTimestampFields(request *types.APIRequest, gvk schema2.Group
 					return
 				}
 
-				millis, err := strconv.ParseInt(timeValue, 10, 64)
-				if err != nil {
-					logrus.Warnf("convert timestamp value: %s failed with error: %s", timeValue, err.Error())
-					return
-				}
+				dur, ok := isDuration(timeValue)
+				if !ok {
+					millis, err := strconv.ParseInt(timeValue, 10, 64)
+					if err != nil {
+						logrus.Warnf("convert timestamp value: %s failed with error: %s", timeValue, err.Error())
+						return
+					}
 
-				timestamp := time.Unix(0, millis*int64(time.Millisecond))
-				dur := time.Since(timestamp)
+					timestamp := time.Unix(0, millis*int64(time.Millisecond))
+					dur = time.Since(timestamp)
+				}
 
 				humanDuration := duration.HumanDuration(dur)
 				if humanDuration == "<invalid>" {
@@ -285,6 +288,11 @@ func convertMetadataTimestampFields(request *types.APIRequest, gvk schema2.Group
 			}
 		}
 	}
+}
+
+func isDuration(value string) (time.Duration, bool) {
+	d, err := time.ParseDuration(value)
+	return d, err == nil
 }
 
 func excludeValues(request *types.APIRequest, unstr *unstructured.Unstructured) {

--- a/pkg/resources/virtual/virtual.go
+++ b/pkg/resources/virtual/virtual.go
@@ -11,13 +11,14 @@ import (
 	"github.com/rancher/steve/pkg/resources/virtual/clusters"
 	"github.com/rancher/steve/pkg/resources/virtual/common"
 	"github.com/rancher/steve/pkg/resources/virtual/events"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
-var now = time.Now()
+var now = time.Now
 
 // TransformBuilder builds transform functions for specified GVKs through GetTransformFunc
 type TransformBuilder struct {
@@ -72,7 +73,7 @@ func (t *TransformBuilder) GetTransformFunc(gvk schema.GroupVersionKind, columns
 					return obj, nil
 				}
 
-				curValue[index] = fmt.Sprintf("%d", now.Add(-duration).UnixMilli())
+				curValue[index] = fmt.Sprintf("%d", now().Add(-duration).UnixMilli())
 				if err := unstructured.SetNestedSlice(obj.Object, curValue, "metadata", "fields"); err != nil {
 					return nil, err
 				}

--- a/pkg/resources/virtual/virtual_test.go
+++ b/pkg/resources/virtual/virtual_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestTransformChain(t *testing.T) {
-	now = func() time.Time { return time.Date(1992, 9, 2, 0, 0, 0, 0, time.UTC) }()
+	now = func() time.Time { return time.Date(1992, 9, 2, 0, 0, 0, 0, time.UTC) }
 	noColumns := []rescommon.ColumnDefinition{}
 	tests := []struct {
 		name             string
@@ -154,7 +154,7 @@ func TestTransformChain(t *testing.T) {
 							"message":       "",
 						},
 						"fields": []interface{}{
-							fmt.Sprintf("%d", now.Add(-24*time.Hour).UnixMilli()),
+							fmt.Sprintf("%d", now().Add(-24*time.Hour).UnixMilli()),
 						},
 					},
 					"id":  "test-ns/testobj",
@@ -216,7 +216,7 @@ func TestTransformChain(t *testing.T) {
 							"message":       "",
 						},
 						"fields": []interface{}{
-							fmt.Sprintf("%d", now.Add(-24*time.Hour).UnixMilli()),
+							fmt.Sprintf("%d", now().Add(-24*time.Hour).UnixMilli()),
 						},
 					},
 					"id":  "test-ns/testobj",


### PR DESCRIPTION
Refers to rancher/rancher#50882

It seems under certain conditions, this value can be already transformed into a duration, making this value "polymorphic", so this patch adds support for that.

While looking into this, I noticed we are incorrectly mocking `time.Now`, and only using its value, which can lead to incorrect values.