### PR TITLE
Omit update for immutable fields during upsert

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -271,12 +271,16 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 	l.deleteEventsByCountStmt = l.Prepare(fmt.Sprintf(deleteEventsByCountFmt, dbName, dbName))
 	l.dropEventsStmt = l.Prepare(fmt.Sprintf(dropEventsFmt, dbName))
 
+	addFieldsOnConflict := "NOTHING"
+	if len(setStatements) > 0 {
+		addFieldsOnConflict = "UPDATE SET " + strings.Join(setStatements, ", ")
+	}
 	l.addFieldsStmt = l.Prepare(fmt.Sprintf(
-		`INSERT INTO "%s_fields"(key, %s) VALUES (?, %s) ON CONFLICT DO UPDATE SET %s`,
+		`INSERT INTO "%s_fields"(key, %s) VALUES (?, %s) ON CONFLICT DO %s`,
 		dbName,
 		strings.Join(columns, ", "),
 		strings.Join(qmarks, ", "),
-		strings.Join(setStatements, ", "),
+		addFieldsOnConflict,
 	))
 	l.deleteFieldsByKeyStmt = l.Prepare(fmt.Sprintf(`DELETE FROM "%s_fields" WHERE key = ?`, dbName))
 	l.deleteFieldsStmt = l.Prepare(fmt.Sprintf(deleteFieldsFmt, dbName))


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52162

Analyzing queries performance using SQLite's `EXPLAIN` plans (unlike #832, `_fields` tables already used an `UPSERT` approach), it showed a fairly long plan (151 steps), result of the many indices configured.
We could revisit the number of indices we use (although they may be needed to support the UI). Alternatively, since every `UPDATE` will require every index to be individually refreshed (which impacts performance), we can reduce the number of fields being updated in the special case of fields being immutable.

With these changes the query will be changed from (example for ConfigMaps):
```
INSERT INTO _v1_ConfigMap_fields (
  key,
  "metadata.name",
  "metadata.creationTimestamp",
  "metadata.namespace",
  "metadata.fields[0]",
  "metadata.fields[1]",
  "metadata.fields[2]",
  id,
  "metadata.state.name"
) VALUES (?,?,?,?,?,?,?,?,?)
ON CONFLICT DO UPDATE SET
  "metadata.name" = excluded."metadata.name",
  "metadata.creationTimestamp" = excluded."metadata.creationTimestamp",
  "metadata.namespace" = excluded."metadata.namespace",
  "metadata.fields[0]" = excluded."metadata.fields[0]",
  "metadata.fields[1]" = excluded."metadata.fields[1]",
  "metadata.fields[2]" = excluded."metadata.fields[2]",
  id = excluded.id,
  "metadata.state.name" = excluded."metadata.state.name";
```
to
```
INSERT INTO _v1_ConfigMap_fields (
  key,
  "metadata.name",
  "metadata.creationTimestamp",
  "metadata.namespace",
  "metadata.fields[0]",
  "metadata.fields[1]",
  "metadata.fields[2]",
  id,
  "metadata.state.name"
) VALUES (?,?,?,?,?,?,?,?,?)
ON CONFLICT DO UPDATE SET
  "metadata.fields[0]" = excluded."metadata.fields[0]",
  "metadata.fields[1]" = excluded."metadata.fields[1]",
  "metadata.fields[2]" = excluded."metadata.fields[2]";
```
This reduces the `EXPLAIN` plan from 151 steps down to 116.

Running a k6 benchmark that produces configmap updates at a constant rate, we can observe some improvements in the durations for this particular query:
- Before
```
min_ms        max_ms        avg_ms        p50         p90         p95         p99
------------------------------------------------------------------------------------------
0.36          4.70          0.64          0.52        0.91        1.15        2.22
```
- After
```
min_ms        max_ms        avg_ms        p50         p90         p95         p99
------------------------------------------------------------------------------------------
0.30          3.59          0.55          0.44        0.82        1.13        1.89
```