### PR TITLE
Create a compound index on namespace+name

### DIFF
--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -44,6 +44,7 @@ func TestNewInformer(t *testing.T) {
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -169,6 +170,7 @@ func TestNewInformer(t *testing.T) {
 		// is tested in depth in its own indexer_test.go
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -240,6 +242,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
 		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -41,10 +41,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(4)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -68,12 +65,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(6)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -181,12 +173,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(6)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error")).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)
@@ -242,13 +229,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
-		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil)
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(7)
 		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
 				err := f(txClient)

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -227,10 +227,9 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 			setStatement := fmt.Sprintf(`"%s" = excluded."%s"`, field, field)
 			setStatements[index] = setStatement
 		}
-		if slices.Contains(indexedFields, "metadata.name") && slices.Contains(indexedFields, "metadata.namespace") {
+		if opts.IsNamespaced {
 			mdn := "metadata.name"
 			mdns := "metadata.namespace"
-			// createDoubleFieldsIndexFmt = `CREATE INDEX "%s_%s_%s_index" ON "%s_fields"("%s","%s")`
 			createFieldsIndexQuery := fmt.Sprintf(createDoubleFieldsIndexFmt,
 				dbName, mdns, mdn, dbName, mdns, mdn)
 			_, err = tx.Exec(createFieldsIndexQuery)

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -110,8 +110,9 @@ const (
 			key TEXT NOT NULL PRIMARY KEY,
             %s
 	   )`
-	createFieldsIndexFmt = `CREATE INDEX "%s_%s_index" ON "%s_fields"("%s")`
-	deleteFieldsFmt      = `DELETE FROM "%s_fields"`
+	createFieldsIndexFmt       = `CREATE INDEX "%s_%s_index" ON "%s_fields"("%s")`
+	createDoubleFieldsIndexFmt = `CREATE INDEX "%s_%s_%s_index" ON "%s_fields"("%s","%s")`
+	deleteFieldsFmt            = `DELETE FROM "%s_fields"`
 
 	failedToGetFromSliceFmt = "[listoption indexer] failed to get subfield [%s] from slice items"
 
@@ -229,8 +230,9 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 		if slices.Contains(indexedFields, "metadata.name") && slices.Contains(indexedFields, "metadata.namespace") {
 			mdn := "metadata.name"
 			mdns := "metadata.namespace"
-			createFieldsIndexQuery := fmt.Sprintf(`CREATE INDEX "%s_%s_%s_index" ON "%s_fields"("%s", "%s")`,
-				dbName, mdn, mdns, dbName, mdn, mdns)
+			// createDoubleFieldsIndexFmt = `CREATE INDEX "%s_%s_%s_index" ON "%s_fields"("%s","%s")`
+			createFieldsIndexQuery := fmt.Sprintf(createDoubleFieldsIndexFmt,
+				dbName, mdns, mdn, dbName, mdns, mdn)
 			_, err = tx.Exec(createFieldsIndexQuery)
 			if err != nil {
 				return &db.QueryError{QueryString: createFieldsIndexQuery, Err: err}

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -226,6 +226,16 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 			setStatement := fmt.Sprintf(`"%s" = excluded."%s"`, field, field)
 			setStatements[index] = setStatement
 		}
+		if slices.Contains(indexedFields, "metadata.name") && slices.Contains(indexedFields, "metadata.namespace") {
+			mdn := "metadata.name"
+			mdns := "metadata.namespace"
+			createFieldsIndexQuery := fmt.Sprintf(`CREATE INDEX "%s_%s_%s_index" ON "%s_fields"("%s", "%s")`,
+				dbName, mdn, mdns, dbName, mdn, mdns)
+			_, err = tx.Exec(createFieldsIndexQuery)
+			if err != nil {
+				return &db.QueryError{QueryString: createFieldsIndexQuery, Err: err}
+			}
+		}
 		createLabelsTableQuery := fmt.Sprintf(createLabelsTableFmt, dbName, dbName)
 		_, err = tx.Exec(createLabelsTableQuery)
 		if err != nil {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1128,7 +1128,7 @@ func doBenchmarkSort(b *testing.B, size int, listOptions sqltypes.ListOptions) {
 }
 
 func BenchmarkSorting(b *testing.B) {
-	sizes := []int{1000, 5000, 10000, 50000, 100000, 500000}
+	sizes := []int{1000, 5000, 10000, 50000, 100000}
 	type optionPair struct {
 		stype       string
 		listOptions sqltypes.ListOptions

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1115,6 +1115,7 @@ func verifyListIsSorted(b *testing.B, list *unstructured.UnstructuredList, size 
 }
 func BenchmarkNamespaceNameList(b *testing.B) {
 	// At 50,000,000 this starts to get very slow
+	const listoptionIndexerVerifySort = "LISTOPTION_INDEXER_VERIFY_SORT"
 	size := 10000
 	itemList := makePseudoRandomList(size)
 	ctx := context.Background()
@@ -1155,7 +1156,9 @@ func BenchmarkNamespaceNameList(b *testing.B) {
 		if len(list.Items) != size {
 			b.Errorf("expecting %d items, got %d", size, len(list.Items))
 		}
-		//verifyListIsSorted(b, list, size)
+		if os.Getenv(listoptionIndexerVerifySort) == "true" {
+			verifyListIsSorted(b, list, size)
+		}
 	})
 	b.Run(fmt.Sprintf("sort-%d with explicit id", size), func(b *testing.B) {
 		listOptions := sqltypes.ListOptions{
@@ -1180,7 +1183,9 @@ func BenchmarkNamespaceNameList(b *testing.B) {
 		if len(list.Items) != size {
 			b.Errorf("expecting %d items, got %d", size, len(list.Items))
 		}
-		//verifyListIsSorted(b, list, size)
+		if os.Getenv(listoptionIndexerVerifySort) == "true" {
+			verifyListIsSorted(b, list, size)
+		}
 	})
 }
 

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -53,6 +54,15 @@ func makeListOptionIndexer(ctx context.Context, opts ListOptionIndexerOptions, s
 	s, err := store.NewStore(ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc, db, shouldEncrypt, gvk, name, nil, nil)
 	if err != nil {
 		return nil, "", err
+	}
+	if opts.IsNamespaced {
+		// Can't use slices.Compare because []string doesn't implement comparable
+		idEntry := []string{"id"}
+		if opts.Fields == nil {
+			opts.Fields = [][]string{idEntry}
+		} else {
+			opts.Fields = append(opts.Fields, idEntry)
+		}
 	}
 
 	listOptionIndexer, err := NewListOptionIndexer(ctx, s, opts)
@@ -112,6 +122,10 @@ func TestNewListOptionIndexer(t *testing.T) {
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.namespace", id, "metadata.namespace")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.creationTimestamp", id, "metadata.creationTimestamp")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, fields[0][0], id, fields[0][0])).Return(nil, nil)
+		txClient.EXPECT().Exec(fmt.Sprintf(createDoubleFieldsIndexFmt, id, "metadata.namespace", "metadata.name", id, "metadata.namespace", "metadata.name")).Return(nil, nil)
+
+		//createFieldsIndexQuery := fmt.Sprintf(createDoubleFieldsIndexFmt,
+		//	dbName, mdn, mdns, dbName, mdn, mdns)
 		txClient.EXPECT().Exec(fmt.Sprintf(createLabelsTableFmt, id, id)).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createLabelsTableIndexFmt, id, id)).Return(nil, nil)
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
@@ -266,6 +280,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.namespace", id, "metadata.namespace")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.creationTimestamp", id, "metadata.creationTimestamp")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, fields[0][0], id, fields[0][0])).Return(nil, nil)
+		txClient.EXPECT().Exec(fmt.Sprintf(createDoubleFieldsIndexFmt, id, "metadata.namespace", "metadata.name", id, "metadata.namespace", "metadata.name")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createLabelsTableFmt, id, id)).Return(nil, fmt.Errorf("error"))
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error")).Do(
 			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
@@ -315,6 +330,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.namespace", id, "metadata.namespace")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.creationTimestamp", id, "metadata.creationTimestamp")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, fields[0][0], id, fields[0][0])).Return(nil, nil)
+		txClient.EXPECT().Exec(fmt.Sprintf(createDoubleFieldsIndexFmt, id, "metadata.namespace", "metadata.name", id, "metadata.namespace", "metadata.name")).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createLabelsTableFmt, id, id)).Return(nil, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createLabelsTableIndexFmt, id, id)).Return(nil, nil)
 		store.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(fmt.Errorf("error")).Do(
@@ -1028,6 +1044,144 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			assert.Equal(t, test.expectedContToken, contToken)
 		})
 	}
+}
+
+func makePseudoRandomList(size int) *unstructured.UnstructuredList {
+	numLength := 1 + int(math.Floor(math.Log10(float64(size))))
+	name_template := fmt.Sprintf("n%%0%dd", numLength)
+	// Make a predictable but randomish list of numbers
+	// item 0: ns0, n0
+	// item 23: ns0, n1
+	// item 46: ns0, n2
+	// At some point the index will be set back to the start
+	// the ns value goes up every <ns_delta> hits
+	// the name_val is the index, and i provides the name-value as we walk through the array.
+	// Use any size, as long as both name_delta (23) and ns_delta (17) are relatively prime to it.
+	// This assures that every index in the array will be initialized to an actual object
+	name_val := 0
+	name_delta := 23 // space the names out in runs of 23
+
+	ns_val := 0
+	ns_block := 0
+	ns_delta := 17 // so only 17 namespaces
+	namespace_template := "ns%02d"
+
+	items := make([]unstructured.Unstructured, size)
+	for i := range size {
+		nv := fmt.Sprintf(name_template, i)
+		nsv := fmt.Sprintf(namespace_template, ns_block)
+		obj := unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      nv,
+					"namespace": nsv,
+				},
+				"id": nv + "/" + nsv,
+			},
+		}
+		items[name_val] = obj
+		name_val += name_delta
+		if name_val >= size {
+			name_val -= size
+		}
+		ns_val += ns_delta
+		if ns_val >= size {
+			ns_val -= size
+			ns_block += 1
+		}
+	}
+	ulist := &unstructured.UnstructuredList{
+		Items: items,
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ConfigMap",
+	}
+	ulist.SetGroupVersionKind(gvk)
+	return ulist
+}
+
+func verifyListIsSorted(b *testing.B, list *unstructured.UnstructuredList, size int) {
+	for i := range size - 1 {
+		curr := list.Items[i]
+		next := list.Items[i+1]
+		if curr.GetNamespace() == next.GetNamespace() {
+			assert.Less(b, curr.GetName(), next.GetName())
+		} else {
+			assert.Less(b, curr.GetNamespace(), next.GetNamespace())
+		}
+	}
+}
+func BenchmarkNamespaceNameList(b *testing.B) {
+	// At 50,000,000 this starts to get very slow
+	size := 10000
+	itemList := makePseudoRandomList(size)
+	ctx := context.Background()
+	opts := ListOptionIndexerOptions{
+		IsNamespaced: true,
+	}
+	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+	defer cleanTempFiles(dbPath)
+	assert.NoError(b, err)
+	for _, item := range itemList.Items {
+		err = loi.Add(&item)
+		assert.NoError(b, err)
+	}
+	b.Run(fmt.Sprintf("sort-%d with explicit namespace/name", size), func(b *testing.B) {
+		listOptions := sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "namespace"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields: []string{"metadata", "name"},
+						Order:  sqltypes.ASC,
+					},
+				},
+			},
+		}
+		partitions := []partition.Partition{{All: true}}
+		ns := ""
+		list, total, _, err := loi.ListByOptions(ctx, &listOptions, partitions, ns)
+		if err != nil {
+			b.Fatal("error getting data", err)
+		}
+		if total != size {
+			b.Errorf("expecting %d items, got %d", size, total)
+		}
+		if len(list.Items) != size {
+			b.Errorf("expecting %d items, got %d", size, len(list.Items))
+		}
+		//verifyListIsSorted(b, list, size)
+	})
+	b.Run(fmt.Sprintf("sort-%d with explicit id", size), func(b *testing.B) {
+		listOptions := sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"id"},
+						Order:  sqltypes.ASC,
+					},
+				},
+			},
+		}
+		partitions := []partition.Partition{{All: true}}
+		ns := ""
+		list, total, _, err := loi.ListByOptions(ctx, &listOptions, partitions, ns)
+		if err != nil {
+			b.Fatal("error getting data", err)
+		}
+		if total != size {
+			b.Errorf("expecting %d items, got %d", size, total)
+		}
+		if len(list.Items) != size {
+			b.Errorf("expecting %d items, got %d", size, len(list.Items))
+		}
+		//verifyListIsSorted(b, list, size)
+	})
 }
 
 func TestUserDefinedExtractFunction(t *testing.T) {
@@ -2987,6 +3141,6 @@ func TestNonNumberResourceVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	list, _, _, err := loi.ListByOptions(ctx, &sqltypes.ListOptions{}, []partition.Partition{{All: true}}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedList.Items, list.Items)
 }


### PR DESCRIPTION
# DO NOT MERGE

## I think we aren't going to want to do this

##  Reviewing is ok, but be sure to take https://github.com/rancher/steve/pull/752#discussion_r2240968068 into account before approving.

Related to [#50999](https://github.com/rancher/rancher/issues/50999)

Supersedes [#724] as benchmarking on larger data sets showed this was slightly faster.

See https://github.com/rancher/steve/pull/724#issue-3224361745 for benchmark results on
1. sorting on separately indexed metadata.namespace and .name fields
2. sorting on `id`
3. sorting on a compound-indexed metadata.namespace and .name fields (this PR)