### PR TITLE
Backport projectsOrNamespace work from main to v2.12 line.

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -31,15 +31,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func makeListOptionIndexer(ctx context.Context, opts ListOptionIndexerOptions, shouldEncrypt bool) (*ListOptionIndexer, string, error) {
-	gvk := schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    "ConfigMap",
-	}
-	example := &unstructured.Unstructured{}
-	example.SetGroupVersionKind(gvk)
-	name := informerNameFromGVK(gvk)
+var emptyNamespaceList = &unstructured.UnstructuredList{Object: map[string]any{"items": []any{}}, Items: []unstructured.Unstructured{}}
+
+func makeListOptionIndexer(ctx context.Context, opts ListOptionIndexerOptions, shouldEncrypt bool, nsList *unstructured.UnstructuredList) (*ListOptionIndexer, string, error) {
 	m, err := encryption.NewManager()
 	if err != nil {
 		return nil, "", err
@@ -49,13 +43,58 @@ func makeListOptionIndexer(ctx context.Context, opts ListOptionIndexerOptions, s
 	if err != nil {
 		return nil, "", err
 	}
-
+	// First create a namespace table so the projectsornamespaces query succeeds
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Namespace",
+	}
+	example := &unstructured.Unstructured{}
+	example.SetGroupVersionKind(gvk)
+	name := informerNameFromGVK(gvk)
 	s, err := store.NewStore(ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc, db, shouldEncrypt, gvk, name, nil, nil)
 	if err != nil {
 		return nil, "", err
 	}
+	ns_opts := ListOptionIndexerOptions{
+		Fields:       [][]string{},
+		IsNamespaced: false,
+	}
+	listOptionIndexer, err := NewListOptionIndexer(ctx, s, ns_opts)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, item := range nsList.Items {
+		err = listOptionIndexer.Add(&item)
+		if err != nil {
+			return nil, "", err
+		}
+	}
 
-	listOptionIndexer, err := NewListOptionIndexer(ctx, s, opts)
+	gvk = schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ConfigMap",
+	}
+	example = &unstructured.Unstructured{}
+	example.SetGroupVersionKind(gvk)
+	name = informerNameFromGVK(gvk)
+
+	s, err = store.NewStore(ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc, db, shouldEncrypt, gvk, name, nil, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if opts.IsNamespaced {
+		// Can't use slices.Compare because []string doesn't implement comparable
+		idEntry := []string{"id"}
+		if opts.Fields == nil {
+			opts.Fields = [][]string{idEntry}
+		} else {
+			opts.Fields = append(opts.Fields, idEntry)
+		}
+	}
+
+	listOptionIndexer, err = NewListOptionIndexer(ctx, s, opts)
 	if err != nil {
 		return nil, "", err
 	}
@@ -481,8 +520,25 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		obj04_milk,
 		obj05__guard_lodgepole,
 	}
+	ns_a := map[string]any{
+		"metadata": map[string]any{
+			"name": "ns-a",
+			"labels": map[string]any{
+				"guard.cattle.io": "ponderosa",
+			},
+		},
+	}
+	ns_b := map[string]any{
+		"metadata": map[string]any{
+			"name": "ns-b",
+			"labels": map[string]any{
+				"field.cattle.io/projectId": "ns-b",
+			},
+		},
+	}
 
 	itemList := makeList(t, allObjects...)
+	namespaceList := makeList(t, ns_a, ns_b)
 
 	var tests []testCase
 	tests = append(tests, testCase{
@@ -1052,6 +1108,56 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 		expectedContToken: "",
 		expectedErr:       nil,
 	})
+	tests = append(tests, testCase{
+		description: "ListByOptions with a positive projectsornamespaces test should work",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"ns-b"},
+						Op:      sqltypes.In,
+					},
+					{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"ns-b"},
+						Op:      sqltypes.In,
+					},
+				},
+			},
+		},
+		partitions:        []partition.Partition{{All: true}},
+		ns:                "",
+		expectedList:      makeList(t, obj05__guard_lodgepole),
+		expectedTotal:     1,
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions with a negative projectsornamespaces test should work",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"ns-a"},
+						Op:      sqltypes.NotIn,
+					},
+					{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"ns-a"},
+						Op:      sqltypes.NotIn,
+					},
+				},
+			},
+		},
+		partitions:        []partition.Partition{{All: true}},
+		ns:                "",
+		expectedList:      makeList(t, obj05__guard_lodgepole),
+		expectedTotal:     1,
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
 	//tests = append(tests, testCase{
 	//	description: "ListByOptions with a Namespace Partition should select only items where metadata.namespace is equal to Namespace and all other conditions are met",
 	//	partitions: []partition.Partition{
@@ -1069,6 +1175,8 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 
 	t.Parallel()
 
+	// First curl the namespaces to load up the namespace database tables.
+
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			fields := [][]string{
@@ -1083,7 +1191,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				Fields:       fields,
 				IsNamespaced: true,
 			}
-			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false, namespaceList)
 			defer cleanTempFiles(dbPath)
 			assert.NoError(t, err)
 
@@ -1097,6 +1205,7 @@ func TestNewListOptionIndexerEasy(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
+			assert.Nil(t, err)
 
 			assert.Equal(t, test.expectedTotal, total)
 			assert.Equal(t, test.expectedList, list)
@@ -1293,7 +1402,7 @@ func TestUserDefinedExtractFunction(t *testing.T) {
 				Fields:       fields,
 				IsNamespaced: true,
 			}
-			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false, emptyNamespaceList)
 			defer cleanTempFiles(dbPath)
 			assert.NoError(t, err)
 
@@ -1377,6 +1486,146 @@ func TestConstructQuery(t *testing.T) {
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
 		expectedStmtArgs: []any{"somevalue"},
+		expectedErr:      nil,
+	})
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: handles ProjectOrNamespaces IN",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					sqltypes.Filter{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"some_namespace"},
+						Op:      sqltypes.In,
+					},
+					sqltypes.Filter{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"some_namespace"},
+						Op:      sqltypes.In,
+					},
+				},
+			},
+			Filters: []sqltypes.OrFilter{},
+		},
+		partitions: []partition.Partition{
+			{
+				All: true,
+			},
+		},
+		ns: "",
+		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  LEFT OUTER JOIN "_v1_Namespace_fields" nsf ON f."metadata.namespace" = nsf."metadata.name"
+  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON nsf.key = lt1.key
+  WHERE
+    ((nsf."metadata.name" IN (?)) OR (lt1.label = ? AND lt1.value IN (?)))
+  ORDER BY f."metadata.name" ASC `,
+		expectedStmtArgs: []any{"some_namespace", "field.cattle.io/projectId", "some_namespace"},
+		expectedErr:      nil,
+	})
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: handles ProjectOrNamespaces multiple IN",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					sqltypes.Filter{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"some_namespace", "p-example"},
+						Op:      sqltypes.In,
+					},
+					sqltypes.Filter{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"some_namespace", "p-example"},
+						Op:      sqltypes.In,
+					},
+				},
+			},
+			Filters: []sqltypes.OrFilter{},
+		},
+		partitions: []partition.Partition{
+			{
+				All: true,
+			},
+		},
+		ns: "",
+		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  LEFT OUTER JOIN "_v1_Namespace_fields" nsf ON f."metadata.namespace" = nsf."metadata.name"
+  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON nsf.key = lt1.key
+  WHERE
+    ((nsf."metadata.name" IN (?, ?)) OR (lt1.label = ? AND lt1.value IN (?, ?)))
+  ORDER BY f."metadata.name" ASC `,
+		expectedStmtArgs: []any{"some_namespace", "p-example", "field.cattle.io/projectId", "some_namespace", "p-example"},
+		expectedErr:      nil,
+	})
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: handles ProjectOrNamespaces NOT IN",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					sqltypes.Filter{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"some_namespace"},
+						Op:      sqltypes.NotIn,
+					},
+					sqltypes.Filter{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"some_namespace"},
+						Op:      sqltypes.NotIn,
+					},
+				},
+			},
+			Filters: []sqltypes.OrFilter{},
+		},
+		partitions: []partition.Partition{{All: true}},
+		ns:         "",
+		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  LEFT OUTER JOIN "_v1_Namespace_fields" nsf ON f."metadata.namespace" = nsf."metadata.name"
+  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON nsf.key = lt1.key
+  WHERE
+    ((nsf."metadata.name" NOT IN (?)) AND ((lt1.label = ? AND lt1.value NOT IN (?)) OR (o.key NOT IN (SELECT o1.key FROM "something" o1
+		JOIN "something_fields" f1 ON o1.key = f1.key
+		LEFT OUTER JOIN "_v1_Namespace_fields" nsf1 ON f1."metadata.namespace" = nsf1."metadata.name"
+		LEFT OUTER JOIN "_v1_Namespace_labels" lt1i1 ON nsf1.key = lt1i1.key
+		WHERE lt1i1.label = ?))))
+  ORDER BY f."metadata.name" ASC `,
+		expectedStmtArgs: []any{"some_namespace", "field.cattle.io/projectId", "some_namespace", "field.cattle.io/projectId"},
+		expectedErr:      nil,
+	})
+	tests = append(tests, testCase{
+		description: "TestConstructQuery: handles ProjectOrNamespaces multiple NOT IN",
+		listOptions: sqltypes.ListOptions{
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					sqltypes.Filter{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"some_namespace", "p-example"},
+						Op:      sqltypes.NotIn,
+					},
+					sqltypes.Filter{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"some_namespace", "p-example"},
+						Op:      sqltypes.NotIn,
+					},
+				},
+			},
+			Filters: []sqltypes.OrFilter{},
+		},
+		partitions: []partition.Partition{{All: true}},
+		ns:         "",
+		expectedStmt: `SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  LEFT OUTER JOIN "_v1_Namespace_fields" nsf ON f."metadata.namespace" = nsf."metadata.name"
+  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON nsf.key = lt1.key
+  WHERE
+    ((nsf."metadata.name" NOT IN (?, ?)) AND ((lt1.label = ? AND lt1.value NOT IN (?, ?)) OR (o.key NOT IN (SELECT o1.key FROM "something" o1
+		JOIN "something_fields" f1 ON o1.key = f1.key
+		LEFT OUTER JOIN "_v1_Namespace_fields" nsf1 ON f1."metadata.namespace" = nsf1."metadata.name"
+		LEFT OUTER JOIN "_v1_Namespace_labels" lt1i1 ON nsf1.key = lt1i1.key
+		WHERE lt1i1.label = ?))))
+  ORDER BY f."metadata.name" ASC `,
+		expectedStmtArgs: []any{"some_namespace", "p-example", "field.cattle.io/projectId", "some_namespace", "p-example", "field.cattle.io/projectId"},
 		expectedErr:      nil,
 	})
 	tests = append(tests, testCase{
@@ -2027,7 +2276,7 @@ SELECT DISTINCT o.object, o.objectnonce, o.dekid FROM "something" o
 			}
 			lii := &ListOptionIndexer{
 				Indexer:       i,
-				indexedFields: []string{"metadata.queryField1", "status.queryField2", "spec.containers.image"},
+				indexedFields: []string{"metadata.queryField1", "status.queryField2", "spec.containers.image", "metadata.name", "metadata.namespace"},
 			}
 			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
 			if test.expectedErr != nil {
@@ -2321,7 +2570,7 @@ func TestWatchEncryption(t *testing.T) {
 		IsNamespaced: true,
 	}
 	// shouldEncrypt = true to ensure we can write + read from encrypted events
-	loi, dbPath, err := makeListOptionIndexer(ctx, opts, true)
+	loi, dbPath, err := makeListOptionIndexer(ctx, opts, true, emptyNamespaceList)
 	defer cleanTempFiles(dbPath)
 	assert.NoError(t, err)
 
@@ -2407,7 +2656,7 @@ func TestWatchMany(t *testing.T) {
 		},
 		IsNamespaced: true,
 	}
-	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false, emptyNamespaceList)
 	defer cleanTempFiles(dbPath)
 	assert.NoError(t, err)
 
@@ -2664,7 +2913,7 @@ func TestWatchFilter(t *testing.T) {
 				Fields:       [][]string{{"metadata", "somefield"}},
 				IsNamespaced: true,
 			}
-			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+			loi, dbPath, err := makeListOptionIndexer(ctx, opts, false, emptyNamespaceList)
 			defer cleanTempFiles(dbPath)
 			assert.NoError(t, err)
 
@@ -2756,7 +3005,7 @@ func TestWatchResourceVersion(t *testing.T) {
 	opts := ListOptionIndexerOptions{
 		IsNamespaced: true,
 	}
-	loi, dbPath, err := makeListOptionIndexer(parentCtx, opts, false)
+	loi, dbPath, err := makeListOptionIndexer(parentCtx, opts, false, emptyNamespaceList)
 	defer cleanTempFiles(dbPath)
 	assert.NoError(t, err)
 
@@ -2910,7 +3159,7 @@ func TestWatchGarbageCollection(t *testing.T) {
 		GCInterval:  40 * time.Millisecond,
 		GCKeepCount: 2,
 	}
-	loi, dbPath, err := makeListOptionIndexer(parentCtx, opts, false)
+	loi, dbPath, err := makeListOptionIndexer(parentCtx, opts, false, emptyNamespaceList)
 	defer cleanTempFiles(dbPath)
 	assert.NoError(t, err)
 
@@ -3021,7 +3270,7 @@ func TestNonNumberResourceVersion(t *testing.T) {
 		Fields:       [][]string{{"metadata", "somefield"}},
 		IsNamespaced: true,
 	}
-	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false)
+	loi, dbPath, err := makeListOptionIndexer(ctx, opts, false, emptyNamespaceList)
 	defer cleanTempFiles(dbPath)
 	assert.NoError(t, err)
 
@@ -3062,6 +3311,6 @@ func TestNonNumberResourceVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	list, _, _, err := loi.ListByOptions(ctx, &sqltypes.ListOptions{}, []partition.Partition{{All: true}}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedList.Items, list.Items)
 }

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -27,9 +27,10 @@ const (
 
 // ListOptions represents the query parameters that may be included in a list request.
 type ListOptions struct {
-	Filters    []OrFilter
-	SortList   SortList
-	Pagination Pagination
+	Filters              []OrFilter
+	ProjectsOrNamespaces OrFilter
+	SortList             SortList
+	Pagination           Pagination
 }
 
 // Filter represents a field to filter by.

--- a/pkg/stores/sqlpartition/listprocessor/processor.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor.go
@@ -4,19 +4,17 @@ package listprocessor
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/rancher/steve/pkg/stores/queryhelper"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/queryparser"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/selection"
-	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -80,7 +78,7 @@ func k8sRequirementToOrFilter(requirement queryparser.Requirement) (sqltypes.Fil
 }
 
 // ParseQuery parses the query params of a request and returns a ListOptions.
-func ParseQuery(apiOp *types.APIRequest, namespaceCache Cache) (sqltypes.ListOptions, error) {
+func ParseQuery(apiOp *types.APIRequest, gvKind string) (sqltypes.ListOptions, error) {
 	opts := sqltypes.ListOptions{}
 
 	q := apiOp.Request.URL.Query()
@@ -140,29 +138,31 @@ func ParseQuery(apiOp *types.APIRequest, namespaceCache Cache) (sqltypes.ListOpt
 	}
 	opts.Pagination = pagination
 
-	op := sqltypes.Eq
+	op := sqltypes.In
 	projectsOrNamespaces := q.Get(projectsOrNamespacesVar)
 	if projectsOrNamespaces == "" {
 		projectsOrNamespaces = q.Get(projectsOrNamespacesVar + notOp)
 		if projectsOrNamespaces != "" {
-			op = sqltypes.NotEq
+			op = sqltypes.NotIn
 		}
 	}
 	if projectsOrNamespaces != "" {
-		projOrNSFilters, err := parseNamespaceOrProjectFilters(apiOp.Context(), projectsOrNamespaces, op, namespaceCache)
-		if err != nil {
-			return opts, err
-		}
-		if len(projOrNSFilters) == 0 {
-			return opts, apierror.NewAPIError(validation.ErrorCode{Code: "No Data", Status: http.StatusNoContent},
-				fmt.Sprintf("could not find any namespaces named [%s] or namespaces belonging to project named [%s]", projectsOrNamespaces, projectsOrNamespaces))
-		}
-		if op == sqltypes.NotEq {
-			for _, filter := range projOrNSFilters {
-				opts.Filters = append(opts.Filters, sqltypes.OrFilter{Filters: []sqltypes.Filter{filter}})
+		if gvKind == "Namespace" {
+			projNSFilter := parseNamespaceOrProjectFilters(projectsOrNamespaces, op)
+			if len(projNSFilter.Filters) == 2 {
+				if op == sqltypes.In {
+					opts.Filters = append(opts.Filters, projNSFilter)
+				} else {
+					opts.Filters = append(opts.Filters, sqltypes.OrFilter{Filters: []sqltypes.Filter{projNSFilter.Filters[0]}})
+					opts.Filters = append(opts.Filters, sqltypes.OrFilter{Filters: []sqltypes.Filter{projNSFilter.Filters[1]}})
+				}
+			} else if len(projNSFilter.Filters) == 0 {
+				// do nothing
+			} else {
+				logrus.Infof("Ignoring unexpected filter for query %q: parseNamespaceOrProjectFilters returned %d filters, expecting 2", q, len(projNSFilter.Filters))
 			}
 		} else {
-			opts.Filters = append(opts.Filters, sqltypes.OrFilter{Filters: projOrNSFilters})
+			opts.ProjectsOrNamespaces = parseNamespaceOrProjectFilters(projectsOrNamespaces, op)
 		}
 	}
 
@@ -183,40 +183,22 @@ func splitQuery(query string) []string {
 	return strings.Split(query, ".")
 }
 
-func parseNamespaceOrProjectFilters(ctx context.Context, projOrNS string, op sqltypes.Op, namespaceInformer Cache) ([]sqltypes.Filter, error) {
-	filters := []sqltypes.Filter{}
-	for _, pn := range strings.Split(projOrNS, ",") {
-		uList, _, _, err := namespaceInformer.ListByOptions(ctx, &sqltypes.ListOptions{
-			Filters: []sqltypes.OrFilter{
-				{
-					Filters: []sqltypes.Filter{
-						{
-							Field:   []string{"metadata", "name"},
-							Matches: []string{pn},
-							Op:      sqltypes.Eq,
-						},
-						{
-							Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
-							Matches: []string{pn},
-							Op:      sqltypes.Eq,
-						},
-					},
-				},
-			},
-		}, []partition.Partition{{Passthrough: true}}, "")
-		if err != nil {
-			return filters, err
-		}
-		for _, item := range uList.Items {
-			filters = append(filters, sqltypes.Filter{
-				Field:   []string{"metadata", "namespace"},
-				Matches: []string{item.GetName()},
+func parseNamespaceOrProjectFilters(projOrNS string, op sqltypes.Op) sqltypes.OrFilter {
+	var filters []sqltypes.Filter
+	projOrNs := strings.Split(projOrNS, ",")
+	if len(projOrNs) > 0 {
+		filters = []sqltypes.Filter{
+			sqltypes.Filter{
+				Field:   []string{"metadata", "name"},
+				Matches: projOrNs,
 				Op:      op,
-				Partial: false,
-			})
+			},
+			sqltypes.Filter{
+				Field:   []string{"metadata", "labels", projectIDFieldLabel},
+				Matches: projOrNs,
+				Op:      op,
+			},
 		}
-		continue
 	}
-
-	return filters, nil
+	return sqltypes.OrFilter{Filters: filters}
 }

--- a/pkg/stores/sqlpartition/listprocessor/processor_test.go
+++ b/pkg/stores/sqlpartition/listprocessor/processor_test.go
@@ -1,31 +1,25 @@
 package listprocessor
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/steve/pkg/sqlcache/partition"
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 //go:generate mockgen --build_flags=--mod=mod -package listprocessor -destination ./proxy_mocks_test.go github.com/rancher/steve/pkg/stores/sqlproxy Cache
 
 func TestParseQuery(t *testing.T) {
 	type testCase struct {
-		description  string
-		setupNSCache func() Cache
-		nsc          Cache
-		req          *types.APIRequest
-		expectedLO   sqltypes.ListOptions
-		errExpected  bool
-		errorText    string
+		description string
+		req         *types.APIRequest
+		gvKind      string // This is to distinguish Namespace projectornamespaces from others
+		expectedLO  sqltypes.ListOptions
+		errExpected bool
+		errorText   string
 	}
 	var tests []testCase
 	tests = append(tests, testCase{
@@ -43,116 +37,7 @@ func TestParseQuery(t *testing.T) {
 		},
 	})
 	tests = append(tests, testCase{
-		description: "ParseQuery() with no errors returned should returned no errors. If projectsornamespaces is not empty" +
-			" and nsc returns namespaces, they should be included as filters.",
-		req: &types.APIRequest{
-			Request: &http.Request{
-				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
-			},
-		},
-		expectedLO: sqltypes.ListOptions{
-			Filters: []sqltypes.OrFilter{
-				{
-					Filters: []sqltypes.Filter{
-						{
-							Field:   []string{"metadata", "namespace"},
-							Matches: []string{"ns1"},
-							Op:      sqltypes.Eq,
-							Partial: false,
-						},
-					},
-				},
-			},
-			Pagination: sqltypes.Pagination{
-				Page: 1,
-			},
-		},
-		setupNSCache: func() Cache {
-			list := &unstructured.UnstructuredList{
-				Items: []unstructured.Unstructured{
-					{
-						Object: map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"name": "ns1",
-							},
-						},
-					},
-				},
-			}
-			nsc := NewMockCache(gomock.NewController(t))
-			nsc.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
-				Filters: []sqltypes.OrFilter{
-					{
-						Filters: []sqltypes.Filter{
-							{
-								Field:   []string{"metadata", "name"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
-							{
-								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
-						},
-					},
-				},
-			}, []partition.Partition{{Passthrough: true}}, "").Return(list, len(list.Items), "", nil)
-			return nsc
-		},
-	})
-	tests = append(tests, testCase{
-		description: "ParseQuery() with a namespace informer error returned should return an error.",
-		req: &types.APIRequest{
-			Request: &http.Request{
-				// namespace informer is only used if projectsornamespace param is given
-				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
-			},
-		},
-		expectedLO: sqltypes.ListOptions{
-			Filters: []sqltypes.OrFilter{
-				{
-					Filters: []sqltypes.Filter{
-						{
-							Field:   []string{"metadata", "namespace"},
-							Matches: []string{"ns1"},
-							Op:      sqltypes.Eq,
-							Partial: false,
-						},
-					},
-				},
-			},
-			Pagination: sqltypes.Pagination{
-				Page: 1,
-			},
-		},
-		errExpected: true,
-		setupNSCache: func() Cache {
-			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
-				Filters: []sqltypes.OrFilter{
-					{
-						Filters: []sqltypes.Filter{
-							{
-								Field:   []string{"metadata", "name"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
-							{
-								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
-						},
-					},
-				},
-			}, []partition.Partition{{Passthrough: true}}, "").Return(nil, 0, "", fmt.Errorf("error"))
-			return nsi
-		},
-	})
-	tests = append(tests, testCase{
-		description: "ParseQuery() with no errors returned should returned no errors. If projectsornamespaces is not empty" +
-			" and nsc does not return namespaces, it should return an empty filter array",
+		description: "ParseQuery() with only projectsornamespaces should return a project/ns filter.",
 		req: &types.APIRequest{
 			Request: &http.Request{
 				URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
@@ -160,35 +45,135 @@ func TestParseQuery(t *testing.T) {
 		},
 		expectedLO: sqltypes.ListOptions{
 			Filters: []sqltypes.OrFilter{},
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"somethin"},
+						Op:      sqltypes.In,
+					},
+					{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"somethin"},
+						Op:      sqltypes.In,
+					},
+				},
+			},
 			Pagination: sqltypes.Pagination{
 				Page: 1,
 			},
 		},
-		errExpected: true,
-		setupNSCache: func() Cache {
-			list := &unstructured.UnstructuredList{
-				Items: []unstructured.Unstructured{},
-			}
-			nsi := NewMockCache(gomock.NewController(t))
-			nsi.EXPECT().ListByOptions(context.Background(), &sqltypes.ListOptions{
-				Filters: []sqltypes.OrFilter{
-					{
-						Filters: []sqltypes.Filter{
-							{
-								Field:   []string{"metadata", "name"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
-							{
-								Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
-								Matches: []string{"somethin"},
-								Op:      sqltypes.Eq,
-							},
+	})
+	tests = append(tests, testCase{
+		description: "ParseQuery() with only projectsornamespaces on a namespace GVK should return a standard filter.",
+		req: &types.APIRequest{
+			Request: &http.Request{
+				URL: &url.URL{RawQuery: "projectsornamespaces=elm&filter=metadata.name~beech"},
+			},
+		},
+		gvKind: "Namespace",
+		expectedLO: sqltypes.ListOptions{
+			Filters: []sqltypes.OrFilter{
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"metadata", "name"},
+							Matches: []string{"beech"},
+							Op:      sqltypes.Eq,
+							Partial: true,
 						},
 					},
 				},
-			}, []partition.Partition{{Passthrough: true}}, "").Return(list, len(list.Items), "", nil)
-			return nsi
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"metadata", "name"},
+							Matches: []string{"elm"},
+							Op:      sqltypes.In,
+						},
+						{
+							Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+							Matches: []string{"elm"},
+							Op:      sqltypes.In,
+						},
+					},
+				},
+			},
+			Pagination: sqltypes.Pagination{
+				Page: 1,
+			},
+		},
+	})
+	tests = append(tests, testCase{
+		description: "ParseQuery() with only a negative projectsornamespaces should return a project/ns filter.",
+		req: &types.APIRequest{
+			Request: &http.Request{
+				URL: &url.URL{RawQuery: "projectsornamespaces!=somethin"},
+			},
+		},
+		expectedLO: sqltypes.ListOptions{
+			Filters: []sqltypes.OrFilter{},
+			ProjectsOrNamespaces: sqltypes.OrFilter{
+				Filters: []sqltypes.Filter{
+					{
+						Field:   []string{"metadata", "name"},
+						Matches: []string{"somethin"},
+						Op:      sqltypes.NotIn,
+					},
+					{
+						Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+						Matches: []string{"somethin"},
+						Op:      sqltypes.NotIn,
+					},
+				},
+			},
+			Pagination: sqltypes.Pagination{
+				Page: 1,
+			},
+		},
+	})
+	tests = append(tests, testCase{
+		description: "ParseQuery() with only negative projectsornamespaces on a namespace GVK should return a standard filter.",
+		req: &types.APIRequest{
+			Request: &http.Request{
+				URL: &url.URL{RawQuery: "projectsornamespaces!=elm&filter=metadata.name~beech"},
+			},
+		},
+		gvKind: "Namespace",
+		expectedLO: sqltypes.ListOptions{
+			Filters: []sqltypes.OrFilter{
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"metadata", "name"},
+							Matches: []string{"beech"},
+							Op:      sqltypes.Eq,
+							Partial: true,
+						},
+					},
+				},
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"metadata", "name"},
+							Matches: []string{"elm"},
+							Op:      sqltypes.NotIn,
+						},
+					},
+				},
+				{
+					Filters: []sqltypes.Filter{
+						{
+							Field:   []string{"metadata", "labels", "field.cattle.io/projectId"},
+							Matches: []string{"elm"},
+							Op:      sqltypes.NotIn,
+						},
+					},
+				},
+			},
+			Pagination: sqltypes.Pagination{
+				Page: 1,
+			},
 		},
 	})
 	tests = append(tests, testCase{
@@ -848,9 +833,6 @@ func TestParseQuery(t *testing.T) {
 				Page: 1,
 			},
 		},
-		setupNSCache: func() Cache {
-			return nil
-		},
 	})
 	tests = append(tests, testCase{
 		description: "ParseQuery() with no errors returned should returned no errors. If page param is given, page" +
@@ -886,12 +868,7 @@ func TestParseQuery(t *testing.T) {
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			if test.setupNSCache == nil {
-				test.nsc = nil
-			} else {
-				test.nsc = test.setupNSCache()
-			}
-			lo, err := ParseQuery(test.req, test.nsc)
+			lo, err := ParseQuery(test.req, test.gvKind)
 			if test.errExpected {
 				assert.NotNil(t, err)
 				if test.errorText != "" {

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -802,7 +802,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		return nil, 0, "", fmt.Errorf("cachefor %v: %w", gvk, err)
 	}
 
-	opts, err := listprocessor.ParseQuery(apiOp, s.namespaceCache)
+	opts, err := listprocessor.ParseQuery(apiOp, gvk.Kind)
 	if err != nil {
 		var apiError *apierror.APIError
 		if errors.As(err, &apiError) {

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -256,7 +256,7 @@ func TestListByPartitions(t *testing.T) {
 			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
 			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
 			copy(listToReturn.Items, expectedItems)
-			opts, err := listprocessor.ParseQuery(req, nil)
+			opts, err := listprocessor.ParseQuery(req, "")
 			assert.Nil(t, err)
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
@@ -268,77 +268,6 @@ func TestListByPartitions(t *testing.T) {
 			assert.Equal(t, expectedItems, list.Items)
 			assert.Equal(t, len(expectedItems), total)
 			assert.Equal(t, "", contToken)
-		},
-	})
-	tests = append(tests, testCase{
-		description: "client ListByPartitions() with ParseQuery error returned should return an error.",
-		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
-			cg := NewMockClientGetter(gomock.NewController(t))
-			cf := NewMockCacheFactory(gomock.NewController(t))
-			tb := NewMockTransformBuilder(gomock.NewController(t))
-			ri := NewMockResourceInterface(gomock.NewController(t))
-
-			s := &Store{
-				ctx:              context.Background(),
-				namespaceCache:   nsi,
-				clientGetter:     cg,
-				cacheFactory:     cf,
-				transformBuilder: tb,
-			}
-			var partitions []partition.Partition
-			req := &types.APIRequest{
-				Request: &http.Request{
-					URL: &url.URL{RawQuery: "projectsornamespaces=somethin"},
-				},
-			}
-			schema := &types.APISchema{
-				Schema: &schemas.Schema{Attributes: map[string]interface{}{
-					"columns": []common.ColumnDefinition{
-						{
-							Field: "some.field",
-						},
-					},
-					"verbs": []string{"list", "watch"},
-				}},
-			}
-			expectedItems := []unstructured.Unstructured{
-				{
-					Object: map[string]interface{}{
-						"kind": "apple",
-						"metadata": map[string]interface{}{
-							"name": "fuji",
-						},
-						"data": map[string]interface{}{
-							"color": "pink",
-						},
-					},
-				},
-			}
-			listToReturn := &unstructured.UnstructuredList{
-				Items: make([]unstructured.Unstructured, len(expectedItems), len(expectedItems)),
-			}
-			gvk := schema2.GroupVersionKind{
-				Group:   "some",
-				Version: "test",
-				Kind:    "gvk",
-			}
-			typeSpecificIndexedFields["some_test_gvk"] = [][]string{{"gvk", "specific", "fields"}}
-
-			attributes.SetGVK(schema, gvk)
-			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
-			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
-			copy(listToReturn.Items, expectedItems)
-
-			nsi.EXPECT().ListByOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, "", fmt.Errorf("error")).Times(2)
-			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
-			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
-			cf.EXPECT().CacheFor(context.Background(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true)
-			_, err := listprocessor.ParseQuery(req, nsi)
-			assert.NotNil(t, err)
-
-			_, _, _, err = s.ListByPartitions(req, schema, partitions)
-			assert.NotNil(t, err)
 		},
 	})
 	tests = append(tests, testCase{
@@ -398,9 +327,9 @@ func TestListByPartitions(t *testing.T) {
 
 			attributes.SetGVK(schema, gvk)
 			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
-			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
+			// items is equal to the list returned by ListByPartitions doesn't ensure no mutation happened
 			copy(listToReturn.Items, expectedItems)
-			_, err := listprocessor.ParseQuery(req, nil)
+			_, err := listprocessor.ParseQuery(req, "")
 			assert.Nil(t, err)
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(nil, fmt.Errorf("error"))
 
@@ -474,7 +403,7 @@ func TestListByPartitions(t *testing.T) {
 			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
 			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
 			copy(listToReturn.Items, expectedItems)
-			opts, err := listprocessor.ParseQuery(req, nil)
+			opts, err := listprocessor.ParseQuery(req, "")
 			assert.Nil(t, err)
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 
@@ -550,7 +479,7 @@ func TestListByPartitions(t *testing.T) {
 			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
 			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
 			copy(listToReturn.Items, expectedItems)
-			_, err := listprocessor.ParseQuery(req, nil)
+			_, err := listprocessor.ParseQuery(req, "")
 			assert.Nil(t, err)
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
@@ -627,7 +556,7 @@ func TestListByPartitions(t *testing.T) {
 			// ListByPartitions copies point so we need some original record of items to ensure as asserting listToReturn's
 			// items is equal to the list returned by ListByParititons doesn't ensure no mutation happened
 			copy(listToReturn.Items, expectedItems)
-			opts, err := listprocessor.ParseQuery(req, nil)
+			opts, err := listprocessor.ParseQuery(req, "")
 			assert.Nil(t, err)
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map


### PR DESCRIPTION
See [#50968](https://github.com/rancher/rancher/issues/50968)

This backports the work from main (steve) to the rancher v2.12 line (steve release/v0.6)

I redid it as a single commit because I made too many mistakes in the first two of the three commits in `main`.
This single commit consolidates them -- there's no need to split this into separate commits to make it easier to review.