### PR TITLE
Fixes parsing of resources older than 2 year

### DIFF
--- a/pkg/resources/common/duration.go
+++ b/pkg/resources/common/duration.go
@@ -27,6 +27,8 @@ func ParseTimestampOrHumanReadableDuration(s string) (time.Duration, error) {
 		}
 
 		switch unit {
+		case 'y':
+			total += time.Duration(val) * 365 * 24 * time.Hour
 		case 'd':
 			total += time.Duration(val) * 24 * time.Hour
 		case 'h':

--- a/pkg/resources/common/duration_test.go
+++ b/pkg/resources/common/duration_test.go
@@ -15,6 +15,16 @@ func TestParseHumanReadableDuration(t *testing.T) {
 		expectedErr bool
 	}{
 		{
+			name:     "years + days",
+			input:    "2y10d",
+			expected: (2*365+10)*24*time.Hour,
+		},
+		{
+			name:     "years + days + hours + mins + secs",
+			input:    "3y1d23h45m56s",
+			expected: (3*365+1)*24*time.Hour + 23*time.Hour + 45*time.Minute + 56*time.Second,
+		},
+		{
 			name:     "days + hours + mins + secs",
 			input:    "1d23h45m56s",
 			expected: 24*time.Hour + 23*time.Hour + 45*time.Minute + 56*time.Second,


### PR DESCRIPTION
- Similar assumption as 24h per day: 365 days per year, ignoring DST and leap-years

Very old resources (older than 2 years) are printed as `2y15d` instead of using just the number of days.

This leads to parser errors for namespaces in rancher:
```
2025/08/18 14:43:34 [WARNING] convert timestamp value: 2y114d failed with error: strconv.ParseInt: parsing "2y114d": invalid syntax
2025/08/18 14:43:34 [WARNING] convert timestamp value: 3y50d failed with error: strconv.ParseInt: parsing "3y50d": invalid syntax
2025/08/18 14:43:34 [WARNING] convert timestamp value: 2y163d failed with error: strconv.ParseInt: parsing "2y163d": invalid syntax
2025/08/18 14:43:34 [WARNING] convert timestamp value: 3y50d failed with error: strconv.ParseInt: parsing "3y50d": invalid syntax
```

Relates to https://github.com/rancher/steve/pull/684
Fixes https://github.com/rancher/rancher/issues/51519