### PR TITLE
Better gc

### DIFF
--- a/pkg/server/cli/clicontext.go
+++ b/pkg/server/cli/clicontext.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"context"
+	"time"
 
 	steveauth "github.com/rancher/steve/pkg/auth"
 	authcli "github.com/rancher/steve/pkg/auth/cli"
 	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	"github.com/rancher/steve/pkg/ui"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/ratelimit"
@@ -52,6 +54,10 @@ func (c *Config) ToServer(ctx context.Context, sqlCache bool) (*server.Server, e
 		AuthMiddleware: auth,
 		Next:           ui.New(c.UIPath),
 		SQLCache:       sqlCache,
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+		},
 	})
 }
 

--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -146,9 +146,9 @@ func (f *CacheFactory) CacheFor(ctx context.Context, fields [][]string, external
 	// actually create the informer
 	if gi.informer == nil {
 		start := time.Now()
-		log.Debugf("CacheFor STARTS creating informer for %v", gvk)
+		log.Infof("CacheFor STARTS creating informer for %v", gvk)
 		defer func() {
-			log.Debugf("CacheFor IS DONE creating informer for %v (took %v)", gvk, time.Now().Sub(start))
+			log.Infof("CacheFor IS DONE creating informer for %v (took %v)", gvk, time.Now().Sub(start))
 		}()
 
 		_, encryptResourceAlways := defaultEncryptedResourceTypes[gvk]

--- a/pkg/sqlcache/informer/factory/informer_factory_test.go
+++ b/pkg/sqlcache/informer/factory/informer_factory_test.go
@@ -75,13 +75,13 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, false, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -122,13 +122,13 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, false, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return expectedI, nil
 		}
@@ -166,13 +166,13 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, false, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -207,13 +207,13 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, true, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -257,13 +257,13 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, true, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -306,13 +306,13 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, true, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -355,7 +355,7 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			// we can't test func == func, so instead we check if the output was as expected
 			input := "someinput"
 			ouput, err := transform(input)
@@ -369,7 +369,7 @@ func TestCacheFor(t *testing.T) {
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, false, shouldEncrypt)
-			assert.Equal(t, 0, maxEventsCount)
+			assert.Equal(t, 0, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
@@ -408,72 +408,20 @@ func TestCacheFor(t *testing.T) {
 		expectedC := Cache{
 			ByOptionsLister: i,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
 			assert.Equal(t, db, dbClient)
 			assert.Equal(t, true, shouldEncrypt)
-			assert.Equal(t, 10, maxEventsCount)
+			assert.Equal(t, 5*time.Second, gcInterval)
+			assert.Equal(t, 10, gcKeepCount)
 			assert.Nil(t, externalUpdateInfo)
 			return i, nil
 		}
 		f := &CacheFactory{
-			defaultMaximumEventsCount: 10,
-			dbClient:                  dbClient,
-			newInformer:               testNewInformer,
-			encryptAll:                true,
-			informers:                 map[schema.GroupVersionKind]*guardedInformer{},
-		}
-		f.ctx, f.cancel = context.WithCancel(context.Background())
-
-		go func() {
-			time.Sleep(10 * time.Second)
-			f.cancel()
-		}()
-		var c Cache
-		var err error
-		// CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool)
-		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
-		assert.Nil(t, err)
-		assert.Equal(t, expectedC, c)
-		time.Sleep(1 * time.Second)
-	}})
-	tests = append(tests, testCase{description: "CacheFor() with per GVK maximum events count", test: func(t *testing.T) {
-		dbClient := NewMockClient(gomock.NewController(t))
-		dynamicClient := NewMockResourceInterface(gomock.NewController(t))
-		fields := [][]string{{"something"}}
-		expectedGVK := schema.GroupVersionKind{
-			Group:   "management.cattle.io",
-			Version: "v3",
-			Kind:    "Token",
-		}
-		sii := NewMockSharedIndexInformer(gomock.NewController(t))
-		sii.EXPECT().HasSynced().Return(true)
-		sii.EXPECT().Run(gomock.Any()).MinTimes(1).AnyTimes()
-		sii.EXPECT().SetWatchErrorHandler(gomock.Any())
-		i := &informer.Informer{
-			// need to set this so Run function is not nil
-			SharedIndexInformer: sii,
-		}
-		expectedC := Cache{
-			ByOptionsLister: i,
-		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt, namespaced bool, watchable bool, maxEventsCount int) (*informer.Informer, error) {
-			assert.Equal(t, client, dynamicClient)
-			assert.Equal(t, fields, fields)
-			assert.Equal(t, expectedGVK, gvk)
-			assert.Equal(t, db, dbClient)
-			assert.Equal(t, true, shouldEncrypt)
-			assert.Equal(t, 10, maxEventsCount)
-			assert.Nil(t, externalUpdateInfo)
-			return i, nil
-		}
-		f := &CacheFactory{
-			defaultMaximumEventsCount: 5,
-			perGVKMaximumEventsCount: map[schema.GroupVersionKind]int{
-				expectedGVK: 10,
-			},
+			gcInterval:  5 * time.Second,
+			gcKeepCount: 10,
 			dbClient:    dbClient,
 			newInformer: testNewInformer,
 			encryptAll:  true,
@@ -487,6 +435,7 @@ func TestCacheFor(t *testing.T) {
 		}()
 		var c Cache
 		var err error
+		// CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool)
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -55,7 +55,7 @@ var newInformer = cache.NewSharedIndexInformer
 
 // NewInformer returns a new SQLite-backed Informer for the type specified by schema in unstructured.Unstructured form
 // using the specified client
-func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, maxEventsCount int) (*Informer, error) {
+func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*Informer, error) {
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		return client.Watch(ctx, options)
 	}
@@ -118,9 +118,10 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 	}
 
 	opts := ListOptionIndexerOptions{
-		Fields:             fields,
-		IsNamespaced:       namespaced,
-		MaximumEventsCount: maxEventsCount,
+		Fields:       fields,
+		IsNamespaced: namespaced,
+		GCInterval:   gcInterval,
+		GCKeepCount:  gcKeepCount,
 	}
 	loi, err := NewListOptionIndexer(ctx, s, opts)
 	if err != nil {

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -81,7 +81,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0, 0)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -105,7 +105,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewIndexer(), should return an error", test: func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewListOptionIndexer(), should return an error", test: func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with transform func", test: func(t *testing.T) {
@@ -257,7 +257,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0, 0)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -293,7 +293,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0, 0)
 		assert.Error(t, err)
 		newInformer = cache.NewSharedIndexInformer
 	}})

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -206,16 +206,18 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 			return &db.QueryError{QueryString: createEventsTableFmt, Err: err}
 		}
 
-		_, err = tx.Exec(fmt.Sprintf(createFieldsTableFmt, dbName, strings.Join(columnDefs, ", ")))
+		createFieldsTableQuery := fmt.Sprintf(createFieldsTableFmt, dbName, strings.Join(columnDefs, ", "))
+		_, err = tx.Exec(createFieldsTableQuery)
 		if err != nil {
-			return err
+			return &db.QueryError{QueryString: createFieldsTableQuery, Err: err}
 		}
 
 		for index, field := range indexedFields {
 			// create index for field
-			_, err = tx.Exec(fmt.Sprintf(createFieldsIndexFmt, dbName, field, dbName, field))
+			createFieldsIndexQuery := fmt.Sprintf(createFieldsIndexFmt, dbName, field, dbName, field)
+			_, err = tx.Exec(createFieldsIndexQuery)
 			if err != nil {
-				return err
+				return &db.QueryError{QueryString: createFieldsIndexQuery, Err: err}
 			}
 
 			// format field into column for prepared statement
@@ -817,7 +819,7 @@ func (l *ListOptionIndexer) executeQuery(ctx context.Context, queryInfo *QueryIn
 		}
 		items, err = l.ReadObjects(rows, l.GetType(), l.GetShouldEncrypt())
 		if err != nil {
-			return err
+			return fmt.Errorf("read objects: %w", err)
 		}
 
 		total = len(items)

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -98,9 +98,9 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().Prepare(gomock.Any()).Return(stmt).AnyTimes()
 		// end NewIndexer() logic
 
-		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(4)
+		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(3)
 		store.EXPECT().RegisterAfterDeleteAll(gomock.Any()).Times(2)
 
 		// create events table
@@ -175,9 +175,9 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().Prepare(gomock.Any()).Return(stmt).AnyTimes()
 		// end NewIndexer() logic
 
-		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(4)
+		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(3)
 		store.EXPECT().RegisterAfterDeleteAll(gomock.Any()).Times(2)
 
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error"))
@@ -210,9 +210,9 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().Prepare(gomock.Any()).Return(stmt).AnyTimes()
 		// end NewIndexer() logic
 
-		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(4)
+		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(3)
 		store.EXPECT().RegisterAfterDeleteAll(gomock.Any()).Times(2)
 
 		txClient.EXPECT().Exec(fmt.Sprintf(createEventsTableFmt, id)).Return(nil, nil)
@@ -255,9 +255,9 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().Prepare(gomock.Any()).Return(stmt).AnyTimes()
 		// end NewIndexer() logic
 
-		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(4)
+		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(3)
 		store.EXPECT().RegisterAfterDeleteAll(gomock.Any()).Times(2)
 
 		txClient.EXPECT().Exec(fmt.Sprintf(createEventsTableFmt, id)).Return(nil, nil)
@@ -304,9 +304,9 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().Prepare(gomock.Any()).Return(stmt).AnyTimes()
 		// end NewIndexer() logic
 
-		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(4)
-		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(4)
+		store.EXPECT().RegisterAfterAdd(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterUpdate(gomock.Any()).Times(3)
+		store.EXPECT().RegisterAfterDelete(gomock.Any()).Times(3)
 		store.EXPECT().RegisterAfterDeleteAll(gomock.Any()).Times(2)
 
 		txClient.EXPECT().Exec(fmt.Sprintf(createEventsTableFmt, id)).Return(nil, nil)
@@ -2745,7 +2745,8 @@ func TestWatchGarbageCollection(t *testing.T) {
 	parentCtx := context.Background()
 
 	opts := ListOptionIndexerOptions{
-		MaximumEventsCount: 2,
+		GCInterval:  40 * time.Millisecond,
+		GCKeepCount: 2,
 	}
 	loi, dbPath, err := makeListOptionIndexer(parentCtx, opts)
 	defer cleanTempFiles(dbPath)
@@ -2773,6 +2774,9 @@ func TestWatchGarbageCollection(t *testing.T) {
 	err = loi.Delete(barDeleted)
 	assert.NoError(t, err)
 	rv4 := getRV(t)
+
+	// Make sure GC runs
+	time.Sleep(2 * opts.GCInterval)
 
 	for _, rv := range []string{rv1, rv2} {
 		watcherCh, errCh := startWatcher(parentCtx, loi, rv)
@@ -2810,6 +2814,9 @@ func TestWatchGarbageCollection(t *testing.T) {
 	err = loi.Add(barNew)
 	assert.NoError(t, err)
 	rv5 := getRV(t)
+
+	// Make sure GC runs
+	time.Sleep(2 * opts.GCInterval)
 
 	for _, rv := range []string{rv1, rv2, rv3} {
 		watcherCh, errCh := startWatcher(parentCtx, loi, rv)

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -314,7 +314,7 @@ func (s *Store) Reset() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if err := s.cacheFactory.Reset(); err != nil {
-		return err
+		return fmt.Errorf("reset: %w", err)
 	}
 
 	if err := s.initializeNamespaceCache(); err != nil {
@@ -781,7 +781,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 	ns := attributes.Namespaced(apiSchema)
 	inf, err := s.cacheFactory.CacheFor(s.ctx, fields, externalGVKDependencies[gvk], selfGVKDependencies[gvk], transformFunc, tableClient, gvk, ns, controllerschema.IsListWatchable(apiSchema))
 	if err != nil {
-		return nil, 0, "", err
+		return nil, 0, "", fmt.Errorf("cachefor %v: %w", gvk, err)
 	}
 	if gvk.Group == "ext.cattle.io" && (gvk.Kind == "Token" || gvk.Kind == "Kubeconfig") {
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
@@ -811,7 +811,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		if errors.Is(err, informer.ErrInvalidColumn) {
 			return nil, 0, "", apierror.NewAPIError(validation.InvalidBodyContent, err.Error())
 		}
-		return nil, 0, "", err
+		return nil, 0, "", fmt.Errorf("listbyoptions %v: %w", gvk, err)
 	}
 
 	return list, total, continueToken, nil


### PR DESCRIPTION
# Context

(Need to create the issue for this)

We do garbage collection on the *_events table to prevent infinite growing of that table (and thus disk usage). The current way has been found to be taking a lot of CPU when a lot of events are coming in.

This PR introduce a time-based approach to GC: every X interval we run the GC query, which keeps only a configured N events. In a future Rancher/rancher PR, this will be configured via two settings.

The PR includes some additional error wrapping for sQL code (which were found missing). 

That NewInformer function has way too many parameters but I hope to change the way we create informers and cache factories in near future so I kept it this way for now..

I have also moved the log message "CacheFor blablabla" to be an Info message after some feedback on slack.