### PR TITLE
VAI: Replace namespace+name default sort with id 

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -794,7 +794,8 @@ func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions 
 	} else {
 		// make sure one default order is always picked
 		if l.namespaced {
-			query += "\n  ORDER BY f.\"metadata.namespace\" ASC, f.\"metadata.name\" ASC "
+			// ID == metadata.namespace + "/" + metaqata.name
+			query += "\n  ORDER BY f.\"id\" ASC "
 		} else {
 			query += "\n  ORDER BY f.\"metadata.name\" ASC "
 		}

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -1112,6 +1113,145 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			assert.Equal(t, test.expectedContToken, contToken)
 		})
 	}
+}
+
+func makePseudoRandomList(size int) *unstructured.UnstructuredList {
+	numLength := 1 + int(math.Floor(math.Log10(float64(size))))
+	name_template := fmt.Sprintf("n%%0%dd", numLength)
+	// Make a predictable but randomish list of numbers
+	// item 0: ns0, n0
+	// item 23: ns0, n1
+	// item 46: ns0, n2
+	// At some point the index will be set back to the start
+	// the ns value goes up every <ns_delta> hits
+	// the name_val is the index, and i provides the name-value as we walk through the array.
+	// Use any size, as long as both name_delta (23) and ns_delta (17) are relatively prime to it.
+	// This assures that every index in the array will be initialized to an actual object
+	name_val := 0
+	name_delta := 23 // space the names out in runs of 23
+
+	ns_val := 0
+	ns_block := 0
+	ns_delta := 17 // so only 17 namespaces
+	namespace_template := "ns%02d"
+
+	items := make([]unstructured.Unstructured, size)
+	for i := range size {
+		nv := fmt.Sprintf(name_template, i)
+		nsv := fmt.Sprintf(namespace_template, ns_block)
+		obj := unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      nv,
+					"namespace": nsv,
+				},
+				"id": nv + "/" + nsv,
+			},
+		}
+		items[name_val] = obj
+		name_val += name_delta
+		if name_val >= size {
+			name_val -= size
+		}
+		ns_val += ns_delta
+		if ns_val >= size {
+			ns_val -= size
+			ns_block += 1
+		}
+	}
+	ulist := &unstructured.UnstructuredList{
+		Items: items,
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ConfigMap",
+	}
+	ulist.SetGroupVersionKind(gvk)
+	return ulist
+}
+
+func verifyListIsSorted(b *testing.B, list *unstructured.UnstructuredList, size int) {
+	for i := range size - 1 {
+		curr := list.Items[i]
+		next := list.Items[i+1]
+		if curr.GetNamespace() == next.GetNamespace() {
+			assert.Less(b, curr.GetName(), next.GetName())
+		} else {
+			assert.Less(b, curr.GetNamespace(), next.GetNamespace())
+		}
+	}
+}
+func BenchmarkNamespaceNameList(b *testing.B) {
+	// At 50,000,000 this starts to get very slow
+	size := 10000
+	itemList := makePseudoRandomList(size)
+	ctx := context.Background()
+	opts := ListOptionIndexerOptions{
+		IsNamespaced: true,
+	}
+	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+	defer cleanTempFiles(dbPath)
+	assert.NoError(b, err)
+	for _, item := range itemList.Items {
+		err = loi.Add(&item)
+		assert.NoError(b, err)
+	}
+	b.Run(fmt.Sprintf("sort-%d with explicit namespace/name", size), func(b *testing.B) {
+		listOptions := sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "namespace"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields: []string{"metadata", "name"},
+						Order:  sqltypes.ASC,
+					},
+				},
+			},
+		}
+		partitions := []partition.Partition{{All: true}}
+		ns := ""
+		list, total, _, err := loi.ListByOptions(ctx, &listOptions, partitions, ns)
+		if err != nil {
+			b.Fatal("error getting data", err)
+		}
+		if total != size {
+			b.Errorf("expecting %d items, got %d", size, total)
+		}
+		if len(list.Items) != size {
+			b.Errorf("expecting %d items, got %d", size, len(list.Items))
+		}
+		//verifyListIsSorted(b, list, size)
+	})
+	b.Run(fmt.Sprintf("sort-%d with explicit id", size), func(b *testing.B) {
+		listOptions := sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"id"},
+						Order:  sqltypes.ASC,
+					},
+				},
+			},
+		}
+		partitions := []partition.Partition{{All: true}}
+		ns := ""
+		list, total, _, err := loi.ListByOptions(ctx, &listOptions, partitions, ns)
+		if err != nil {
+			b.Fatal("error getting data", err)
+		}
+		if total != size {
+			b.Errorf("expecting %d items, got %d", size, total)
+		}
+		if len(list.Items) != size {
+			b.Errorf("expecting %d items, got %d", size, len(list.Items))
+		}
+		//verifyListIsSorted(b, list, size)
+	})
+
 }
 
 func TestUserDefinedExtractFunction(t *testing.T) {

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -61,7 +61,7 @@ func (i *IntegrationSuite) TearDownSuite() {
 }
 
 func (i *IntegrationSuite) TestSQLCacheFilters() {
-	fields := [][]string{{"metadata", "annotations", "somekey"}}
+	fields := [][]string{{"id"}, {"metadata", "annotations", "somekey"}}
 	require := i.Require()
 	configMapWithAnnotations := func(name string, annotations map[string]string) v1.ConfigMap {
 		return v1.ConfigMap{


### PR DESCRIPTION
Related to [#50999](https://github.com/rancher/rancher/issues/50999)

The problem this PR solves is that while there are indices on the `namespace` and
`name` fields for each table, there isn't a combined index for the two fields.
It turns out that the `id` field is always set to either `<namespace>/<name>` or `<name>`
for non-namespaced resources, and it's indexed, so we can sort on that.

<strike>
The second commit adds benchmarks. Here are the results:
```
Size    Namespace+Name (ns) time/size (psec)    Id (ns)   time/size (psec)  Indexed NS+N per/size
1000    0.0307               0.0307              0.0165    0.0165            0.01607       0.0161
5000    0.0959               0.0192              0.0821    0.0164            0.08147       0.0163
10000   0.1765               0.0177              0.1845    0.0185            0.1743        0.0174
50000   0.8637               0.0173              0.9515    0.0190            0.8982        0.0180
100000  1.8877               0.0189              2.1145    0.0211            1.8402        0.0184


```

The main thing this tells us is that for smaller datasets sorting by `id` is faster,
but it starts to become slower than the unindexed `namespace`+`name`. I think
this is because the database can very quickly sort items by `namespace` first (as
it's indexed), and since there are smaller sets of `names` within each namespace,
assuming an `O(n log n)` algorithm, sorting each set of names is very fast. With
the combined `id` sort, we get no advantage of first partitioning the data.

The right most pair of columns show the results for adding a combined index. These results
are better for both the unindexed ns+name and id in 9 out of 10 cases. I say we go with that instead.

So another commit on its way…
</strike>

Silvio posted some benchmarks on a networked system that shows that sorting on `id` is much faster than `namespace`+`name` -- this is because the second sort ends up doing a linear search on the `name` field. By `id` everything is indexed.


