### PR TITLE
Log error details when Dashboard UI download fails

### DIFF
--- a/pkg/ui/handler.go
+++ b/pkg/ui/handler.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -100,10 +99,10 @@ func NewUIHandler(opts *Options) *Handler {
 
 func (u *Handler) canDownload(url string) bool {
 	u.downloadOnce.Do(func() {
-		if err := serveRemote(ioutil.Discard, url); err == nil {
+		if err := serveRemote(io.Discard, url); err == nil {
 			u.downloadSuccess = true
 		} else {
-			logrus.Errorf("Failed to download %s, falling back to packaged UI", url)
+			logrus.Errorf("failed to download %s: %v, falling back to packaged UI", url, err)
 		}
 	})
 	return u.downloadSuccess


### PR DESCRIPTION
## Issue: [rancher/rancher#51765](https://github.com/rancher/rancher/issues/51765)
## Problem

When Rancher/Steve fails to fetch the up-to-date Dashboard UI, the log only shows:

```
[ERROR] failed to download <URL>, falling back to packaged UI
```

It lacks error context (e.g., timeout, TLS, 404), making incidents hard to diagnose. See [#51765](https://github.com/rancher/rancher/issues/51765).

## Solution

In `Handler.canDownload`:

* Log the underlying error returned by `serveIndex`:

  ```
  logrus.Errorf("failed to download %s: %v, falling back to packaged UI", url, err)
  ```
* Modernize discard writer: `ioutil.Discard` -> `io.Discard`.

This is a **log-only** improvement. No behavioral changes beyond richer diagnostics.

### Before

```
[ERROR] Failed to download https://releases.rancher.com/dashboard/latest/index.html, falling back to packaged UI
```

### After

```
[ERROR] failed to download https://releases.rancher.com/dashboard/latest/index.html: Get ".../index.html": dial tcp ...: i/o timeout, falling back to packaged UI
```

## Testing

### Manual

1. Run Rancher/Steve with the Dashboard index pointing to an unreachable/invalid host.
2. Trigger UI fetch.
3. Verify logs:

   * New log line includes the concrete error.