### PR TITLE
Delete only the tables that have changed.

### DIFF
--- a/pkg/clustercache/controller.go
+++ b/pkg/clustercache/controller.go
@@ -30,7 +30,7 @@ type ClusterCache interface {
 	OnAdd(ctx context.Context, handler Handler)
 	OnRemove(ctx context.Context, handler Handler)
 	OnChange(ctx context.Context, handler ChangeHandler)
-	OnSchemas(schemas *schema.Collection) error
+	OnSchemas(schemas *schema.Collection, unused *schema.Collection) error
 }
 
 type event struct {
@@ -124,7 +124,7 @@ func (h *clusterCache) addResourceEventHandler(gvk schema2.GroupVersionKind, inf
 	})
 }
 
-func (h *clusterCache) OnSchemas(schemas *schema.Collection) error {
+func (h *clusterCache) OnSchemas(schemas *schema.Collection, _ *schema.Collection) error {
 	h.Lock()
 	defer h.Unlock()
 

--- a/pkg/controllers/schema/schemas.go
+++ b/pkg/controllers/schema/schemas.go
@@ -44,7 +44,7 @@ type handler struct {
 	ctx            context.Context
 	toSync         int32
 	schemas        *schema2.Collection
-	dbschemas        *schema2.Collection
+	dbschemas      *schema2.Collection
 	client         discovery.DiscoveryInterface
 	cols           *common.DynamicColumns
 	crd            apiextcontrollerv1.CustomResourceDefinitionClient
@@ -70,7 +70,7 @@ func Register(ctx context.Context,
 		cols:           cols,
 		client:         discovery,
 		schemas:        schemas,
-		dbschemas:        dbschemas,
+		dbschemas:      dbschemas,
 		handler:        schemasHandler,
 		crd:            crd,
 		ssar:           ssar,

--- a/pkg/resources/counts/counts_test.go
+++ b/pkg/resources/counts/counts_test.go
@@ -273,7 +273,7 @@ func (f *fakeClusterCache) OnChange(ctx context.Context, handler clustercache.Ch
 	f.changeHandler = handler
 }
 
-func (f *fakeClusterCache) OnSchemas(schemas *schema.Collection, *schema.Collection) error {
+func (f *fakeClusterCache) OnSchemas(schemas *schema.Collection, unusedSchemas *schema.Collection) error {
 	return nil
 }
 

--- a/pkg/resources/counts/counts_test.go
+++ b/pkg/resources/counts/counts_test.go
@@ -273,7 +273,7 @@ func (f *fakeClusterCache) OnChange(ctx context.Context, handler clustercache.Ch
 	f.changeHandler = handler
 }
 
-func (f *fakeClusterCache) OnSchemas(schemas *schema.Collection) error {
+func (f *fakeClusterCache) OnSchemas(schemas *schema.Collection, *schema.Collection) error {
 	return nil
 }
 

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -281,6 +281,20 @@ func (mr *MockCacheFactoryMockRecorder) CacheFor(ctx, fields, externalUpdateInfo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable)
 }
 
+// DeleteTablesForGVK mocks base method.
+func (m *MockCacheFactory) DeleteTablesForGVK(gvk schema.GroupVersionKind) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTablesForGVK", gvk)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTablesForGVK indicates an expected call of DeleteTablesForGVK.
+func (mr *MockCacheFactoryMockRecorder) DeleteTablesForGVK(gvk any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTablesForGVK", reflect.TypeOf((*MockCacheFactory)(nil).DeleteTablesForGVK), gvk)
+}
+
 // Reset mocks base method.
 func (m *MockCacheFactory) Reset() error {
 	m.ctrl.T.Helper()

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -299,7 +299,12 @@ type CacheFactoryInitializer func() (CacheFactory, error)
 
 type CacheFactory interface {
 	CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (factory.Cache, error)
+	DeleteTablesForGVK(gvk schema.GroupVersionKind) error
 	Reset() error
+}
+
+func (s *Store) DeleteTablesForGVK(gvk schema.GroupVersionKind) error {
+	return s.cacheFactory.DeleteTablesForGVK(gvk)
 }
 
 // NewProxyStore returns a Store implemented directly on top of kubernetes.

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -374,7 +374,7 @@ func (s *Store) initializeNamespaceCache() error {
 
 	gvk := attributes.GVK(&nsSchema)
 	// get fields from schema's columns
-	fields := getFieldsFromSchema(&nsSchema)
+	fields := GetFieldsFromSchema(&nsSchema)
 
 	// get any type-specific fields that steve is interested in
 	fields = append(fields, getFieldForGVK(gvk)...)
@@ -408,9 +408,9 @@ func gvkKey(group, version, kind string) string {
 	return group + "_" + version + "_" + kind
 }
 
-// getFieldsFromSchema converts object field names from types.APISchema's format into steve's
+// GetFieldsFromSchema converts object field names from types.APISchema's format into steve's
 // cache.sql.informer's slice format (e.g. "metadata.resourceVersion" is ["metadata", "resourceVersion"])
-func getFieldsFromSchema(schema *types.APISchema) [][]string {
+func GetFieldsFromSchema(schema *types.APISchema) [][]string {
 	var fields [][]string
 	columns := attributes.Columns(schema)
 	if columns == nil {
@@ -586,7 +586,7 @@ func newWatchers() *Watchers {
 func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest, client dynamic.ResourceInterface) (chan watch.Event, error) {
 	// warnings from inside the informer are discarded
 	gvk := attributes.GVK(schema)
-	fields := getFieldsFromSchema(schema)
+	fields := GetFieldsFromSchema(schema)
 	fields = append(fields, getFieldForGVK(gvk)...)
 	cols := common.GetColumnDefinitions(schema)
 	transformFunc := s.transformBuilder.GetTransformFunc(gvk, cols, attributes.IsCRD(schema))
@@ -793,7 +793,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		return nil, 0, "", err
 	}
 	gvk := attributes.GVK(apiSchema)
-	fields := getFieldsFromSchema(apiSchema)
+	fields := GetFieldsFromSchema(apiSchema)
 	fields = append(fields, getFieldForGVK(gvk)...)
 	cols := common.GetColumnDefinitions(apiSchema)
 


### PR DESCRIPTION
Pertaining to [#50978](https://github.com/rancher/rancher/issues/50978)

Do all the same things as in non-VAI when a schema changes, but this time only delete the tables that have
an informer.

Note that this still runs through all the schemas due to the call to `refreshAll`. I think all change that on the VAI side.