### PR TITLE
[v0.6] Use a separate lock for refreshAll

### DIFF
--- a/pkg/controllers/schema/schemas.go
+++ b/pkg/controllers/schema/schemas.go
@@ -41,6 +41,9 @@ func (s SchemasHandlerFunc) OnSchemas(schemas *schema2.Collection, changedSchema
 type handler struct {
 	sync.Mutex
 
+	// refreshLock prevents refreshAll to be run in parallel
+	refreshLock sync.Mutex
+
 	ctx               context.Context
 	toSync            int32
 	schemas           *schema2.Collection
@@ -222,8 +225,8 @@ func (h *handler) getColumns(ctx context.Context, schemas map[string]*types.APIS
 }
 
 func (h *handler) refreshAll(ctx context.Context, changedGVKs map[k8sapimachineryschema.GroupVersionKind]bool, forceChange bool) error {
-	h.Lock()
-	defer h.Unlock()
+	h.refreshLock.Lock()
+	defer h.refreshLock.Unlock()
 
 	if !h.needToSync() {
 		return nil


### PR DESCRIPTION
# Issue  https://github.com/rancher/rancher/issues/51626

Related to https://github.com/rancher/rancher/issues/51589

# Problem

https://github.com/rancher/steve/pull/745 started locking the CRD sync handler using the same lock as the one used for `refreshAll`. In the case of Vai enabled, `refreshAll` takes a bit of time because it needs to reset the database and re-populate the `namespace` tables (LIST+WATCH to k8s). The end result: All CRD handlers are blocked until the database is reset.

**wait but why ..?**

Handlers registered through lasso all run concurrently for separate keys (eg: `namespace-1/configmap-1` will run concurrently to `namespace-1/configmap-2`) however all handlers for a given key runs sequentially. In this case, it's worse because a single lock is used for ALL keys, meaning once that [lock is taken in refreshAll](https://github.com/rancher/steve/blob/abe3505670afb3e9d859bd43fbd53618120b0d59/pkg/controllers/schema/schemas.go#L225-L226), none of the CRD handlers can run (they'll all be stuck on the lock)

# Solution

We use a different `sync.Mutex` for refreshAll call. The `refreshLock` lock prevents multiple refreshAll from running concurrently. The other lock protects the various changedIDs, createdIDs, etc for writing and accessing.

So there is still a single lock being locked in the CRD sync handler for ALL keys, but those are locked and unlocked quickly, they're no longer stuck waiting for the DB reset to finish.
