### PR TITLE
Add workflows to cherry-pick PRs

### DIFF
--- a/.github/workflows/backport-from-label.yaml
+++ b/.github/workflows/backport-from-label.yaml
@@ -1,0 +1,37 @@
+name: Backport label
+
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+    - main
+    - 'release/**'
+
+jobs:
+  backport-label:
+    permissions:
+      # Necessary to add cherry-pick-done/* label
+      pull-requests: write
+      # Necessary to create the PR
+      #
+      # NOTE: We'll want to switch to an app token once we have one.
+      # Reason: GHA is designed to not trigger other workflows when creating a PR
+      # within a workflow run using the workflow run token.
+      #
+      # Temporary workaround is to close/re-open the PR in the UI. This will trigger
+      # the pull_request event.
+      contents: write
+
+    if: github.event.pull_request.merged == true && startsWith(github.event.label.name, 'cherry-pick/')
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - uses: rancher/cherry-pick-action/from-label@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        label-added: ${{ github.event.label.name }}
+        all-labels-json: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        pull-request: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generate-cherry-pick-labels.yaml
+++ b/.github/workflows/generate-cherry-pick-labels.yaml
@@ -1,0 +1,16 @@
+name: Auto-generate cherry-pick labels
+
+on:
+  workflow_dispatch:
+  create:
+
+jobs:
+  generate-cherry-pick-labels:
+    permissions:
+      # Necessary to create/edit labels
+      issues: write
+    uses: rancher/cherry-pick-action/.github/workflows/generate-cherry-pick-labels.yaml@main
+    with:
+      branch-filter-regex: "^main|release/.*"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# TL;DR

Automate backport PRs with labels, here's the GIF:

![output](https://github.com/user-attachments/assets/b51559b7-06f8-444f-bd5c-ba892d20ec82)


# Context

We've often backporting work to previous branches. This involves the following:
- Create a new branch in your fork based on the branch you want to backport the PR to
- Find the commits you want to backport
- Run `git cherry-pick <commits>`
- Solve any conflicts
- Push to the branch
- Go to Github UI
- Open a PR to upstream, select the correct branch
- Set the title (not enforced, but usually `[<branch>] <old title>`)
- Set the body (not enforced, but usually just take the old body and replace the issue wit the "backport-specific issue")
- Add the labels (if any)
- Assign the reviewers (usually the same that reviewed the original PR)

This is tedious, error prone, just plain annoying.

# Solution

Let's just automate all of this..

## Triggering based on label

This involves this workflow file:
- `.github/workflows/cherry-pick-from-labels.yaml`

Essentially, **when a PR is already merged**, you can create a backport PR by adding a label to the original PR of the form `cherry-pick/<target-branch>`. For example, if you want to backport a PR to `release/v0.6`, you would add the label `cherry-pick/release/v0.6`.

Once the backport PR is opened, a new label `cherry-pick-done/<target-branch>` is added to the original PR to prevent re-running the cherry-pick action. (If needed, you can remove that one and the cherry-pick one and re-add to re-trigger the workflow if needed).

A comment is create in the original PR to let you know that a backport PR has been created. See an example here: https://github.com/tomleb/rancher-steve/pull/39#issuecomment-3334869122.

Limitations:
- The PR has to already be merged. If the label is added before the PR is merged, then on merge nothing will happen. Workaround is: remove the label and add it again. We can probably get rid of this limitation eventually, needs more exploration on my side, but for now that's what I'm settling with.
- We don't have a token provided by EIO yet which means the PR is created using the workflow token. This prevents other workflows (like CI status check) from being started. The workaround is to close and re-open the resulting PR.

Features:
- Does a membership check to ensure only rancher member can trigger those workflows. (Taken from UI's backport script) 

## Auto creating labels

This involves this workflow file:
- `.github/workflows/generate-cherry-pick-labels.yaml`

Since the solution relies on labels, those labels need to exists prior. We simply create them automatically (either via a manual workflow run or whenever a new branch is created). In case of steve, we want to match on:
- `main`
- `release/*`

This means we'll generate the following labels:
- `cherry-pick/main`
- `cherry-pick-done/main`
- `cherry-pick/release/v0.6`
- `cherry-pick-done/release/v0.6` 
- `cherry-pick/release/v0.5`
- `cherry-pick-done/release/v0.5`
etc