### PR TITLE
[release/v0.6] Fix nil pointer panic when stopping a cache factory

### DIFF
--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -264,11 +264,15 @@ func (f *CacheFactory) Stop(gvk schema.GroupVersionKind) error {
 	// Wait for all informers to have exited
 	gi.wg.Wait()
 
-	// DropAll needs its own context because the context from the informer
-	// is canceled
-	err := gi.informer.DropAll(context.Background())
-	if err != nil {
-		return fmt.Errorf("dropall %q: %w", gvk, err)
+	// Since we hold the lock on gi.stopMutex, we do not need to also hold
+	// onto gi.informersMutex
+	if gi.informer != nil {
+		// DropAll needs its own context because the context from the informer
+		// is canceled
+		err := gi.informer.DropAll(context.Background())
+		if err != nil {
+			return fmt.Errorf("dropall %q: %w", gvk, err)
+		}
 	}
 
 	return nil

--- a/pkg/sqlcache/informer/factory/informer_factory_test.go
+++ b/pkg/sqlcache/informer/factory/informer_factory_test.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -513,11 +514,31 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		// CacheFor(ctx context.Context, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool)
 		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedC, c)
 		time.Sleep(1 * time.Second)
+	}})
+	// Test for panic from https://github.com/rancher/rancher/issues/52124
+	tests = append(tests, testCase{description: "CacheFor() able to stop cache with a nil gi.informer", test: func(t *testing.T) {
+		dbClient := NewMockClient(gomock.NewController(t))
+		dynamicClient := NewMockResourceInterface(gomock.NewController(t))
+		fields := [][]string{{"something"}}
+		expectedGVK := schema.GroupVersionKind{}
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields [][]string, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcInterval time.Duration, gcKeepCount int) (*informer.Informer, error) {
+			return nil, fmt.Errorf("fake error")
+		}
+		f := &CacheFactory{
+			dbClient:    dbClient,
+			newInformer: testNewInformer,
+			encryptAll:  true,
+			informers:   map[schema.GroupVersionKind]*guardedInformer{},
+		}
+		f.ctx, f.cancel = context.WithCancel(context.Background())
+		_, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		assert.Error(t, err)
+		err = f.Stop(expectedGVK)
+		assert.NoError(t, err)
 	}})
 	t.Parallel()
 	for _, test := range tests {


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/52127

Backports of https://github.com/rancher/steve/pull/841

Basically, if newTestInformer or SetWatchErrorHandler fails, we end up not assigning a `gi.informer`. So then if we stop the cache at that point, we try to `DropAll` from the nil `gi.informer`.

This PR fixes the panic by checking for `gi.informer` first. I added a test to verify this, without the fix, the test panics. With the fix, no longer any panic.