### PR TITLE
Use Upsert syntax instead of `REPLACE INTO`

### DIFF
--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -23,7 +23,13 @@ import (
 )
 
 const (
-	upsertStmtFmt    = `REPLACE INTO "%s"(key, object, objectnonce, dekid) VALUES (?, ?, ?, ?)`
+	upsertStmtFmt = `
+INSERT INTO "%s" (key, object, objectnonce, dekid)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(key) DO UPDATE SET
+  object = excluded.object,
+  objectnonce = excluded.objectnonce,
+  dekid = excluded.dekid`
 	deleteStmtFmt    = `DELETE FROM "%s" WHERE key = ?`
 	deleteAllStmtFmt = `DELETE FROM "%s"`
 	dropBaseStmtFmt  = `DROP TABLE IF EXISTS "%s"`


### PR DESCRIPTION
I tweaked Steve db client to dump the duration of all statement executions, and analyzed them while running the [Vai ingestion benchmark](https://github.com/rancher/dartboard/pull/102) locally. The average duration was not too bad but could be improved, and there were exceptions when it could take up to 30ms.
After analyzing the different queries with [SQLite's Query Planner](https://www.sqlite.org/eqp.html) (and Gemini's precious help), it turns out we are using `REPLACE INTO` statement, whose more modern alternative `Upsert` provides a better performance, as it no longer needs `DELETE  + INSERT` in case of a conflict.
These are the timings summary before and after these optimizations (in my local VM):
- Before:
```
min_ms        max_ms        avg_ms        p50         p90         p95         p99
------------------------------------------------------------------------------------------
0.02          11.89         0.17          0.15        0.23        0.27        0.63
```
- After:
```
min_ms        max_ms        avg_ms        p50         p90         p95         p99
------------------------------------------------------------------------------------------
0.02          6.20          0.07          0.06        0.09        0.11        0.28
```
I expect much bigger impact on slower systems.