### PR TITLE
Sort by ipaddr

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"reflect"
 	"strconv"
@@ -21,6 +23,7 @@ import (
 	"errors"
 
 	"github.com/rancher/steve/pkg/sqlcache/db/transaction"
+	"github.com/sirupsen/logrus"
 
 	// needed for drivers
 	_ "modernc.org/sqlite"
@@ -494,6 +497,38 @@ func (c *client) NewConnection(useTempDir bool) (string, error) {
 				return "", nil
 			}
 			return parts[arg2], nil
+		},
+	)
+	sqlite.RegisterDeterministicScalarFunction(
+		"inet_aton",
+		1,
+		func(ctx *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+			var arg1 string
+			switch argTyped := args[0].(type) {
+			case string:
+				arg1 = argTyped
+			case []byte:
+				arg1 = string(argTyped)
+			default:
+				logrus.Errorf("inet_aton: unsupported type for arg1: expected a string, got :%T", args[0])
+				return int64(0), nil
+			}
+			ip := net.ParseIP(arg1)
+			if ip == nil {
+				logrus.Errorf("inet_aton: invalid IP address: %s", arg1)
+				return int64(0), nil
+			}
+			ipAs4 := ip.To4()
+			if ipAs4 != nil {
+				return int64(binary.BigEndian.Uint32(ipAs4)), nil
+			}
+			// By elimination it must be IPv6 (until IPv[n > 6] comes along one day
+			ipAs16 := ip.To16()
+			if ipAs16 == nil {
+				logrus.Errorf("inet_aton: invalid IPv6 address: %s", arg1)
+				return int64(0), nil
+			}
+			return int64(binary.BigEndian.Uint64(ipAs16)), nil
 		},
 	)
 	c.conn = sqlDB

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -768,7 +768,7 @@ func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions 
 		for _, sortDirective := range lo.SortList.SortDirectives {
 			fields := sortDirective.Fields
 			if isLabelsFieldList(fields) {
-				clause, err := buildSortLabelsClause(fields[2], joinTableIndexByLabelName, sortDirective.Order == sqltypes.ASC)
+				clause, err := buildSortLabelsClause(fields[2], joinTableIndexByLabelName, sortDirective.Order == sqltypes.ASC, sortDirective.SortAsIP)
 				if err != nil {
 					return nil, err
 				}
@@ -777,6 +777,9 @@ func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions 
 				fieldEntry, err := l.getValidFieldEntry("f", fields)
 				if err != nil {
 					return queryInfo, err
+				}
+				if sortDirective.SortAsIP {
+					fieldEntry = fmt.Sprintf("inet_aton(%s)", fieldEntry)
 				}
 				direction := "ASC"
 				if sortDirective.Order == sqltypes.DESC {
@@ -980,8 +983,12 @@ func (l *ListOptionIndexer) buildORClauseFromFilters(orFilters sqltypes.OrFilter
 	return fmt.Sprintf("(%s)", strings.Join(clauses, ") OR (")), params, nil
 }
 
-func buildSortLabelsClause(labelName string, joinTableIndexByLabelName map[string]int, isAsc bool) (string, error) {
+func buildSortLabelsClause(labelName string, joinTableIndexByLabelName map[string]int, isAsc bool, sortAsIP bool) (string, error) {
 	ltIndex, err := internLabel(labelName, joinTableIndexByLabelName, -1)
+	fieldEntry := fmt.Sprintf("lt%d.value", ltIndex)
+	if sortAsIP {
+		fieldEntry = fmt.Sprintf("inet_aton(%s)", fieldEntry)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -991,7 +998,7 @@ func buildSortLabelsClause(labelName string, joinTableIndexByLabelName map[strin
 		dir = "DESC"
 		nullsPosition = "FIRST"
 	}
-	return fmt.Sprintf("lt%d.value %s NULLS %s", ltIndex, dir, nullsPosition), nil
+	return fmt.Sprintf("%s %s NULLS %s", fieldEntry, dir, nullsPosition), nil
 }
 
 func getUnboundSortLabels(lo *sqltypes.ListOptions) []string {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -385,6 +385,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			"somefield": "foo",
 			"sortfield": "400",
 		},
+		"status": map[string]any{
+			"podIP": "99.4.5.6",
+		},
 	}
 	obj02_milk_saddles := map[string]any{
 		"metadata": map[string]any{
@@ -396,6 +399,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				"cows":   "milk",
 				"horses": "saddles",
 			},
+		},
+		"status": map[string]any{
+			"podIP": "102.1.2.3",
 		},
 	}
 	obj02a_beef_saddles := map[string]any{
@@ -409,6 +415,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				"horses": "saddles",
 			},
 		},
+		"status": map[string]any{
+			"podIP": "102.99.2.3",
+		},
 	}
 	obj02b_milk_shoes := map[string]any{
 		"metadata": map[string]any{
@@ -420,6 +429,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				"cows":   "milk",
 				"horses": "shoes",
 			},
+		},
+		"status": map[string]any{
+			"podIP": "102.103.2.3",
 		},
 	}
 	obj03_saddles := map[string]any{
@@ -433,6 +445,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			},
 		},
 		"status": map[string]any{
+			"podIP":          "77.4.5.6",
 			"someotherfield": "helloworld",
 		},
 	}
@@ -447,6 +460,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			},
 		},
 		"status": map[string]any{
+			"podIP":          "102.99.99.1",
 			"someotherfield": "helloworld",
 		},
 	}
@@ -460,6 +474,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				"cows": "milk",
 			},
 		},
+		"status": map[string]any{
+			"podIP": "102.99.105.1",
+		},
 	}
 	obj05__guard_lodgepole := map[string]any{
 		"metadata": map[string]any{
@@ -469,6 +486,9 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			"labels": map[string]any{
 				"guard.cattle.io": "lodgepole",
 			},
+		},
+		"status": map[string]any{
+			"podIP": "203.1.2.3",
 		},
 	}
 	allObjects := []map[string]any{
@@ -977,6 +997,26 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedContToken: "",
 		expectedErr:       nil,
 	})
+	tests = append(tests, testCase{
+		description: "ListByOptions: sorting on ip sorts on the ip octets",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"status", "podIP"},
+						Order:  sqltypes.ASC,
+					},
+				},
+			},
+		},
+		partitions:   []partition.Partition{{All: true}},
+		ns:           "",
+		expectedList: makeList(t, obj03_saddles, obj01_no_labels, obj02_milk_saddles, obj02a_beef_saddles, obj03a_shoes, obj02b_milk_shoes, obj04_milk, obj05__guard_lodgepole),
+
+		expectedTotal:     len(allObjects),
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
 	//tests = append(tests, testCase{
 	//	description: "ListByOptions with a Namespace Partition should select only items where metadata.namespace is equal to Namespace and all other conditions are met",
 	//	partitions: []partition.Partition{
@@ -999,6 +1039,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			fields := [][]string{
 				{"metadata", "somefield"},
 				{"status", "someotherfield"},
+				{"status", "podIP"},
 				{"metadata", "unknown"},
 				{"metadata", "sortfield"},
 			}
@@ -1943,6 +1984,66 @@ SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
 		expectedErr:      nil,
 	})
 
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: sort on an IP-designated field does an inet_aton conversion",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "queryField1"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields:   []string{"status", "podIP"},
+						Order:    sqltypes.ASC,
+						SortAsIP: true,
+					},
+				},
+			},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  WHERE
+    (FALSE)
+  ORDER BY f."metadata.queryField1" ASC, inet_aton(f."status.podIP") ASC`,
+		expectedStmtArgs: []any{},
+		expectedErr:      nil,
+	})
+
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: sort can ip-convert a label field",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "labels", "this"},
+						Order:  sqltypes.ASC,
+					},
+					{
+						Fields: []string{"status", "queryField2"},
+						Order:  sqltypes.DESC,
+					},
+				},
+			},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `WITH lt1(key, value) AS (
+SELECT key, value FROM "something_labels"
+  WHERE label = ?
+)
+SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  LEFT OUTER JOIN lt1 ON o.key = lt1.key
+  WHERE
+    (FALSE)
+  ORDER BY lt1.value ASC NULLS LAST, f."status.queryField2" DESC`,
+		expectedStmtArgs: []any{"this"},
+		expectedErr:      nil,
+	})
+
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
@@ -1952,7 +2053,7 @@ SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
 			}
 			lii := &ListOptionIndexer{
 				Indexer:       i,
-				indexedFields: []string{"metadata.queryField1", "status.queryField2", "spec.containers.image"},
+				indexedFields: []string{"metadata.queryField1", "status.queryField2", "spec.containers.image", "status.podIP"},
 			}
 			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
 			if test.expectedErr != nil {
@@ -2036,6 +2137,7 @@ func TestBuildSortLabelsClause(t *testing.T) {
 		labelName                 string
 		joinTableIndexByLabelName map[string]int
 		direction                 bool
+		sortAsIP                  bool
 		expectedStmt              string
 		expectedErr               string
 	}
@@ -2060,10 +2162,18 @@ func TestBuildSortLabelsClause(t *testing.T) {
 		direction:                 false,
 		expectedStmt:              `lt4.value DESC NULLS FIRST`,
 	})
+	tests = append(tests, testCase{
+		description:               "TestBuildSortClause: hit descending",
+		labelName:                 "testBSL3",
+		joinTableIndexByLabelName: map[string]int{"testBSL3": 5},
+		direction:                 false,
+		sortAsIP:                  true,
+		expectedStmt:              `inet_aton(lt5.value) DESC NULLS FIRST`,
+	})
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			stmt, err := buildSortLabelsClause(test.labelName, test.joinTableIndexByLabelName, test.direction)
+			stmt, err := buildSortLabelsClause(test.labelName, test.joinTableIndexByLabelName, test.direction, test.sortAsIP)
 			if test.expectedErr != "" {
 				assert.Equal(t, test.expectedErr, err.Error())
 			} else {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -1003,15 +1003,16 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 			SortList: sqltypes.SortList{
 				SortDirectives: []sqltypes.Sort{
 					{
-						Fields: []string{"status", "podIP"},
-						Order:  sqltypes.ASC,
+						Fields:   []string{"status", "podIP"},
+						Order:    sqltypes.ASC,
+						SortAsIP: true,
 					},
 				},
 			},
 		},
 		partitions:   []partition.Partition{{All: true}},
 		ns:           "",
-		expectedList: makeList(t, obj03_saddles, obj01_no_labels, obj02_milk_saddles, obj02a_beef_saddles, obj03a_shoes, obj02b_milk_shoes, obj04_milk, obj05__guard_lodgepole),
+		expectedList: makeList(t, obj03_saddles, obj01_no_labels, obj02_milk_saddles, obj02a_beef_saddles, obj03a_shoes, obj04_milk, obj02b_milk_shoes, obj05__guard_lodgepole),
 
 		expectedTotal:     len(allObjects),
 		expectedContToken: "",
@@ -1063,6 +1064,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
+			require.Nil(t, err)
 
 			assert.Equal(t, test.expectedTotal, total)
 			assert.Equal(t, test.expectedList, list)
@@ -1252,6 +1254,121 @@ func TestUserDefinedExtractFunction(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			fields := [][]string{
 				{"spec", "rules", "host"},
+			}
+			fields = append(fields, test.extraIndexedFields...)
+
+			opts := ListOptionIndexerOptions{
+				Fields:       fields,
+				IsNamespaced: true,
+			}
+			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+			defer cleanTempFiles(dbPath)
+			assert.NoError(t, err)
+
+			for _, item := range itemList.Items {
+				err = loi.Add(&item)
+				assert.NoError(t, err)
+			}
+
+			list, total, contToken, err := loi.ListByOptions(ctx, &test.listOptions, test.partitions, test.ns)
+			if test.expectedErr != nil {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedList, list)
+			assert.Equal(t, test.expectedTotal, total)
+			assert.Equal(t, test.expectedContToken, contToken)
+		})
+	}
+}
+
+func TestUserDefinedInetToAnonFunction(t *testing.T) {
+	makeObj := func(name string, ipAddr string) map[string]any {
+		h1 := map[string]any{
+			"metadata": map[string]any{
+				"name": name,
+			},
+			"status": map[string]any{
+				"podIP": ipAddr,
+			},
+		}
+		return h1
+	}
+	ctx := context.Background()
+
+	type testCase struct {
+		description string
+		listOptions sqltypes.ListOptions
+		partitions  []partition.Partition
+		ns          string
+
+		items []*unstructured.Unstructured
+
+		extraIndexedFields [][]string
+		expectedList       *unstructured.UnstructuredList
+		expectedTotal      int
+		expectedContToken  string
+		expectedErr        error
+	}
+	obj01 := makeObj("lirdle.com", "145.53.12.123")
+	obj02 := makeObj("cyberciti.biz", "2607:f0d0:1002:51::4")
+	obj03 := makeObj("zombo.com", "50.28.52.163")
+	obj04 := makeObj("not-an-ipaddr", "aardvarks")
+	obj05 := makeObj("smaller-cyberciti.biz", "2607:f0d0:997:51::4")
+	allObjects := []map[string]any{obj01, obj02, obj03, obj04, obj05}
+	makeList := func(t *testing.T, objs ...map[string]any) *unstructured.UnstructuredList {
+		t.Helper()
+
+		if len(objs) == 0 {
+			return &unstructured.UnstructuredList{Object: map[string]any{"items": []any{}}, Items: []unstructured.Unstructured{}}
+		}
+
+		var items []any
+		for _, obj := range objs {
+			items = append(items, obj)
+		}
+
+		list := &unstructured.Unstructured{
+			Object: map[string]any{
+				"items": items,
+			},
+		}
+
+		itemList, err := list.ToList()
+		require.NoError(t, err)
+
+		return itemList
+	}
+	itemList := makeList(t, allObjects...)
+
+	var tests []testCase
+	tests = append(tests, testCase{
+		description: "sort by numeric IP addr value",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields:   []string{"status", "podIP"},
+						Order:    sqltypes.ASC,
+						SortAsIP: true,
+					},
+				},
+			},
+		},
+		partitions:        []partition.Partition{{All: true}},
+		ns:                "",
+		expectedList:      makeList(t, obj04, obj03, obj01, obj05, obj02),
+		expectedTotal:     len(allObjects),
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	t.Parallel()
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			fields := [][]string{
+				{"status", "podIP"},
 			}
 			fields = append(fields, test.extraIndexedFields...)
 

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -57,8 +57,9 @@ type OrFilter struct {
 // The order is represented by prefixing the sort key by '-', e.g. sort=-metadata.name.
 // e.g. To sort internal clusters first followed by clusters in alpha order: sort=-spec.internal,spec.displayName
 type Sort struct {
-	Fields []string
-	Order  SortOrder
+	Fields   []string
+	Order    SortOrder
+	SortAsIP bool
 }
 
 type SortList struct {

--- a/pkg/stores/sqlpartition/listprocessor/processor.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor.go
@@ -105,11 +105,17 @@ func ParseQuery(apiOp *types.APIRequest, namespaceCache Cache) (sqltypes.ListOpt
 	opts.Filters = filterOpts
 
 	sortKeys := q.Get(sortParam)
+	callsIPFunctionRegex := regexp.MustCompile(`^(?i)ip\(.+\)$`)
 	if sortKeys != "" {
 		sortList := *sqltypes.NewSortList()
 		sortParts := strings.Split(sortKeys, ",")
 		for _, sortPart := range sortParts {
 			field := sortPart
+			sortAsIP := false
+			if callsIPFunctionRegex.MatchString(sortPart) {
+				field = sortPart[3 : len(sortPart)-1]
+				sortAsIP = true
+			}
 			if len(field) > 0 {
 				sortOrder := sqltypes.ASC
 				if field[0] == '-' {
@@ -118,8 +124,9 @@ func ParseQuery(apiOp *types.APIRequest, namespaceCache Cache) (sqltypes.ListOpt
 				}
 				if len(field) > 0 {
 					sortDirective := sqltypes.Sort{
-						Fields: queryhelper.SafeSplit(field),
-						Order:  sortOrder,
+						Fields:   queryhelper.SafeSplit(field),
+						Order:    sortOrder,
+						SortAsIP: sortAsIP,
 					}
 					sortList.SortDirectives = append(sortList.SortDirectives, sortDirective)
 				}

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -788,11 +788,10 @@ func TestParseQuery(t *testing.T) {
 		},
 	})
 	tests = append(tests, testCase{
-		description: "ParseQuery() with no errors returned should returned no errors. If two sort params are given, sort " +
-			"options with primary field and secondary field should be set.",
+		description: "ParseQuery() with no errors: If two sort params are given, recognize ASC/DESC and map ip(field) to SortAsIP:true.",
 		req: &types.APIRequest{
 			Request: &http.Request{
-				URL: &url.URL{RawQuery: "sort=-metadata.name,spec.something"},
+				URL: &url.URL{RawQuery: "sort=-metadata.name,ip(spec.something)"},
 			},
 		},
 		expectedLO: sqltypes.ListOptions{
@@ -803,8 +802,9 @@ func TestParseQuery(t *testing.T) {
 						Order:  sqltypes.DESC,
 					},
 					{
-						Fields: []string{"spec", "something"},
-						Order:  sqltypes.ASC,
+						Fields:   []string{"spec", "something"},
+						Order:    sqltypes.ASC,
+						SortAsIP: true,
 					},
 				},
 			},

--- a/pkg/stores/sqlpartition/queryparser/selector_test.go
+++ b/pkg/stores/sqlpartition/queryparser/selector_test.go
@@ -176,6 +176,7 @@ func TestLexerSequence(t *testing.T) {
 		{"key!~ value", []Token{IdentifierToken, NotPartialEqualsToken, IdentifierToken}},
 		{"key !~value", []Token{IdentifierToken, NotPartialEqualsToken, IdentifierToken}},
 		{"key!~value", []Token{IdentifierToken, NotPartialEqualsToken, IdentifierToken}},
+		{`ip(status.podIP)`, []Token{IdentifierToken, OpenParToken, IdentifierToken, ClosedParToken}},
 	}
 	for _, v := range testcases {
 		var tokens []Token
@@ -217,6 +218,7 @@ func TestParserLookahead(t *testing.T) {
 		{"key gt 3", []Token{IdentifierToken, IdentifierToken, IdentifierToken, EndOfStringToken}},
 		{"key lt 4", []Token{IdentifierToken, IdentifierToken, IdentifierToken, EndOfStringToken}},
 		{`key = "multi-word-string"`, []Token{IdentifierToken, EqualsToken, QuotedStringToken, EndOfStringToken}},
+		{`ip(status.podIP)`, []Token{IdentifierToken, OpenParToken, IdentifierToken, ClosedParToken, EndOfStringToken}},
 	}
 	for _, v := range testcases {
 		p := &Parser{l: &Lexer{s: v.s, pos: 0}, position: 0}

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -86,7 +86,9 @@ var (
 			{"spec", "volumeName"}},
 		gvkKey("", "v1", "Pod"): {
 			{"spec", "containers", "image"},
-			{"spec", "nodeName"}},
+			{"spec", "nodeName"},
+			{"status", "podIP"},
+		},
 		gvkKey("", "v1", "ReplicationController"): {
 			{"spec", "template", "spec", "containers", "image"}},
 		gvkKey("", "v1", "Secret"): {


### PR DESCRIPTION
This lets users sort indexed fields that represent IPv4 and IPv6 addresses correctly, on a byte-by-byte basis. Otherwise an IP like '123.150.2.3' would sort before '123.9.0.0' because the string "1...." after "123." sorts before the "9".

The solution here is to implement mysql's `inet_aton` function as a custom function (using our own code), and then invoking that only when sorting on a field with the `ip(X)` directive.

The function supports both IPv4 and IPv6 addresses. The result of sorting a mix of the two is consistently the same, but I'm not going to attempt to explain how to look at two strings and determine which is the lesser. The function converts the strings into 64-bit integers and does that comparison internally.

In a later issue we can decide if we want to expose this function, and in fact other builtin sqlite functions, more generally, as in:
```
$ curl .../?filter=ip(status.lables.smallerIP)<ip(123.9.0.0)...
```

This PR just supports correct sorting of IP addresses using the `sort=...ip(FIELD)` directive.

The "ip" part is case-sensitive right now, as is everything else in the query parser.