### PR TITLE
Reset db more selectively: approach #2

### DIFF
--- a/pkg/controllers/schema/schemas.go
+++ b/pkg/controllers/schema/schemas.go
@@ -150,8 +150,9 @@ func (h *handler) queueRefresh() {
 			h.changedIDs = make(map[k8sapimachineryschema.GroupVersionKind]bool)
 		}
 		h.Unlock()
-		if len(changedIDs) > 0 || len(deletedCRDs) > 0 || len(createdCRDs) > 0 {
-			err = h.refreshAll(h.ctx, changedIDs, len(deletedCRDs) > 0 || len(createdCRDs) > 0)
+		crdNumCountChanged := len(deletedCRDs) > 0 || len(createdCRDs) > 0
+		if len(changedIDs) > 0 || crdNumCountChanged {
+			err = h.refreshAll(h.ctx, changedIDs, crdNumCountChanged)
 		}
 		if err != nil {
 			logrus.Errorf("failed to sync schemas: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
+	"sync"
 
 	apiserver "github.com/rancher/apiserver/pkg/server"
 	"github.com/rancher/apiserver/pkg/types"
@@ -29,6 +31,7 @@ import (
 	"github.com/rancher/steve/pkg/stores/sqlpartition"
 	"github.com/rancher/steve/pkg/stores/sqlproxy"
 	"github.com/rancher/steve/pkg/summarycache"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
 
@@ -210,7 +213,7 @@ func setup(ctx context.Context, server *Server) error {
 
 	var onSchemasHandler schemacontroller.SchemasHandlerFunc
 	if server.SQLCache {
-		s, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, server.cacheFactory)
+		sqlStore, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, server.cacheFactory, false)
 		if err != nil {
 			panic(err)
 		}
@@ -219,7 +222,7 @@ func setup(ctx context.Context, server *Server) error {
 			proxy.NewUnformatterStore(
 				proxy.NewWatchRefresh(
 					sqlpartition.NewStore(
-						s,
+						sqlStore,
 						asl,
 					),
 					asl,
@@ -232,12 +235,52 @@ func setup(ctx context.Context, server *Server) error {
 		for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), common.TemplateOptions{InSQLMode: true}) {
 			sf.AddTemplate(template)
 		}
+		mutex := &sync.Mutex{}
+		fieldsForSchema := make(map[string][][]string) // map schemaID to fields
+		initializedDB := false
 
-		onSchemasHandler = func(schemas *schema.Collection) error {
+		onSchemasHandler = func(schemas *schema.Collection, changedSchemas map[string]*types.APISchema, deletedSomething bool) error {
+			resetEverything := false
+			// We need a mutex around the fieldsForSchema closure because this handler is invoked asynchronously
+			// from the server
+			mutex.Lock()
+			if !initializedDB {
+				initializedDB = true
+				resetEverything = true
+				for _, id := range schemas.IDs() {
+					theSchema := schemas.Schema(id)
+					if theSchema == nil {
+						fieldsForSchema[id] = [][]string{}
+						continue
+					}
+					fieldsForSchema[id] = sqlproxy.GetFieldsFromSchema(theSchema)
+				}
+				logrus.Debugf("onSchemasHandler: need to reset everything on first run")
+			} else {
+				for id, theSchema := range changedSchemas {
+					oldFields, ok := fieldsForSchema[id]
+					newFields := sqlproxy.GetFieldsFromSchema(theSchema)
+					if !ok || !slices.EqualFunc(oldFields, newFields,
+						func(s1, s2 []string) bool {
+							return slices.Equal(s1, s2)
+						}) {
+						resetEverything = true
+					}
+					fieldsForSchema[id] = newFields
+				}
+				if deletedSomething {
+					resetEverything = true
+				}
+				logrus.Debugf("onSchemasHandler: need to reset everything: %t", resetEverything)
+			}
+			mutex.Unlock()
+			if !resetEverything {
+				return nil
+			}
 			if err := ccache.OnSchemas(schemas); err != nil {
 				return err
 			}
-			if err := s.Reset(); err != nil {
+			if err := sqlStore.Reset(); err != nil {
 				return err
 			}
 			return nil
@@ -246,7 +289,9 @@ func setup(ctx context.Context, server *Server) error {
 		for _, template := range resources.DefaultSchemaTemplates(cf, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), server.controllers.Core.Namespace().Cache(), common.TemplateOptions{InSQLMode: false}) {
 			sf.AddTemplate(template)
 		}
-		onSchemasHandler = ccache.OnSchemas
+		onSchemasHandler = func(schemas *schema.Collection, _ map[string]*types.APISchema, _ bool) error {
+			return ccache.OnSchemas(schemas)
+		}
 	}
 
 	schemas.SetupWatcher(ctx, server.BaseSchemas, asl, sf)

--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/rancher/steve/pkg/sqlcache/db/transaction"
+	"github.com/sirupsen/logrus"
 
 	// needed for drivers
 	_ "modernc.org/sqlite"
@@ -416,9 +417,12 @@ func (c *client) NewConnection(useTempDir bool) (string, error) {
 		}
 	}
 	if !useTempDir {
-		err := os.RemoveAll(InformerObjectCacheDBPath)
-		if err != nil {
-			return "", err
+		for _, suffix := range []string{"", "-shm", "-wal"} {
+			f := InformerObjectCacheDBPath + suffix
+			err := os.RemoveAll(f)
+			if err != nil {
+				logrus.Errorf("error removing existing db file %s: %v", f, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to [#509780(https://github.com/rancher/rancher/issues/50978)

This is the first step to solving the underlying problem that we reset the VAI database too often.

This PR ensures the database and informers/watchers are initialized, and then resets them only
when there's been a change that requires doing that. These changes are limited to:

1. A change in a CRD that caused a change in the schema fields that we need to index in the database
2. A CRD is deleted
3. A new CRD is added