### PR TITLE
Make virtual transformers idempotent

### DIFF
--- a/pkg/clustercache/controller.go
+++ b/pkg/clustercache/controller.go
@@ -150,17 +150,7 @@ func (h *clusterCache) OnSchemas(schemas *schema.Collection) error {
 		opts := &client.Options{
 			Schema: schema.Schema,
 		}
-		kubeconfigGVK := schema2.GroupVersionKind{Group: "ext.cattle.io", Version: "v1", Kind: "Kubeconfig"}
-		tokenGVK := schema2.GroupVersionKind{Group: "ext.cattle.io", Version: "v1", Kind: "Token"}
-		client := h.summaryClient
-		// Due to a bug in Rancher's extension apiserver for the token and kubeconfig APIs, we
-		// must disable the WatchList features for those APIs.
-		if gvk == kubeconfigGVK || gvk == tokenGVK {
-			client = &noWatchListClient{
-				ExtendedInterface: h.summaryClient,
-			}
-		}
-		summaryInformer := informer.NewFilteredSummaryInformerWithOptions(client, gvr, opts, metav1.NamespaceAll, 2*time.Hour,
+		summaryInformer := informer.NewFilteredSummaryInformerWithOptions(h.summaryClient, gvr, opts, metav1.NamespaceAll, 2*time.Hour,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, nil)
 		ctx, cancel := context.WithCancel(h.ctx)
 		w := &watcher{
@@ -309,13 +299,4 @@ func callAll(handlers []interface{}, gvr schema2.GroupVersionKind, key string, o
 	}
 
 	return obj, merr.NewErrors(errs...)
-}
-
-// noWatchListListWatch disables WatchList feature
-type noWatchListClient struct {
-	client.ExtendedInterface
-}
-
-func (n *noWatchListClient) IsWatchListSemanticsUnSupported() bool {
-	return true
 }

--- a/pkg/resources/virtual/common/common.go
+++ b/pkg/resources/virtual/common/common.go
@@ -67,7 +67,7 @@ func addIDField(raw *unstructured.Unstructured) *unstructured.Unstructured {
 		objectID = fmt.Sprintf("%s/%s", namespace, objectID)
 	}
 	currentIDValue, ok := raw.Object["id"]
-	if ok {
+	if ok && raw.Object["_id"] == nil {
 		raw.Object["_id"] = currentIDValue
 	}
 	raw.Object["id"] = objectID

--- a/pkg/resources/virtual/dates/dates.go
+++ b/pkg/resources/virtual/dates/dates.go
@@ -87,6 +87,10 @@ func (d *Converter) Transform(obj *unstructured.Unstructured) (*unstructured.Uns
 			}
 		}
 
+		if isUnixMilli(value) {
+			continue
+		}
+
 		// Handle duration strings (e.g. "5m", "1d") by converting to absolute timestamp
 		duration, err := rescommon.ParseTimestampOrHumanReadableDuration(value)
 		if err != nil {
@@ -128,4 +132,16 @@ func getValueFromJSONPath(obj map[string]any, jp *jsonpath.JSONPath) (string, bo
 		}
 	}
 	return "", false
+}
+
+func isUnixMilli(s string) bool {
+	if len(s) != 13 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/resources/virtual/dates/dates_test.go
+++ b/pkg/resources/virtual/dates/dates_test.go
@@ -1,10 +1,97 @@
 package dates
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	rescommon "github.com/rancher/steve/pkg/resources/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestTransformIdempotency(t *testing.T) {
+	mockTime := func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) }
+	Now = mockTime
+
+	tests := []struct {
+		name      string
+		converter Converter
+		input     *unstructured.Unstructured
+		wantField any
+	}{
+		{
+			name: "built-in duration field is stable after two transforms",
+			converter: Converter{
+				GVK: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				Columns: []rescommon.ColumnDefinition{
+					{
+						TableColumnDefinition: v1.TableColumnDefinition{Name: "Age"},
+						Field:                 "$.metadata.fields[0]",
+					},
+				},
+			},
+			input: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"fields": []any{"1d"},
+					},
+				},
+			},
+			wantField: fmt.Sprintf("%d", mockTime().Add(-24*time.Hour).UnixMilli()),
+		},
+		{
+			name: "CRD duration field is stable after two transforms",
+			converter: Converter{
+				GVK: schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "TestResource"},
+				Columns: []rescommon.ColumnDefinition{
+					{
+						TableColumnDefinition: v1.TableColumnDefinition{Name: "Age", Type: "date"},
+						Field:                 "$.metadata.fields[0]",
+					},
+				},
+				IsCRD: true,
+			},
+			input: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "test.cattle.io/v1",
+					"kind":       "TestResource",
+					"metadata": map[string]any{
+						"fields": []any{"5m"},
+					},
+				},
+			},
+			wantField: fmt.Sprintf("%d", mockTime().Add(-5*time.Minute).UnixMilli()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := tt.input
+
+			first, err := tt.converter.Transform(obj)
+			require.NoError(t, err)
+
+			fields1, ok, err := unstructured.NestedSlice(first.Object, "metadata", "fields")
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, tt.wantField, fields1[0])
+
+			second, err := tt.converter.Transform(first)
+			require.NoError(t, err)
+
+			fields2, ok, err := unstructured.NestedSlice(second.Object, "metadata", "fields")
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, fields1[0], fields2[0], "second transform should produce the same result as the first")
+		})
+	}
+}
 
 func TestIsUnixMilli(t *testing.T) {
 	tests := []struct {

--- a/pkg/resources/virtual/dates/dates_test.go
+++ b/pkg/resources/virtual/dates/dates_test.go
@@ -1,0 +1,62 @@
+package dates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUnixMilli(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "valid unix milli timestamp",
+			input: "1714567890123",
+			want:  true,
+		},
+		{
+			name:  "too short",
+			input: "171456789012",
+			want:  false,
+		},
+		{
+			name:  "too long",
+			input: "17145678901234",
+			want:  false,
+		},
+		{
+			name:  "contains non-digit character",
+			input: "171456789012a",
+			want:  false,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "duration string",
+			input: "5m",
+			want:  false,
+		},
+		{
+			name:  "RFC3339 timestamp",
+			input: "2024-05-01T12:00:00Z",
+			want:  false,
+		},
+		{
+			name:  "negative number 13 chars",
+			input: "-171456789012",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isUnixMilli(tt.input))
+		})
+	}
+}

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -87,7 +87,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields m
 	if !watchable {
 		watchFunc = func(options metav1.ListOptions) (watch.Interface, error) {
 			ctx, cancel := context.WithCancel(ctx)
-			return newSyntheticWatcher(ctx, cancel).watch(client, options, defaultRefreshTime)
+			return newSyntheticWatcher(ctx, cancel, gvk).watch(client, options, defaultRefreshTime)
 		}
 	}
 	listWatcher := &cache.ListWatch{

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -130,11 +130,7 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields m
 
 	// In non-test mode `newInformer` is cache.NewSharedIndexInformer
 	// defined in k8s.io/client-go/tools/cache/shared_informer.go : func NewSharedIndexInformer(lw ...
-
-	// We disable the WatchList feature here for two reasons:
-	// 1. The WatchList feature makes our virtual function run twice for the initial objects, causing issues
-	// 2. THe synthetic watcher doesn't support it
-	sii := newInformer(&noWatchListListWatch{ListWatch: listWatcher}, example, resyncPeriod, cache.Indexers{})
+	sii := newInformer(listWatcher, example, resyncPeriod, cache.Indexers{})
 	if transform != nil {
 		if err := sii.SetTransform(transform); err != nil {
 			return nil, err
@@ -203,13 +199,4 @@ func SetSyntheticWatchableInterval(interval time.Duration) {
 
 func informerNameFromGVK(gvk schema.GroupVersionKind) string {
 	return gvk.Group + "_" + gvk.Version + "_" + gvk.Kind
-}
-
-// noWatchListListWatch disables WatchList feature
-type noWatchListListWatch struct {
-	*cache.ListWatch
-}
-
-func (n *noWatchListListWatch) IsWatchListSemanticsUnSupported() bool {
-	return true
 }

--- a/pkg/sqlcache/informer/synthetic_watcher.go
+++ b/pkg/sqlcache/informer/synthetic_watcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 )
@@ -20,15 +21,17 @@ type SyntheticWatcher struct {
 	stopChanLock sync.Mutex
 	context      context.Context
 	cancelFunc   context.CancelFunc
+	gvk          schema.GroupVersionKind
 }
 
-func newSyntheticWatcher(context context.Context, cancel context.CancelFunc) *SyntheticWatcher {
+func newSyntheticWatcher(context context.Context, cancel context.CancelFunc, gvk schema.GroupVersionKind) *SyntheticWatcher {
 	return &SyntheticWatcher{
 		stopChan:   make(chan struct{}),
 		doneChan:   make(chan struct{}),
 		resultChan: make(chan watch.Event, 0),
 		context:    context,
 		cancelFunc: cancel,
+		gvk:        gvk,
 	}
 }
 
@@ -51,9 +54,16 @@ func (rw *SyntheticWatcher) receive(client dynamic.ResourceInterface, options me
 		previousState := make(map[string]objectHolder)
 		ticker := time.NewTicker(interval)
 
+		initialSyncSent := false
+
 		for {
 			select {
 			case <-ticker.C:
+				// Clear Watch-specific fields set by the WatchList flow since
+				// the synthetic watcher is only used for non watchable resources.
+				options.SendInitialEvents = nil
+				options.ResourceVersionMatch = ""
+				options.AllowWatchBookmarks = false
 				list, err := client.List(rw.context, options)
 				if err != nil {
 					logrus.Errorf("synthetic watcher: client.List => error: %s", err)
@@ -103,6 +113,12 @@ func (rw *SyntheticWatcher) receive(client dynamic.ResourceInterface, options me
 				}
 				previousState = currentState
 
+				if !initialSyncSent {
+					sendInitialSyncBookmark(list.GetResourceVersion(), rw.gvk, rw.resultChan)
+					initialSyncSent = true
+					logrus.Debugf("synthetic watcher: sent initial events end bookmark for %v", rw.gvk)
+				}
+
 			case <-rw.stopChan:
 				rw.cancelFunc()
 				return
@@ -112,6 +128,23 @@ func (rw *SyntheticWatcher) receive(client dynamic.ResourceInterface, options me
 			}
 		}
 	}()
+}
+
+// sendInitialSyncBookmark constructs and sends a synthetic watch.Bookmark event.
+// This satisfies the client-go Reflector's requirement for the KEP-3157 WatchList protocol,
+// signaling that the initial stream of events has finished and stopping the timeout ticker.
+func sendInitialSyncBookmark(resourceVersion string, gvk schema.GroupVersionKind, resultChan chan watch.Event) {
+	bookmarkObj := &unstructured.Unstructured{}
+	bookmarkObj.SetAnnotations(map[string]string{
+		metav1.InitialEventsAnnotationKey: "true",
+	})
+	bookmarkObj.SetResourceVersion(resourceVersion)
+	bookmarkObj.SetGroupVersionKind(gvk)
+
+	resultChan <- watch.Event{
+		Type:   watch.Bookmark,
+		Object: bookmarkObj,
+	}
 }
 
 func createWatchEvent(event watch.EventType, u *unstructured.Unstructured) (watch.Event, error) {

--- a/pkg/sqlcache/informer/synthetic_watcher_test.go
+++ b/pkg/sqlcache/informer/synthetic_watcher_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -84,7 +85,7 @@ func TestSyntheticWatcher(t *testing.T) {
 	dynamicClient.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes().Return(list2, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sw := newSyntheticWatcher(ctx, cancel)
+	sw := newSyntheticWatcher(ctx, cancel, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ComponentStatus"})
 	pollingInterval := 10 * time.Millisecond
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		return sw.watch(dynamicClient, options, pollingInterval)
@@ -108,20 +109,21 @@ func TestSyntheticWatcher(t *testing.T) {
 	}()
 	wg.Wait()
 	// Verify we get what we expected to see
-	assert.Len(t, results, 8)
+	assert.Len(t, results, 9)
 	for i, _ := range list.Items {
 		assert.Equal(t, "added-result", results[i].eventName)
 	}
-	assert.Equal(t, "modified-result", results[len(list.Items)].eventName)
+	assert.Equal(t, "bookmark-result", results[len(list.Items)].eventName)
 	assert.Equal(t, "modified-result", results[len(list.Items)+1].eventName)
-	assert.Equal(t, "deleted-result", results[len(list.Items)+2].eventName)
-	assert.Equal(t, "stop", results[7].eventName)
+	assert.Equal(t, "modified-result", results[len(list.Items)+2].eventName)
+	assert.Equal(t, "deleted-result", results[len(list.Items)+3].eventName)
+	assert.Equal(t, "stop", results[8].eventName)
 	// We can't really assert that the events get the correct timestamps on them
 	// because they can be held up in the channel for unexpected durations. I did have
 	// assert.Greater(t, float64(timeDelta), 0.9*float64(pollingInterval))
 	// but saw a failure -- the interval was actually 0.75 * pollingInterval.
 	// So there's no point testing that.
-	assert.Greater(t, results[4].createdAt, results[0].createdAt)
+	assert.Greater(t, results[5].createdAt, results[0].createdAt)
 }
 
 func TestIsUpdateObjectScenarios(t *testing.T) {


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/53703

- In this PR, I am making the transformers function idempotent due to the following the PR description and code comment. https://github.com/kubernetes/kubernetes/pull/131799 mentions that transformers can run twice. 
- There is also code comment in the deltafifo.go codebase of client-go about making transformers idempotent.
```
// It's recommended for the TransformFunc to be idempotent.
// It MUST be idempotent if objects already present in the cache are passed to
// the Replace() to avoid re-mutating them. Default informers do not pass
// existing objects to Replace though.
```
- Make the synthetic watcher to send a bookmark event after the initial list call so that reflector doesn't complain about `no bookmark event` for our synthetic watcher.
- The other commits are about reverting the disabling of WatchList feature since they were planned for 2.15.0.

