### PR TITLE
Respect shouldEncrypt configuration when storing events

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -49,6 +49,8 @@ type Client interface {
 	Upsert(tx transaction.Client, stmt *sql.Stmt, key string, obj any, shouldEncrypt bool) error
 	CloseStmt(closable Closable) error
 	NewConnection(isTemp bool) (string, error)
+	Encryptor() Encryptor
+	Decryptor() Decryptor
 }
 
 // WithTransaction runs f within a transaction.
@@ -362,6 +364,14 @@ func (c *client) Upsert(tx transaction.Client, stmt *sql.Stmt, key string, obj a
 
 	_, err = tx.Stmt(stmt).Exec(key, objBytes, dataNonce, kid)
 	return err
+}
+
+func (c *client) Encryptor() Encryptor {
+	return c.encryptor
+}
+
+func (c *client) Decryptor() Decryptor {
+	return c.decryptor
 }
 
 // toBytes encodes an object to a byte slice

--- a/pkg/sqlcache/informer/db_mocks_test.go
+++ b/pkg/sqlcache/informer/db_mocks_test.go
@@ -141,6 +141,34 @@ func (mr *MockClientMockRecorder) CloseStmt(closable any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseStmt", reflect.TypeOf((*MockClient)(nil).CloseStmt), closable)
 }
 
+// Decryptor mocks base method.
+func (m *MockClient) Decryptor() db.Decryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Decryptor")
+	ret0, _ := ret[0].(db.Decryptor)
+	return ret0
+}
+
+// Decryptor indicates an expected call of Decryptor.
+func (mr *MockClientMockRecorder) Decryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decryptor", reflect.TypeOf((*MockClient)(nil).Decryptor))
+}
+
+// Encryptor mocks base method.
+func (m *MockClient) Encryptor() db.Encryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Encryptor")
+	ret0, _ := ret[0].(db.Encryptor)
+	return ret0
+}
+
+// Encryptor indicates an expected call of Encryptor.
+func (mr *MockClientMockRecorder) Encryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encryptor", reflect.TypeOf((*MockClient)(nil).Encryptor))
+}
+
 // NewConnection mocks base method.
 func (m *MockClient) NewConnection(isTemp bool) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/informer/factory/db_mocks_test.go
+++ b/pkg/sqlcache/informer/factory/db_mocks_test.go
@@ -57,6 +57,34 @@ func (mr *MockClientMockRecorder) CloseStmt(closable any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseStmt", reflect.TypeOf((*MockClient)(nil).CloseStmt), closable)
 }
 
+// Decryptor mocks base method.
+func (m *MockClient) Decryptor() db.Decryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Decryptor")
+	ret0, _ := ret[0].(db.Decryptor)
+	return ret0
+}
+
+// Decryptor indicates an expected call of Decryptor.
+func (mr *MockClientMockRecorder) Decryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decryptor", reflect.TypeOf((*MockClient)(nil).Decryptor))
+}
+
+// Encryptor mocks base method.
+func (m *MockClient) Encryptor() db.Encryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Encryptor")
+	ret0, _ := ret[0].(db.Encryptor)
+	return ret0
+}
+
+// Encryptor indicates an expected call of Encryptor.
+func (mr *MockClientMockRecorder) Encryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encryptor", reflect.TypeOf((*MockClient)(nil).Encryptor))
+}
+
 // NewConnection mocks base method.
 func (m *MockClient) NewConnection(isTemp bool) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/informer/sql_mocks_test.go
+++ b/pkg/sqlcache/informer/sql_mocks_test.go
@@ -71,6 +71,20 @@ func (mr *MockStoreMockRecorder) CloseStmt(closable any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseStmt", reflect.TypeOf((*MockStore)(nil).CloseStmt), closable)
 }
 
+// Decryptor mocks base method.
+func (m *MockStore) Decryptor() db.Decryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Decryptor")
+	ret0, _ := ret[0].(db.Decryptor)
+	return ret0
+}
+
+// Decryptor indicates an expected call of Decryptor.
+func (mr *MockStoreMockRecorder) Decryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decryptor", reflect.TypeOf((*MockStore)(nil).Decryptor))
+}
+
 // Delete mocks base method.
 func (m *MockStore) Delete(obj any) error {
 	m.ctrl.T.Helper()
@@ -83,6 +97,20 @@ func (m *MockStore) Delete(obj any) error {
 func (mr *MockStoreMockRecorder) Delete(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), obj)
+}
+
+// Encryptor mocks base method.
+func (m *MockStore) Encryptor() db.Encryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Encryptor")
+	ret0, _ := ret[0].(db.Encryptor)
+	return ret0
+}
+
+// Encryptor indicates an expected call of Encryptor.
+func (mr *MockStoreMockRecorder) Encryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encryptor", reflect.TypeOf((*MockStore)(nil).Encryptor))
 }
 
 // Get mocks base method.

--- a/pkg/sqlcache/store/db_mocks_test.go
+++ b/pkg/sqlcache/store/db_mocks_test.go
@@ -141,6 +141,34 @@ func (mr *MockClientMockRecorder) CloseStmt(closable any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseStmt", reflect.TypeOf((*MockClient)(nil).CloseStmt), closable)
 }
 
+// Decryptor mocks base method.
+func (m *MockClient) Decryptor() db.Decryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Decryptor")
+	ret0, _ := ret[0].(db.Decryptor)
+	return ret0
+}
+
+// Decryptor indicates an expected call of Decryptor.
+func (mr *MockClientMockRecorder) Decryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decryptor", reflect.TypeOf((*MockClient)(nil).Decryptor))
+}
+
+// Encryptor mocks base method.
+func (m *MockClient) Encryptor() db.Encryptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Encryptor")
+	ret0, _ := ret[0].(db.Encryptor)
+	return ret0
+}
+
+// Encryptor indicates an expected call of Encryptor.
+func (mr *MockClientMockRecorder) Encryptor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encryptor", reflect.TypeOf((*MockClient)(nil).Encryptor))
+}
+
 // NewConnection mocks base method.
 func (m *MockClient) NewConnection(isTemp bool) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Issue

In https://github.com/rancher/rancher/issues/40773 we introduced a new `_events` table to store Events to be able to support watches and resource version. In that table we store the resource version, the type of event and the object.

By default, the SQL cache encrypts Tokens and Secrets object. It's also possible to encrypt all objects by setting the env var `CATTLE_ENCRYPT_CACHE_ALL=true`.

When trying to allow multiple encoding options for objects in the DB (as it's currently using `gob`), I noticed that the objects in the events table wasn't encrypted. As such, this adds this support.

Note: The code is essentially the same as https://github.com/rancher/steve/blob/2bba9dfd5c468e594a193a2691d99d7d23a47839/pkg/sqlcache/db/client.go#L354-L363 and https://github.com/rancher/steve/blob/2bba9dfd5c468e594a193a2691d99d7d23a47839/pkg/sqlcache/db/client.go#L335-L349.

---

Since we're so late in the release cycle, I refrained from making big changes to the codebase. But if we go forward with the different encoding approach then I'll probably end up pulling out the encryptor outside of the DB code, so the DB would only store a blob and not "know" about the encryption. (eg: removing the nonce / kid columns).