### PR TITLE
bug: add namespace=true to secret/project related cache

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -1190,11 +1190,12 @@ func (s *Store) cacheForWithDeps(ctx context.Context, apiOp *types.APIRequest, a
 		mcioProjectSchema := types.APISchema{
 			Schema: &schemas.Schema{
 				Attributes: map[string]interface{}{
-					"group":    "management.cattle.io",
-					"version":  "v3",
-					"kind":     "Project",
-					"resource": "projects",
-					"verbs":    []string{"get", "list", "watch"},
+					"group":      "management.cattle.io",
+					"version":    "v3",
+					"kind":       "Project",
+					"resource":   "projects",
+					"verbs":      []string{"get", "list", "watch"},
+					"namespaced": true,
 				},
 			},
 		}


### PR DESCRIPTION
Follow up to: https://github.com/rancher/steve/pull/1079

Fixes:

```
time="2026-04-14T20:28:39-04:00" level=error msg="Unknown error: listbyoptions management.cattle.io/v3, Kind=Project:
  transaction: while executing query: SELECT o.object, o.objectnonce, o.dekid FROM \"management.cattle.io_v3_Project\" o\n  JOIN
  \"management.cattle.io_v3_Project_fields\" f ON o.key = f.key\n  WHERE\n    f.\"metadata.namespace\" = ?\n  ORDER BY
  f.\"metadata.name\" ASC\t\n  LIMIT 100000\n got error: SQL logic error: no such column: f.metadata.namespace (1)"
```