### PR TITLE
Fix using old database while doing a DB reset

### DIFF
--- a/pkg/sqlcache/informer/factory/informer_factory_test.go
+++ b/pkg/sqlcache/informer/factory/informer_factory_test.go
@@ -72,7 +72,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -97,7 +97,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(5 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -163,7 +163,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -184,7 +184,7 @@ func TestCacheFor(t *testing.T) {
 		f.ctx, f.cancel = context.WithCancel(context.Background())
 		f.cancel()
 
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -204,7 +204,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -229,7 +229,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -254,7 +254,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -279,7 +279,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -303,7 +303,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -328,7 +328,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -352,7 +352,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -385,7 +385,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(5 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, transformFunc, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
@@ -405,7 +405,7 @@ func TestCacheFor(t *testing.T) {
 			// need to set this so Run function is not nil
 			SharedIndexInformer: sii,
 		}
-		expectedC := Cache{
+		expectedC := &Cache{
 			ByOptionsLister: i,
 		}
 		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
@@ -433,7 +433,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.cancel()
 		}()
-		var c Cache
+		var c *Cache
 		var err error
 		// CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool)
 		c, err = f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -145,7 +145,9 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 func (i *Informer) Run(stopCh <-chan struct{}) {
 	var wg wait.Group
 	wg.StartWithChannel(stopCh, i.SharedIndexInformer.Run)
-	wg.StartWithContext(wait.ContextForChannel(stopCh), i.loi.RunGC)
+	if i.loi != nil {
+		wg.StartWithContext(wait.ContextForChannel(stopCh), i.loi.RunGC)
+	}
 	wg.Wait()
 }
 

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -44,6 +44,11 @@ type ListOptionIndexer struct {
 	watchersLock sync.RWMutex
 	watchers     map[*watchKey]*watcher
 
+	// gcInterval is how often to run the garbage collection
+	gcInterval time.Duration
+	// gcKeepCount is how many events to keep in _events table when gc runs
+	gcKeepCount int
+
 	upsertEventsQuery        string
 	findEventsRowByRVQuery   string
 	listEventsAfterQuery     string
@@ -282,7 +287,8 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 	l.deleteLabelsByKeyStmt = l.Prepare(l.deleteLabelsByKeyQuery)
 	l.deleteLabelsStmt = l.Prepare(l.deleteLabelsQuery)
 
-	go l.runGC(ctx, opts.GCInterval, opts.GCKeepCount)
+	l.gcInterval = opts.GCInterval
+	l.gcKeepCount = opts.GCKeepCount
 
 	return l, nil
 }
@@ -1555,21 +1561,22 @@ func matchFilter(filterName string, filterNamespace string, filterSelector label
 	return true
 }
 
-func (l *ListOptionIndexer) runGC(ctx context.Context, interval time.Duration, keepCount int) {
-	if interval == 0 || keepCount == 0 {
+func (l *ListOptionIndexer) RunGC(ctx context.Context) {
+	if l.gcInterval == 0 || l.gcKeepCount == 0 {
 		return
 	}
 
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(l.gcInterval)
 	defer ticker.Stop()
 
-	logrus.Infof("Started SQL cache garbage collection for %s (interval=%s, keep=%d)", l.GetName(), interval, keepCount)
+	logrus.Infof("Started SQL cache garbage collection for %s (interval=%s, keep=%d)", l.GetName(), l.gcInterval, l.gcKeepCount)
+	defer logrus.Infof("Stopped SQL cache garbage collection for %s (interval=%s, keep=%d)", l.GetName(), l.gcInterval, l.gcKeepCount)
 
 	for {
 		select {
 		case <-ticker.C:
 			err := l.WithTransaction(ctx, true, func(tx transaction.Client) error {
-				_, err := tx.Stmt(l.deleteEventsByCountStmt).Exec(keepCount)
+				_, err := tx.Stmt(l.deleteEventsByCountStmt).Exec(l.gcKeepCount)
 				if err != nil {
 					return &db.QueryError{QueryString: l.deleteEventsByCountQuery, Err: err}
 				}

--- a/pkg/sqlcache/informer/listoption_indexer_test.go
+++ b/pkg/sqlcache/informer/listoption_indexer_test.go
@@ -100,6 +100,8 @@ func makeListOptionIndexer(ctx context.Context, opts ListOptionIndexerOptions, s
 		return nil, "", err
 	}
 
+	go listOptionIndexer.RunGC(ctx)
+
 	return listOptionIndexer, dbPath, nil
 }
 

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -95,7 +95,10 @@ func (i *IntegrationSuite) TestSQLCacheFilters() {
 
 	cache, cacheFactory, err := i.createCacheAndFactory(fields, nil)
 	require.NoError(err)
-	defer cacheFactory.Reset()
+	defer func() {
+		cacheFactory.DoneWithCache(cache)
+		cacheFactory.Reset()
+	}()
 
 	// doesn't match the filter for somekey == somevalue
 	notMatches := configMapWithAnnotations("not-matches-filter", map[string]string{"somekey": "notequal"})
@@ -327,7 +330,7 @@ func (i *IntegrationSuite) createCacheAndFactory(fields [][]string, transformFun
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to make cache: %w", err)
 	}
-	return &cache, cacheFactory, nil
+	return cache, cacheFactory, nil
 }
 
 func (i *IntegrationSuite) waitForCacheReady(readyResourceNames []string, namespace string, cache *factory.Cache) error {

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -267,10 +267,10 @@ func (m *MockCacheFactory) EXPECT() *MockCacheFactoryMockRecorder {
 }
 
 // CacheFor mocks base method.
-func (m *MockCacheFactory) CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced, watchable bool) (factory.Cache, error) {
+func (m *MockCacheFactory) CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced, watchable bool) (*factory.Cache, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CacheFor", ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable)
-	ret0, _ := ret[0].(factory.Cache)
+	ret0, _ := ret[0].(*factory.Cache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -279,6 +279,18 @@ func (m *MockCacheFactory) CacheFor(ctx context.Context, fields [][]string, exte
 func (mr *MockCacheFactoryMockRecorder) CacheFor(ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable)
+}
+
+// DoneWithCache mocks base method.
+func (m *MockCacheFactory) DoneWithCache(arg0 *factory.Cache) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DoneWithCache", arg0)
+}
+
+// DoneWithCache indicates an expected call of DoneWithCache.
+func (mr *MockCacheFactoryMockRecorder) DoneWithCache(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoneWithCache", reflect.TypeOf((*MockCacheFactory)(nil).DoneWithCache), arg0)
 }
 
 // Reset mocks base method.

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -289,7 +289,7 @@ type Store struct {
 	notifier         RelationshipNotifier
 	cacheFactory     CacheFactory
 	cfInitializer    CacheFactoryInitializer
-	namespaceCache   Cache
+	namespaceCache   *factory.Cache
 	lock             sync.Mutex
 	columnSetter     SchemaColumnSetter
 	transformBuilder TransformBuilder
@@ -300,7 +300,8 @@ type Store struct {
 type CacheFactoryInitializer func() (CacheFactory, error)
 
 type CacheFactory interface {
-	CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (factory.Cache, error)
+	CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (*factory.Cache, error)
+	DoneWithCache(*factory.Cache)
 	Reset() error
 }
 
@@ -336,6 +337,9 @@ func NewProxyStore(ctx context.Context, c SchemaColumnSetter, clientGetter Clien
 func (s *Store) Reset() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.namespaceCache != nil {
+		s.cacheFactory.DoneWithCache(s.namespaceCache)
+	}
 	if err := s.cacheFactory.Reset(); err != nil {
 		return fmt.Errorf("reset: %w", err)
 	}
@@ -595,6 +599,10 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 	if err != nil {
 		return nil, err
 	}
+	// FIXME: This needs to be called when the watch ends, not at the end of
+	// this func. However, there's currently a bug where we don't correctly
+	// shutdown watches, so for now, we do this.
+	defer s.cacheFactory.DoneWithCache(inf)
 
 	var selector labels.Selector
 	if w.Selector != "" {
@@ -803,6 +811,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("cachefor %v: %w", gvk, err)
 	}
+	defer s.cacheFactory.DoneWithCache(inf)
 
 	opts, err := listprocessor.ParseQuery(apiOp, gvk.Kind)
 	if err != nil {

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -75,7 +75,7 @@ func TestNewProxyStore(t *testing.T) {
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
 			bloi := NewMockByOptionsLister(gomock.NewController(t))
-			c := factory.Cache{
+			c := &factory.Cache{
 				ByOptionsLister: &informer.Informer{
 					ByOptionsLister: bloi,
 				},
@@ -167,7 +167,7 @@ func TestNewProxyStore(t *testing.T) {
 			nsSchema := baseNSSchema
 			scc.EXPECT().SetColumns(context.Background(), &nsSchema).Return(nil)
 			cg.EXPECT().TableAdminClient(nil, &nsSchema, "", &WarningBuffer{}).Return(ri, nil)
-			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(factory.Cache{}, fmt.Errorf("error"))
+			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(nil, fmt.Errorf("error"))
 
 			s, err := NewProxyStore(context.Background(), scc, cg, rn, nil, cf, true)
 			assert.Nil(t, err)
@@ -194,7 +194,6 @@ func TestListByPartitions(t *testing.T) {
 		description: "client ListByPartitions() with no errors returned should return no errors. Should pass fields" +
 			" from schema.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
@@ -203,12 +202,12 @@ func TestListByPartitions(t *testing.T) {
 			inf := &informer.Informer{
 				ByOptionsLister: bloi,
 			}
-			c := factory.Cache{
+			c := &factory.Cache{
 				ByOptionsLister: inf,
 			}
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
+				namespaceCache:   &factory.Cache{ByOptionsLister: bloi},
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				transformBuilder: tb,
@@ -261,6 +260,7 @@ func TestListByPartitions(t *testing.T) {
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(c, nil)
+			cf.EXPECT().DoneWithCache(c)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), []common.ColumnDefinition{{Field: "some.field"}}, false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
 			list, total, contToken, err := s.ListByPartitions(req, schema, partitions)
@@ -274,7 +274,9 @@ func TestListByPartitions(t *testing.T) {
 		description: "client ListByPartitions() with no errors returned should return no errors. Should pass fields" +
 			" from schema.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
+			nsi := &factory.Cache{
+				ByOptionsLister: NewMockByOptionsLister(gomock.NewController(t)),
+			}
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			tb := NewMockTransformBuilder(gomock.NewController(t))
@@ -340,21 +342,23 @@ func TestListByPartitions(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client ListByPartitions() should detect listable-but-unwatchable schema, still work normally",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
 			bloi := NewMockByOptionsLister(gomock.NewController(t))
+			nsi := factory.Cache{
+				ByOptionsLister: bloi,
+			}
 			tb := NewMockTransformBuilder(gomock.NewController(t))
 			inf := &informer.Informer{
 				ByOptionsLister: bloi,
 			}
-			c := factory.Cache{
+			c := &factory.Cache{
 				ByOptionsLister: inf,
 			}
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
+				namespaceCache:   &nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				transformBuilder: tb,
@@ -410,6 +414,7 @@ func TestListByPartitions(t *testing.T) {
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			// note also the watchable bool is expected to be false
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), false).Return(c, nil)
+			cf.EXPECT().DoneWithCache(c)
 
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), []common.ColumnDefinition{{Field: "some.field"}}, false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), "", nil)
@@ -423,7 +428,9 @@ func TestListByPartitions(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client ListByPartitions() with CacheFor() error returned should return an errors. Should pass fields",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
+			nsi := factory.Cache{
+				ByOptionsLister: NewMockByOptionsLister(gomock.NewController(t)),
+			}
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
@@ -431,7 +438,7 @@ func TestListByPartitions(t *testing.T) {
 
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
+				namespaceCache:   &nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				transformBuilder: tb,
@@ -484,7 +491,7 @@ func TestListByPartitions(t *testing.T) {
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
-			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(factory.Cache{}, fmt.Errorf("error"))
+			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(nil, fmt.Errorf("error"))
 
 			_, _, _, err = s.ListByPartitions(req, schema, partitions)
 			assert.NotNil(t, err)
@@ -494,7 +501,9 @@ func TestListByPartitions(t *testing.T) {
 		description: "client ListByPartitions() with ListByOptions() error returned should return an errors. Should pass fields" +
 			" from schema.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
+			nsi := factory.Cache{
+				ByOptionsLister: NewMockByOptionsLister(gomock.NewController(t)),
+			}
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
@@ -503,12 +512,12 @@ func TestListByPartitions(t *testing.T) {
 			inf := &informer.Informer{
 				ByOptionsLister: bloi,
 			}
-			c := factory.Cache{
+			c := &factory.Cache{
 				ByOptionsLister: inf,
 			}
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
+				namespaceCache:   &nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				transformBuilder: tb,
@@ -561,6 +570,7 @@ func TestListByPartitions(t *testing.T) {
 			cg.EXPECT().TableAdminClient(req, schema, "", &WarningBuffer{}).Return(ri, nil)
 			// This tests that fields are being extracted from schema columns and the type specific fields map
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {`id`}, {`metadata`, `state`, `name`}, {"gvk", "specific", "fields"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(schema), attributes.Namespaced(schema), true).Return(c, nil)
+			cf.EXPECT().DoneWithCache(c)
 			bloi.EXPECT().ListByOptions(req.Context(), &opts, partitions, req.Namespace).Return(nil, 0, "", fmt.Errorf("error"))
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 
@@ -610,21 +620,23 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
 			bloi := NewMockByOptionsLister(gomock.NewController(t))
+			nsi := factory.Cache{
+				ByOptionsLister: bloi,
+			}
 			tb := NewMockTransformBuilder(gomock.NewController(t))
 			inf := &informer.Informer{
 				ByOptionsLister: bloi,
 			}
-			c := factory.Cache{
+			c := &factory.Cache{
 				ByOptionsLister: inf,
 			}
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
+				namespaceCache:   &nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				transformBuilder: tb,
@@ -674,6 +686,7 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 			attributes.SetGVK(theSchema, gvk)
 			cg.EXPECT().TableAdminClient(apiOp, theSchema, "", &WarningBuffer{}).Return(ri, nil)
 			cf.EXPECT().CacheFor(context.Background(), [][]string{{"some", "field"}, {"id"}, {"metadata", "state", "name"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(theSchema), attributes.Namespaced(theSchema), true).Return(c, nil)
+			cf.EXPECT().DoneWithCache(c)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(theSchema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 
 			listToReturn := &unstructured.UnstructuredList{
@@ -695,13 +708,14 @@ func TestReset(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client Reset() with no errors returned should return no errors.",
 		test: func(t *testing.T) {
-			nsc := NewMockCache(gomock.NewController(t))
+			nsc := &factory.Cache{
+				ByOptionsLister: NewMockByOptionsLister(gomock.NewController(t)),
+			}
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			cs := NewMockSchemaColumnSetter(gomock.NewController(t))
 			ri := NewMockResourceInterface(gomock.NewController(t))
 			tb := NewMockTransformBuilder(gomock.NewController(t))
-			nsc2 := factory.Cache{}
 			s := &Store{
 				ctx:              context.Background(),
 				namespaceCache:   nsc,
@@ -715,17 +729,17 @@ func TestReset(t *testing.T) {
 			cf.EXPECT().Reset().Return(nil)
 			cs.EXPECT().SetColumns(gomock.Any(), gomock.Any()).Return(nil)
 			cg.EXPECT().TableAdminClient(nil, &nsSchema, "", &WarningBuffer{}).Return(ri, nil)
-			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(nsc2, nil)
+			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(nsc, nil)
+			cf.EXPECT().DoneWithCache(nsc)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(&nsSchema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			err := s.Reset()
 			assert.Nil(t, err)
-			assert.Equal(t, nsc2, s.namespaceCache)
+			assert.Equal(t, nsc, s.namespaceCache)
 		},
 	})
 	tests = append(tests, testCase{
 		description: "client Reset() with cache factory Reset() error returned, should return an error.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			cs := NewMockSchemaColumnSetter(gomock.NewController(t))
@@ -733,7 +747,6 @@ func TestReset(t *testing.T) {
 
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				columnSetter:     cs,
@@ -749,7 +762,6 @@ func TestReset(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client Reset() with column setter error returned, should return an error.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			cs := NewMockSchemaColumnSetter(gomock.NewController(t))
@@ -757,7 +769,6 @@ func TestReset(t *testing.T) {
 
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				columnSetter:     cs,
@@ -774,7 +785,6 @@ func TestReset(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client Reset() with column getter TableAdminClient() error returned, should return an error.",
 		test: func(t *testing.T) {
-			nsi := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			cs := NewMockSchemaColumnSetter(gomock.NewController(t))
@@ -782,7 +792,6 @@ func TestReset(t *testing.T) {
 
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsi,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				columnSetter:     cs,
@@ -801,7 +810,6 @@ func TestReset(t *testing.T) {
 	tests = append(tests, testCase{
 		description: "client Reset() with cache factory CacheFor() error returned, should return an error.",
 		test: func(t *testing.T) {
-			nsc := NewMockCache(gomock.NewController(t))
 			cg := NewMockClientGetter(gomock.NewController(t))
 			cf := NewMockCacheFactory(gomock.NewController(t))
 			cs := NewMockSchemaColumnSetter(gomock.NewController(t))
@@ -810,7 +818,6 @@ func TestReset(t *testing.T) {
 
 			s := &Store{
 				ctx:              context.Background(),
-				namespaceCache:   nsc,
 				clientGetter:     cg,
 				cacheFactory:     cf,
 				columnSetter:     cs,
@@ -822,7 +829,7 @@ func TestReset(t *testing.T) {
 			cf.EXPECT().Reset().Return(nil)
 			cs.EXPECT().SetColumns(gomock.Any(), gomock.Any()).Return(nil)
 			cg.EXPECT().TableAdminClient(nil, &nsSchema, "", &WarningBuffer{}).Return(ri, nil)
-			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(factory.Cache{}, fmt.Errorf("error"))
+			cf.EXPECT().CacheFor(context.Background(), [][]string{{`id`}, {`metadata`, `state`, `name`}, {"spec", "displayName"}}, gomock.Any(), gomock.Any(), gomock.Any(), &tablelistconvert.Client{ResourceInterface: ri}, attributes.GVK(&nsSchema), false, true).Return(nil, fmt.Errorf("error"))
 			tb.EXPECT().GetTransformFunc(attributes.GVK(&nsSchema), gomock.Any(), false).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			err := s.Reset()
 			assert.NotNil(t, err)


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/51583

There are two problems here:
1. It was possible for the garbage collection to run SQL queries on the old DB with the right timing. We were cancelling the `context.Context` but not waiting on it to finish.
2. We were not fully preventing list requests from hitting an old DB

More details below

## Garbage collection

See first commit. We're now overriding the k8s interface to run the Garbage collection within a wait group. This means [Run() will be called](https://github.com/rancher/steve/blob/0abbdd2940805e4e5ba55936d029299b9a7854f5/pkg/sqlcache/informer/factory/informer_factory.go#L172) which will call the SharedIndexInformer's Run and our GC Run. And then we [wait for both of these to be done](https://github.com/rancher/steve/blob/0abbdd2940805e4e5ba55936d029299b9a7854f5/pkg/sqlcache/informer/factory/informer_factory.go#L206) before doing the DB reset.

## Preventing list requests

We already had a mutex that would prevent calls for CacheFor to get an informer. However, once the informer is acquired, nothing prevents it from accessing the DB (the rest of the List request). So, with the right timing, it's possible that the following happens:
1. CacheFor to get the informer (mutex lock + mutex unlock)
2. Reset is called
3. Rest of list request accessing old DB

To prevent this, I went with the following solution: CacheFor only calls lock on success. It's up to the caller to unlock the mutex with DoneWithCache() once done with the request.

This allows multiple concurrent requests because it's a RWLock and CacheFor does a RLock() call. As soon as Reset is called, no new CacheFor call will go through, it'll wait for all list requests to be finished (shouldn't be too long) and then the DB can be reset. Finally, once the Reset is done, pending CacheFor calls will be able to continue.

## Future work

The next step will be working on https://github.com/rancher/rancher/issues/51569 so DoneWithCache will _likely_ be per-GVK instead of global. We'll see.. It might be more complex to deal with GVKs that depends on other GVKs.