### PR TITLE
Fix slow labels queries

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -458,6 +458,9 @@ func (c *client) NewConnection(useTempDir bool) (string, error) {
 		// if two transactions want to write at the same time, allow 2 minutes for the first to complete
 		// before baling out
 		"_pragma=busy_timeout=120000&"+
+		// store temporary tables to memory, to speed up queries making use
+		// of temporary tables (eg: when using DISTINCT)
+		"_pragma=temp_store=2&"+
 		// default to IMMEDIATE mode for transactions. Setting this parameter is the only current way
 		// to be able to switch between DEFERRED and IMMEDIATE modes in modernc.org/sqlite's implementation
 		// of BeginTx

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -653,7 +653,11 @@ func (l *ListOptionIndexer) constructQuery(lo *sqltypes.ListOptions, partitions 
 		params = withParams
 		joinPartsToUse = joinParts
 	}
-	query += fmt.Sprintf(`SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "%s" o`, dbName)
+	query += "SELECT "
+	if queryUsesLabels {
+		query += "DISTINCT "
+	}
+	query += fmt.Sprintf(`o.object, o.objectnonce, o.dekid FROM "%s" o`, dbName)
 	query += "\n  "
 	query += fmt.Sprintf(`JOIN "%s_fields" f ON o.key = f.key`, dbName)
 	if len(joinPartsToUse) > 0 {

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -849,10 +849,13 @@ func (l *ListOptionIndexer) executeQuery(ctx context.Context, queryInfo *QueryIn
 	var items []any
 	err = l.WithTransaction(ctx, false, func(tx transaction.Client) error {
 		txStmt := tx.Stmt(stmt)
+		now := time.Now()
 		rows, err := txStmt.QueryContext(ctx, queryInfo.params...)
 		if err != nil {
 			return &db.QueryError{QueryString: queryInfo.query, Err: err}
 		}
+		elapsed := time.Since(now)
+		logLongQuery(elapsed, queryInfo.query, queryInfo.params)
 		items, err = l.ReadObjects(rows, l.GetType(), l.GetShouldEncrypt())
 		if err != nil {
 			return fmt.Errorf("read objects: %w", err)
@@ -868,10 +871,13 @@ func (l *ListOptionIndexer) executeQuery(ctx context.Context, queryInfo *QueryIn
 				}
 			}()
 			txStmt := tx.Stmt(countStmt)
+			now = time.Now()
 			rows, err := txStmt.QueryContext(ctx, queryInfo.countParams...)
 			if err != nil {
 				return &db.QueryError{QueryString: queryInfo.countQuery, Err: err}
 			}
+			elapsed = time.Since(now)
+			logLongQuery(elapsed, queryInfo.countQuery, queryInfo.countParams)
 			total, err = l.ReadInt(rows)
 			if err != nil {
 				return fmt.Errorf("error reading query results: %w", err)
@@ -896,6 +902,14 @@ func (l *ListOptionIndexer) executeQuery(ctx context.Context, queryInfo *QueryIn
 	l.latestRVLock.RUnlock()
 
 	return toUnstructuredList(items, latestRV), total, continueToken, nil
+}
+
+func logLongQuery(elapsed time.Duration, query string, params []any) {
+	threshold := 500 * time.Millisecond
+	if elapsed < threshold {
+		return
+	}
+	logrus.Debugf("Query took more than %v (took %v): %s with params %v", threshold, elapsed, query, params)
 }
 
 func (l *ListOptionIndexer) validateColumn(column string) error {

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -538,7 +538,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedErr:       nil,
 	})
 	tests = append(tests, testCase{
-		description: "ListByOptions with single object matching many labels with OR",
+		description: "ListByOptions with many objects matching many labels with OR",
 		listOptions: sqltypes.ListOptions{Filters: []sqltypes.OrFilter{
 			{
 				[]sqltypes.Filter{
@@ -890,6 +890,25 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedTotal:     len(allObjects),
 		expectedContToken: "",
 		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions sorting on two existing labels, with no label filters, should sort correctly",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "labels", "horses"},
+					},
+					{
+						Fields: []string{"metadata", "labels", "cows"},
+					},
+				},
+			},
+		},
+		partitions: []partition.Partition{{All: true}},
+		expectedList: makeList(t, obj02a_beef_saddles, obj02_milk_saddles, obj03_saddles,
+			obj02b_milk_shoes, obj03a_shoes, obj04_milk, obj01_no_labels, obj05__guard_lodgepole),
+		expectedTotal: len(allObjects),
 	})
 	tests = append(tests, testCase{
 		description: "ListByOptions with Pagination.PageSize set should set limit to PageSize",


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/51333

This PR does two things:
1. Configure SQLite to store temporary tables to memory
2. Use `DISTINCT` only when necessary

[This comment](https://github.com/rancher/rancher/issues/51333#issuecomment-3158096876) shows that using in-memory temporary tables speed up queries using `DISTINCT` (due to slow disks).

`DISTINCT` is only necessary when filtering by labels. (TODO: Verify if it's only necessary when making queries filtering by labels with `OR` filters, so that the general case is fast)