### PR TITLE
Stop resetting the VAI DB on any schema or api-service change.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -237,9 +237,6 @@ func setup(ctx context.Context, server *Server) error {
 			if err := ccache.OnSchemas(schemas); err != nil {
 				return err
 			}
-			if err := s.Reset(); err != nil {
-				return err
-			}
 			return nil
 		}
 	} else {


### PR DESCRIPTION
## DO NOT MERGE

### Until v2.12 has shipped -t his is for 2.12.1

Related to [#50978](https://github.com/rancher/rancher/issues/50978)

These are the only two paths into

`pkg/controllers/schema.handler#refreshAll()`, from `OnChangeCRD` and `OnChangeAPIService` .

A change in either of these doesn't need a change in the DB schema, and we still update VAI tables when an object is modified or deleted, so there's no need to reset the DB regarding the data either. 