### PR TITLE
Revert part of steve PR 633

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -683,10 +683,8 @@ func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions 
 				names := thisPartition.Names
 
 				if len(names) == 0 {
-					if len(singlePartitionClauses) == 0 {
-						// degenerate case, there will be no results
-						singlePartitionClauses = append(singlePartitionClauses, "FALSE")
-					}
+					// degenerate case, there will be no results
+					singlePartitionClauses = append(singlePartitionClauses, "FALSE")
 				} else {
 					singlePartitionClauses = append(singlePartitionClauses, fmt.Sprintf(`f."metadata.name" IN (?%s)`, strings.Repeat(", ?", len(thisPartition.Names)-1)))
 					// sort for reproducibility

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -977,20 +977,20 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedContToken: "",
 		expectedErr:       nil,
 	})
-	tests = append(tests, testCase{
-		description: "ListByOptions with a Namespace Partition should select only items where metadata.namespace is equal to Namespace and all other conditions are met",
-		partitions: []partition.Partition{
-			{
-				Namespace: "ns-b",
-			},
-		},
-		// XXX: Why do I need to specify the namespace here too?
-		ns:                "ns-b",
-		expectedList:      makeList(t, obj05__guard_lodgepole),
-		expectedTotal:     1,
-		expectedContToken: "",
-		expectedErr:       nil,
-	})
+	//tests = append(tests, testCase{
+	//	description: "ListByOptions with a Namespace Partition should select only items where metadata.namespace is equal to Namespace and all other conditions are met",
+	//	partitions: []partition.Partition{
+	//		{
+	//			Namespace: "ns-b",
+	//		},
+	//	},
+	//	// XXX: Why do I need to specify the namespace here too?
+	//	ns:                "ns-b",
+	//	expectedList:      makeList(t, obj05__guard_lodgepole),
+	//	expectedTotal:     1,
+	//	expectedContToken: "",
+	//	expectedErr:       nil,
+	//})
 
 	t.Parallel()
 


### PR DESCRIPTION
Specifically, re-comment out a test that was uncommented in this PR, and revert the underlying code that made this test pass.  That code change causes user-based integration tests to fail, so something is not correct in that code.

This was actually unrelated to the reason for PR 633, to fix a problem when sorting on a label that dropped objects that didn't have that label.  That part remains untouched.