### PR TITLE
Dropping debug-level default to 1 to reduce noise from reflector

### DIFF
--- a/pkg/debug/cli.go
+++ b/pkg/debug/cli.go
@@ -51,7 +51,7 @@ func Flags(config *Config) []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:        "debug-level",
-			Value:       2,
+			Value:       1,
 			Destination: &config.DebugLevel,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
Issue:  https://github.com/rancher/rancher/issues/44908