### PR TITLE
Support sorting on schemas that map to our own `table.Column` slices.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -414,6 +414,27 @@ func gvkKey(group, version, kind string) string {
 	return group + "_" + version + "_" + kind
 }
 
+func tableColsToCommonCols(tableDefs []table.Column) []common.ColumnDefinition {
+	colDefs := make([]common.ColumnDefinition, len(tableDefs))
+	for i, td := range tableDefs {
+		// This isn't used right now, but it is used in the PR that tries to identify
+		// numeric fields, so leave it here.
+		// Although the `table.Column` and `metav1.TableColumnDefinition` types
+		// are structurally the same, Go doesn't allow a quick way to cast one to the other.
+		tcd := metav1.TableColumnDefinition{
+			Name:        td.Name,
+			Type:        td.Type,
+			Format:      td.Format,
+			Description: td.Description,
+		}
+		colDefs[i] = common.ColumnDefinition{
+			TableColumnDefinition: tcd,
+			Field:                 fmt.Sprintf("$.metadata.fields[%d]", i),
+		}
+	}
+	return colDefs
+}
+
 // GetFieldsFromSchema converts object field names from types.APISchema's format into steve's
 // cache.sql.informer's slice format (e.g. "metadata.resourceVersion" is ["metadata", "resourceVersion"])
 func GetFieldsFromSchema(schema *types.APISchema) [][]string {
@@ -428,21 +449,7 @@ func GetFieldsFromSchema(schema *types.APISchema) [][]string {
 		if !ok {
 			return nil
 		}
-		colDefs = make([]common.ColumnDefinition, len(tableDefs))
-		for i, td := range tableDefs {
-			// This isn't used right now, but it is used in the PR that tries to identify
-			// numeric fields, so leave it here.
-			tcd := metav1.TableColumnDefinition{
-				Name:        td.Name,
-				Type:        td.Type,
-				Format:      td.Format,
-				Description: td.Description,
-			}
-			colDefs[i] = common.ColumnDefinition{
-				TableColumnDefinition: tcd,
-				Field:                 fmt.Sprintf("$.metadata.fields[%d]", i),
-			}
-		}
+		colDefs = tableColsToCommonCols(tableDefs)
 	}
 	for _, colDef := range colDefs {
 		field := strings.TrimPrefix(colDef.Field, "$")

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -2,6 +2,7 @@ package sqlproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,24 +10,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rancher/apiserver/pkg/apierror"
+	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/accesscontrol"
 	"github.com/rancher/steve/pkg/attributes"
+	"github.com/rancher/steve/pkg/client"
 	"github.com/rancher/steve/pkg/resources/common"
+	"github.com/rancher/steve/pkg/schema/table"
 	"github.com/rancher/steve/pkg/sqlcache/informer"
 	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/listprocessor"
 	"github.com/rancher/steve/pkg/stores/sqlproxy/tablelistconvert"
+	"github.com/rancher/wrangler/v3/pkg/schemas"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 
 	"go.uber.org/mock/gomock"
 
-	"github.com/pkg/errors"
-	"github.com/rancher/apiserver/pkg/apierror"
-	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/steve/pkg/client"
-	"github.com/rancher/wrangler/v3/pkg/schemas"
+	//"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -697,6 +699,58 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 			_, _, _, err := s.ListByPartitions(apiOp, theSchema, partitions)
 			assert.Nil(t, err)
 		})
+	}
+}
+
+func TestTableColsToCommonCols(t *testing.T) {
+	type testCase struct {
+		description string
+		test        func(t *testing.T)
+	}
+	var tests []testCase
+	tests = append(tests, testCase{
+		description: "table columns are converted to common columns",
+		test: func(t *testing.T) {
+			originalColumns := []table.Column{
+				{
+					Name:        "weight",
+					Field:       "$.metadata.fields[0]",
+					Type:        "integer",
+					Description: "how much the pod weighs",
+				},
+				{
+					Name:        "position",
+					Field:       "$.metadata.fields[1]",
+					Type:        "string",
+					Description: "number of this pod",
+				},
+				{
+					Name:        "favoriteColour",
+					Field:       "$.metadata.fields[3]",
+					Type:        "string",
+					Description: "green of course",
+				},
+			}
+			expectedColumns := []common.ColumnDefinition{
+				{
+					TableColumnDefinition: metav1.TableColumnDefinition{Name: "weight", Type: "integer", Description: "how much the pod weighs"},
+					Field:                 "$.metadata.fields[0]",
+				},
+				{
+					TableColumnDefinition: metav1.TableColumnDefinition{Name: "position", Type: "string", Description: "number of this pod"},
+					Field:                 "$.metadata.fields[1]",
+				},
+				{TableColumnDefinition: metav1.TableColumnDefinition{Name: "favoriteColour", Type: "string", Description: "green of course"},
+					Field: "$.metadata.fields[2]",
+				},
+			}
+			got := tableColsToCommonCols(originalColumns)
+			assert.Equal(t, expectedColumns, got)
+		},
+	})
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) { test.test(t) })
 	}
 }
 


### PR DESCRIPTION
See [#52121](https://github.com/rancher/rancher/issues/52121)

It turns out for whatever reason the schema returns an array of `table.Column` instead
of `common.ColumnDefinition` but they're very similar.

I don't see any easy way to automate testing of this. I had to create a downstream cluster in the UI,
go into Extensions, pull in the partner repositories, and then I could easily install two extensions and
then run this:
```
$ curl -gskL https://localhost:5111/v1/catalog.cattle.io.uiplugins'?sort=metadata.fields[0]' | jq '.data[] | [.id, .metadata.fields[0]]'
[
  "cattle-ui-plugin-system/app-launcher",
  "app-launcher"
]
[
  "cattle-ui-plugin-system/cloud-casa-extension",
  "cloud-casa-extension"
]
```