### PR TITLE
[v0.6] Fix slow labels queries

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -454,6 +454,9 @@ func (c *client) NewConnection(useTempDir bool) (string, error) {
 		// if two transactions want to write at the same time, allow 2 minutes for the first to complete
 		// before baling out
 		"_pragma=busy_timeout=120000&"+
+		// store temporary tables to memory, to speed up queries making use
+		// of temporary tables (eg: when using DISTINCT)
+		"_pragma=temp_store=2&"+
 		// default to IMMEDIATE mode for transactions. Setting this parameter is the only current way
 		// to be able to switch between DEFERRED and IMMEDIATE modes in modernc.org/sqlite's implementation
 		// of BeginTx

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -508,6 +508,62 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedErr:       nil,
 	})
 	tests = append(tests, testCase{
+		description: "ListByOptions with single object matching many labels with AND",
+		listOptions: sqltypes.ListOptions{Filters: []sqltypes.OrFilter{
+			{
+				[]sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "labels", "cows"},
+						Matches: []string{"milk"},
+						Op:      sqltypes.Eq,
+					},
+				},
+			},
+			{
+				[]sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "labels", "horses"},
+						Matches: []string{"shoes"},
+						Op:      sqltypes.Eq,
+					},
+				},
+			},
+		},
+		},
+		partitions:        []partition.Partition{{All: true}},
+		ns:                "",
+		expectedList:      makeList(t, obj02b_milk_shoes),
+		expectedTotal:     1,
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions with many objects matching many labels with OR",
+		listOptions: sqltypes.ListOptions{Filters: []sqltypes.OrFilter{
+			{
+				[]sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "labels", "cows"},
+						Matches: []string{"milk"},
+						Op:      sqltypes.Eq,
+					},
+					{
+						Field:   []string{"metadata", "labels", "horses"},
+						Matches: []string{"shoes"},
+						Op:      sqltypes.Eq,
+					},
+				},
+			},
+		},
+		},
+		partitions:        []partition.Partition{{All: true}},
+		ns:                "",
+		expectedList:      makeList(t, obj02_milk_saddles, obj02b_milk_shoes, obj03a_shoes, obj04_milk),
+		expectedTotal:     4,
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
 		description: "ListByOptions with 1 OrFilter set with 1 filter should select where that filter is true",
 		listOptions: sqltypes.ListOptions{Filters: []sqltypes.OrFilter{
 			{
@@ -834,6 +890,25 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedTotal:     len(allObjects),
 		expectedContToken: "",
 		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions sorting on two existing labels, with no label filters, should sort correctly",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "labels", "horses"},
+					},
+					{
+						Fields: []string{"metadata", "labels", "cows"},
+					},
+				},
+			},
+		},
+		partitions: []partition.Partition{{All: true}},
+		expectedList: makeList(t, obj02a_beef_saddles, obj02_milk_saddles, obj03_saddles,
+			obj02b_milk_shoes, obj03a_shoes, obj04_milk, obj01_no_labels, obj05__guard_lodgepole),
+		expectedTotal: len(allObjects),
 	})
 	tests = append(tests, testCase{
 		description: "ListByOptions with Pagination.PageSize set should set limit to PageSize",
@@ -1270,7 +1345,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 		partitions: []partition.Partition{},
 		ns:         "",
-		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
     (f."metadata.queryField1" IN (?)) AND
@@ -1295,7 +1370,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 		partitions: []partition.Partition{},
 		ns:         "",
-		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
     (f."metadata.queryField1" NOT IN (?)) AND
@@ -1680,7 +1755,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 		partitions: []partition.Partition{},
 		ns:         "",
-		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
     (extractBarredValue(f."spec.containers.image", "3") = ?) AND
@@ -1703,7 +1778,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 		partitions: []partition.Partition{},
 		ns:         "",
-		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
     (FALSE)
@@ -1736,7 +1811,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 		partitions: []partition.Partition{},
 		ns:         "",
-		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   WHERE
     (extractBarredValue(f."spec.containers.image", "3") = ?) AND
@@ -1883,7 +1958,7 @@ func TestConstructQuery(t *testing.T) {
 SELECT key, value FROM "something_labels"
   WHERE label = ?
 )
-SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+SELECT o.object, o.objectnonce, o.dekid FROM "something" o
   JOIN "something_fields" f ON o.key = f.key
   LEFT OUTER JOIN lt1 ON o.key = lt1.key
   WHERE


### PR DESCRIPTION
Clean backport of https://github.com/rancher/steve/pull/762

# Issue https://github.com/rancher/rancher/issues/51333

This PR does two things:
1. Configure SQLite to store temporary tables to memory
2. Use `DISTINCT` only when necessary

[This comment](https://github.com/rancher/rancher/issues/51333#issuecomment-3158096876) shows that using in-memory temporary tables speed up queries using `DISTINCT` (due to slow disks).

`DISTINCT` is only necessary when filtering by labels. (TODO: Verify if it's only necessary when making queries filtering by labels with `OR` filters, so that the general case is fast)