### PR TITLE
Rely on foreign keys for deletion

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -54,11 +54,9 @@ type ListOptionIndexer struct {
 	deleteEventsByCountStmt db.Stmt
 	dropEventsStmt          db.Stmt
 	addFieldsStmt           db.Stmt
-	deleteFieldsByKeyStmt   db.Stmt
 	deleteFieldsStmt        db.Stmt
 	dropFieldsStmt          db.Stmt
 	upsertLabelsStmt        db.Stmt
-	deleteLabelsByKeyStmt   db.Stmt
 	deleteLabelsStmt        db.Stmt
 	dropLabelsStmt          db.Stmt
 }
@@ -113,9 +111,10 @@ ON CONFLICT(type, rv) DO UPDATE SET
 	dropEventsFmt = `DROP TABLE IF EXISTS "%s_events"`
 
 	createFieldsTableFmt = `CREATE TABLE "%s_fields" (
-			key TEXT NOT NULL PRIMARY KEY,
-            %s
-	   )`
+		key TEXT NOT NULL REFERENCES "%s"(key) ON DELETE CASCADE,
+		%s,
+		PRIMARY KEY (key)
+    )`
 	createFieldsIndexFmt = `CREATE INDEX "%s_%s_index" ON "%s_fields"("%s")`
 	deleteFieldsFmt      = `DELETE FROM "%s_fields"`
 	dropFieldsFmt        = `DROP TABLE IF EXISTS "%s_fields"`
@@ -135,9 +134,8 @@ INSERT INTO "%s_labels" (key, label, value)
 VALUES (?, ?, ?)
 ON CONFLICT(key, label) DO UPDATE SET
   value = excluded.value`
-	deleteLabelsByKeyStmtFmt = `DELETE FROM "%s_labels" WHERE KEY = ?`
-	deleteLabelsStmtFmt      = `DELETE FROM "%s_labels"`
-	dropLabelsStmtFmt        = `DROP TABLE IF EXISTS "%s_labels"`
+	deleteLabelsStmtFmt = `DELETE FROM "%s_labels"`
+	dropLabelsStmtFmt   = `DROP TABLE IF EXISTS "%s_labels"`
 )
 
 type ListOptionIndexerOptions struct {
@@ -190,8 +188,6 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 	l.RegisterAfterUpdate(l.addIndexFields)
 	l.RegisterAfterUpdate(l.addLabels)
 	l.RegisterAfterUpdate(l.notifyEventModified)
-	l.RegisterAfterDelete(l.deleteFieldsByKey)
-	l.RegisterAfterDelete(l.deleteLabelsByKey)
 	l.RegisterAfterDelete(l.notifyEventDeleted)
 	l.RegisterAfterDeleteAll(l.deleteFields)
 	l.RegisterAfterDeleteAll(l.deleteLabels)
@@ -215,7 +211,7 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 			return err
 		}
 
-		createFieldsTableQuery := fmt.Sprintf(createFieldsTableFmt, dbName, strings.Join(columnDefs, ", "))
+		createFieldsTableQuery := fmt.Sprintf(createFieldsTableFmt, dbName, dbName, strings.Join(columnDefs, ", "))
 		if _, err := tx.Exec(createFieldsTableQuery); err != nil {
 			return err
 		}
@@ -267,12 +263,10 @@ func NewListOptionIndexer(ctx context.Context, s Store, opts ListOptionIndexerOp
 		strings.Join(qmarks, ", "),
 		strings.Join(setStatements, ", "),
 	))
-	l.deleteFieldsByKeyStmt = l.Prepare(fmt.Sprintf(`DELETE FROM "%s_fields" WHERE key = ?`, dbName))
 	l.deleteFieldsStmt = l.Prepare(fmt.Sprintf(deleteFieldsFmt, dbName))
 	l.dropFieldsStmt = l.Prepare(fmt.Sprintf(dropFieldsFmt, dbName))
 
 	l.upsertLabelsStmt = l.Prepare(fmt.Sprintf(upsertLabelsStmtFmt, dbName))
-	l.deleteLabelsByKeyStmt = l.Prepare(fmt.Sprintf(deleteLabelsByKeyStmtFmt, dbName))
 	l.deleteLabelsStmt = l.Prepare(fmt.Sprintf(deleteLabelsStmtFmt, dbName))
 	l.dropLabelsStmt = l.Prepare(fmt.Sprintf(dropLabelsStmtFmt, dbName))
 
@@ -569,13 +563,6 @@ func (l *ListOptionIndexer) addLabels(key string, obj any, tx db.TxClient) error
 	return nil
 }
 
-func (l *ListOptionIndexer) deleteFieldsByKey(key string, _ any, tx db.TxClient) error {
-	args := []any{key}
-
-	_, err := tx.Stmt(l.deleteFieldsByKeyStmt).Exec(args...)
-	return err
-}
-
 func (l *ListOptionIndexer) deleteFields(tx db.TxClient) error {
 	_, err := tx.Stmt(l.deleteFieldsStmt).Exec()
 	return err
@@ -583,11 +570,6 @@ func (l *ListOptionIndexer) deleteFields(tx db.TxClient) error {
 
 func (l *ListOptionIndexer) dropFields(tx db.TxClient) error {
 	_, err := tx.Stmt(l.dropFieldsStmt).Exec()
-	return err
-}
-
-func (l *ListOptionIndexer) deleteLabelsByKey(key string, _ any, tx db.TxClient) error {
-	_, err := tx.Stmt(l.deleteLabelsByKeyStmt).Exec(key)
 	return err
 }
 


### PR DESCRIPTION
While analyzing the queries log resulting from #834, I noticed that the delete query for the main objects table also causes the cascade deletion of the corresponding row in the `_labels` table, making the `deleteLabelsByKey` useless.
I extended this behavior to the `_fields` table, and removed the redundant `AfterDelete`.
These changes were made under the assumption that letting SQLite run the cascade deletion is preferred over 2 additional new transactions to explicitly delete the rows (as they exclusively delete the row without additional logic).