### PR TITLE
Fix send to closed channel panic in watch

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -399,6 +399,11 @@ func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, events
 		return nil
 	})
 	if err != nil {
+		// We might have added a watcher but the transaction failed in
+		// which case we still want to remove the watcher
+		if key != nil {
+			l.removeWatcher(key)
+		}
 		return err
 	}
 


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/51843

This fixes the following panic that could be seen on rancher:

```
E0910 03:10:13.389776      43 chan.go:226] "Observed a panic" panic="send on closed channel" panicGoValue="\"send on closed channel\"" stacktrace=<
   goroutine 38911 [running]:
   k8s.io/apimachinery/pkg/util/runtime.logPanic({0xb3cfa08, 0xc01e0a3e30}, {0x87db5e0, 0xb335b50})
      /root/.cache/go/modcache/k8s.io/apimachinery@v0.33.4/pkg/util/runtime/runtime.go:132 +0xbc
   k8s.io/apimachinery/pkg/util/runtime.handleCrash({0xb3d00d0, 0xc00ab457a0}, {0x87db5e0, 0xb335b50}, {0x0, 0x0, 0xc00f1c93f0?})
      /root/.cache/go/modcache/k8s.io/apimachinery@v0.33.4/pkg/util/runtime/runtime.go:107 +0x116
   k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0xb3d00d0, 0xc00ab457a0}, {0x0, 0x0, 0x0})
      /root/.cache/go/modcache/k8s.io/apimachinery@v0.33.4/pkg/util/runtime/runtime.go:78 +0x5a
   panic({0x87db5e0?, 0xb335b50?})
      /usr/lib64/go/1.24/src/runtime/panic.go:792 +0x132
   github.com/rancher/steve/pkg/sqlcache/informer.(*ListOptionIndexer).notifyEvent(0xc00d5ff760, {0xa40ab3a, 0x8}, {0xa394b60, 0xc01daf12a8}, {0xa394b60, 0xc01daf02e8}, {0xb365460, 0xc01daf1178})
      /root/.cache/go/modcache/github.com/rancher/steve@v0.6.36/pkg/sqlcache/informer/listoption_indexer.go:495 +0x36c
   github.com/rancher/steve/pkg/sqlcache/informer.(*ListOptionIndexer).notifyEventModified(0xc00d5ff760, {0xc01acad4b0, 0x7}, {0xa394b60, 0xc01daf02e8}, {0xb365460, 0xc01daf1178})
      /root/.cache/go/modcache/github.com/rancher/steve@v0.6.36/pkg/sqlcache/informer/listoption_indexer.go:461 +0xd1
   github.com/rancher/steve/pkg/sqlcache/store.(*Store).runAfterUpdate(0xc0013e0b90?, {0xc01acad4b0, 0x7}, {0xa394b60, 0xc01daf02e8}, {0xb365460, 0xc01daf1178})
      /root/.cache/go/modcache/github.com/rancher/steve@v0.6.36/pkg/sqlcache/store/store.go:541 +0xae
   github.com/rancher/steve/pkg/sqlcache/store.(*Store).Update.func1({0xb365460, 0xc01daf1178})
      /root/.cache/go/modcache/github.com/rancher/steve@v0.6.36/pkg/sqlcache/store/store.go:371 +0x125
```

The issue was that there was a small window where the watcher could have been added but the context canceled, leading to the whole `WithTransaction` call to fail. The removeWatcher call was not called, so the watcher was still there, and because we close the channel somewhere else in the code, we'd send to a closed channel.

@gehrkefc I didn't move the channel here because I didn't have the time (it's going to require quite a few changes). Not saying that we shouldn't do it though..