### PR TITLE
Add comments to clarify where non-test-mode methods are defined.

### DIFF
--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -153,6 +153,8 @@ func (f *CacheFactory) cacheForLocked(ctx context.Context, fields [][]string, ex
 
 		_, encryptResourceAlways := defaultEncryptedResourceTypes[gvk]
 		shouldEncrypt := f.encryptAll || encryptResourceAlways
+		// In non-test code this invokes pkg/sqlcache/informer/informer.go: NewInformer()
+		// search for "func NewInformer(ctx"
 		i, err := f.newInformer(f.ctx, client, fields, externalUpdateInfo, selfUpdateInfo, transform, gvk, f.dbClient, shouldEncrypt, namespaced, watchable, f.gcInterval, f.gcKeepCount)
 		if err != nil {
 			return nil, err

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -106,6 +106,8 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields [
 	// We therefore just disable it right away.
 	resyncPeriod := time.Duration(0)
 
+	// In non-test mode `newInformer` is cache.NewSharedIndexInformer
+	// defined in k8s.io/client-go/tools/cache/shared_informer.go : func NewSharedIndexInformer(lw ...
 	sii := newInformer(listWatcher, example, resyncPeriod, cache.Indexers{})
 	if transform != nil {
 		if err := sii.SetTransform(transform); err != nil {


### PR DESCRIPTION
I'm constantly doing the same searches here on these indirect methods.

This change just puts the sources I'm looking for in comments.