### PR TITLE
[release/v0.8] [main] Add multiple label and field pair support in ExternalLabelDepe…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
       with:
         version: ${{ env.GOLANG_CI_LINT_VERSION }}
         install-only: true
+    - name: Install env-test
+      run: go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260324065417-8c5081a9b6ba
     - name: Build
       run: make build-bin
     - name: Test

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -210,13 +210,14 @@ func (i *IntegrationSuite) createNamespace(ctx context.Context, name string, thi
 	return err
 }
 
-func (i *IntegrationSuite) createSecret(ctx context.Context, name string, thisTestLabel string, projectLabel string, secretType string) error {
+func (i *IntegrationSuite) createSecret(ctx context.Context, thisTestLabel string, name string, projectLabel string, clusterName string, secretType string) error {
 	obj := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: defaultTestNamespace,
 			Labels: map[string]string{
-				"management.cattle.io/project-scoped-secret": projectLabel,
+				"management.cattle.io/project-scoped-secret":         projectLabel,
+				"management.cattle.io/project-scoped-secret-cluster": clusterName,
 				testLabel: thisTestLabel,
 			},
 		},
@@ -1233,20 +1234,22 @@ func (i *IntegrationSuite) TestSecretProjectDependencies() {
 
 	err = ctrl.Start(ctx)
 	requireT.NoError(err)
-	secretInfo := [][3]string{
-		{"morocco", "rabat", "france"},
-		{"eritrea", "asmara", "italy"},
-		{"kenya", "nairobi", "england"},
-		{"benin", "portonovo", "france"},
+	secretInfo := [][4]string{
+		// name | project name | cluster name | secret type
+		{"morocco", "rabat", "arabic", "france"},
+		{"eritrea", "asmara", "tigrinya", "italy"},
+		{"kenya", "nairobi", "english", "england"},
+		{"benin", "portonovo", "french", "france"},
 	}
 	projectInfo := [][3]string{
+		// name | clusterName | displayName
 		{"rabat", "arabic", "casablanca"},
 		{"asmara", "tigrinya", "keren"},
 		{"nairobi", "english", "mombasa"},
 		{"portonovo", "french", "cotonou"},
 	}
 	for _, info := range secretInfo {
-		err = i.createSecret(ctx, info[0], labelTest, info[1], info[2])
+		err = i.createSecret(ctx, labelTest, info[0], info[1], info[2], info[3])
 		requireT.NoError(err)
 	}
 	dynamicClient, err := dynamic.NewForConfig(i.restCfg)

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -1,6 +1,12 @@
 package sqltypes
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 type Op string
 
@@ -89,11 +95,79 @@ type ExternalDependency struct {
 }
 
 type ExternalLabelDependency struct {
-	SourceGVK            string
-	SourceLabelName      string
-	TargetGVK            string
-	TargetKeyFieldName   string
+	SourceGVK string
+	TargetGVK string
+
+	SourceLabelTargetField map[string]string
+
 	TargetFinalFieldName string
+
+	generatedQuery string
+}
+
+// NewExternalLabelDependency pre-generates the query needed for the label and key pairs. No labels in
+// ExternalLabelDependency are user supplied, making risk of potential SQL injection minimal.
+func NewExternalLabelDependency(eld ExternalLabelDependency) (ExternalLabelDependency, error) {
+	if len(eld.SourceLabelTargetField) == 0 {
+		return ExternalLabelDependency{}, fmt.Errorf("ExternalLabelDependency must have at least 1 label and field pair")
+	}
+
+	type pair struct {
+		sourceLabelName string
+		targetFieldName string
+	}
+
+	pairs := make([]pair, 0, len(eld.SourceLabelTargetField))
+	for sourceLabelName, targetFieldName := range eld.SourceLabelTargetField {
+		pairs = append(pairs, pair{sourceLabelName: sourceLabelName, targetFieldName: targetFieldName})
+	}
+
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].sourceLabelName == pairs[j].sourceLabelName {
+			return pairs[i].targetFieldName < pairs[j].targetFieldName
+		}
+
+		return pairs[i].sourceLabelName < pairs[j].sourceLabelName
+	})
+
+	joinClauses := make([]string, 0, len(pairs))
+	onClauses := make([]string, 0, len(pairs))
+	whereClauses := make([]string, 0, len(pairs))
+
+	for i, pair := range pairs {
+		joinClauses = append(joinClauses, fmt.Sprintf(`LEFT OUTER JOIN "%s_labels" lt%d ON f.key = lt%d.key`, eld.SourceGVK, i, i))
+		onClauses = append(onClauses, fmt.Sprintf(`lt%d.value = ex2."%s"`, i, pair.targetFieldName))
+		whereClauses = append(whereClauses, fmt.Sprintf(`lt%d.label = "%s"`, i, pair.sourceLabelName))
+	}
+
+	eld.generatedQuery = fmt.Sprintf(`SELECT DISTINCT f.key, ex2."%s" FROM "%s_fields" f
+	%s
+	JOIN "%s_fields" ex2 ON (%s)
+	WHERE (%s) AND f."%s" != ex2."%s"`,
+		eld.TargetFinalFieldName,
+		eld.SourceGVK,
+		strings.Join(joinClauses, "\n\t"),
+		eld.TargetGVK,
+		strings.Join(onClauses, " AND "),
+		strings.Join(whereClauses, " AND "),
+		eld.TargetFinalFieldName,
+		eld.TargetFinalFieldName,
+	)
+
+	return eld, nil
+}
+
+func MustNewExternalLabelDependency(eld ExternalLabelDependency) ExternalLabelDependency {
+	eld, err := NewExternalLabelDependency(eld)
+	if err != nil {
+		panic(err)
+	}
+
+	return eld
+}
+
+func (d ExternalLabelDependency) Query() string {
+	return d.generatedQuery
 }
 
 type ExternalGVKUpdates struct {

--- a/pkg/sqlcache/sqltypes/types_test.go
+++ b/pkg/sqlcache/sqltypes/types_test.go
@@ -1,0 +1,76 @@
+package sqltypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewExternalLabelDependency(t *testing.T) {
+	cases := []struct {
+		name string
+		eld  ExternalLabelDependency
+
+		expectedQuery string
+		err           string
+	}{
+		{
+			name: "missing label and field pairs",
+			eld: ExternalLabelDependency{
+				SourceGVK:              "_v1_Secret",
+				TargetGVK:              "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{},
+				TargetFinalFieldName:   "spec.clusterName",
+			},
+
+			err: "ExternalLabelDependency must have at least 1 label and field pair",
+		},
+		{
+			name: "one label and field pair",
+
+			eld: ExternalLabelDependency{
+				SourceGVK: "_v1_Namespace",
+				TargetGVK: "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{
+					"field.cattle.io/projectId": "metadata.name",
+				},
+				TargetFinalFieldName: "spec.displayName",
+			},
+
+			expectedQuery: `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
+	LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+	WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`,
+		},
+		{
+			name: "two label and field pairs",
+			eld: ExternalLabelDependency{
+				SourceGVK: "_v1_Secret",
+				TargetGVK: "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{
+					"management.cattle.io/project-scoped-secret":         "metadata.name",
+					"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+				},
+				TargetFinalFieldName: "spec.displayName",
+			},
+
+			expectedQuery: `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Secret_fields" f
+	LEFT OUTER JOIN "_v1_Secret_labels" lt0 ON f.key = lt0.key
+	LEFT OUTER JOIN "_v1_Secret_labels" lt1 ON f.key = lt1.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name" AND lt1.value = ex2."spec.clusterName")
+	WHERE (lt0.label = "management.cattle.io/project-scoped-secret" AND lt1.label = "management.cattle.io/project-scoped-secret-cluster") AND f."spec.displayName" != ex2."spec.displayName"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			eld, err := NewExternalLabelDependency(c.eld)
+
+			if c.err != "" {
+				assert.EqualError(t, err, c.err)
+			} else {
+				assert.Equal(t, c.expectedQuery, eld.Query())
+			}
+		})
+	}
+}

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -156,20 +156,11 @@ func (s *Store) checkUpdateExternalInfo(key string) {
 
 func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInfo *sqltypes.ExternalGVKUpdates) error {
 	for _, labelDep := range externalUpdateInfo.ExternalLabelDependencies {
-		rawGetStmt := fmt.Sprintf(`SELECT DISTINCT f.key, ex2."%s" FROM "%s_fields" f
-  LEFT OUTER JOIN "%s_labels" lt1 ON f.key = lt1.key
-  JOIN "%s_fields" ex2 ON lt1.value = ex2."%s"
- WHERE lt1.label = ? AND f."%s" != ex2."%s"`,
-			labelDep.TargetFinalFieldName,
-			labelDep.SourceGVK,
-			labelDep.SourceGVK,
-			labelDep.TargetGVK,
-			labelDep.TargetKeyFieldName,
-			labelDep.TargetFinalFieldName,
-			labelDep.TargetFinalFieldName,
-		)
+		rawGetStmt := labelDep.Query()
+
 		getStmt := s.Prepare(rawGetStmt)
-		rows, err := s.QueryForRows(s.ctx, getStmt, labelDep.SourceLabelName)
+		rows, err := s.QueryForRows(s.ctx, getStmt)
+		getStmt.Close()
 		if err != nil {
 			if !isDBError(err) {
 				logrus.Infof("Error getting external info for table %s, key %s: %v", labelDep.TargetGVK, key, err)
@@ -252,8 +243,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				finalTargetValue)
 		}
 	}
-	return nil
 
+	return nil
 }
 
 // If the new value will change a non-empty current value, return [true, error:nil]

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -784,6 +784,7 @@ func TestAddWithOneUpdate(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			c, txC := SetupMockDB(t)
 			stmts := NewMockStmt(gomock.NewController(t))
+			preparedStmt := NewMockStmt(gomock.NewController(t))
 			store := SetupStoreWithExternalDependencies(t, c, test.updateExternal, test.updateSelf)
 
 			c.EXPECT().Serialize(testObject, false).Return(testObjectSerialized, nil)
@@ -796,12 +797,13 @@ func TestAddWithOneUpdate(t *testing.T) {
 					}
 				}).Times(2)
 			rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt))
-			args1 := []any{"field.cattle.io/projectId"}
+				LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+				JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+				WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
+			args1 := []any{}
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
 			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
 			rawStmt2 := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
@@ -850,6 +852,7 @@ func TestAddWithExternalUpdates(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with no DB client errors", test: func(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		stmts := NewMockStmt(gomock.NewController(t))
+		preparedStmt := NewMockStmt(gomock.NewController(t))
 		store := SetupStoreWithExternalDependencies(t, c, true, false)
 
 		c.EXPECT().Serialize(testObject, false).Return(testObjectSerialized, nil)
@@ -862,12 +865,13 @@ func TestAddWithExternalUpdates(t *testing.T) {
 				}
 			}).Times(2)
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt))
-		args1 := []any{"field.cattle.io/projectId"}
+			LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+			JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+			WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
+		args1 := []any{}
 		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
 		rawStmt1b := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
@@ -885,9 +889,10 @@ func TestAddWithExternalUpdates(t *testing.T) {
          FROM "_v1_Pods_fields" f JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2
          ON f."field.cattle.io/fixer" = ex2."metadata.name"
          WHERE f."spec.projectName" != ex2."spec.projectName"`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 		args2 := []any{}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args2)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
+		// preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields2", "moose2"}}, nil)
 
 		rawStmt3b := `SELECT f."spec.projectName" FROM  "_v1_Pods_fields" f WHERE f.key = ?`
@@ -925,6 +930,7 @@ func TestAddWithSelfUpdates(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with no DB client errors", test: func(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		stmts := NewMockStmt(gomock.NewController(t))
+		preparedStmt := NewMockStmt(gomock.NewController(t))
 		store := SetupStoreWithExternalDependencies(t, c, false, true)
 
 		c.EXPECT().Serialize(testObject, false).Return(testObjectSerialized, nil)
@@ -937,12 +943,13 @@ func TestAddWithSelfUpdates(t *testing.T) {
 				}
 			}).Times(2)
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt))
-		args1 := []any{"field.cattle.io/projectId"}
+	LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+	WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
+		args1 := []any{}
 		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
 		rawStmt1b := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
@@ -1000,15 +1007,16 @@ func TestAddWithBothUpdates(t *testing.T) {
 	tests = append(tests, testCase{description: "Update both external and self", test: func(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		stmts := NewMockStmt(gomock.NewController(t))
+		preparedStmt := NewMockStmt(gomock.NewController(t))
 		store := SetupStoreWithExternalDependencies(t, c, true, true)
 
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-  JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-  WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
+			LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+			JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+			WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		rawStmt3 := `SELECT DISTINCT f.key, ex2."spec.projectName" FROM "_v1_Pods_fields" f
-  JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2 ON f."field.cattle.io/fixer" = ex2."metadata.name"
-  WHERE f."spec.projectName" != ex2."spec.projectName"`
+			JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2 ON f."field.cattle.io/fixer" = ex2."metadata.name"
+			WHERE f."spec.projectName" != ex2."spec.projectName"`
 
 		c.EXPECT().Serialize(testObject, false).Return(testObjectSerialized, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "testStoreObject", testObjectSerialized).Return(nil)
@@ -1027,9 +1035,10 @@ func TestAddWithBothUpdates(t *testing.T) {
 						t.Fail()
 					}
 				})
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt))
-			args1 := []any{"field.cattle.io/projectId"}
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
+			args1 := []any{}
 			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
 			rawStmt2 := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
@@ -1101,6 +1110,7 @@ func SetupMockDB(t *testing.T) (*MockClient, *MockTxClient) {
 
 	return dbC, txC
 }
+
 func SetupStore(t *testing.T, client *MockClient, shouldEncrypt bool) *Store {
 	name := "testStoreObject"
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
@@ -1118,13 +1128,14 @@ func gvkKey(group, version, kind string) string {
 func SetupStoreWithExternalDependencies(t *testing.T, client *MockClient, updateExternal bool, updateSelf bool) *Store {
 	name := "testStoreObject"
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
-	namespaceProjectLabelDep := sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Namespace"),
-		SourceLabelName:      "field.cattle.io/projectId",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	namespaceProjectLabelDep := sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Namespace"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"field.cattle.io/projectId": "metadata.name",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
+	})
 	namespaceNonLabelDep := sqltypes.ExternalDependency{
 		SourceGVK:            gvkKey("", "v1", "Pods"),
 		SourceFieldName:      "field.cattle.io/fixer",

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -268,13 +268,14 @@ var (
 	namespaceGVK             = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 	mcioProjectGvk           = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
 	pcioClusterGvk           = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
-	namespaceProjectLabelDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Namespace"),
-		SourceLabelName:      "field.cattle.io/projectId",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	namespaceProjectLabelDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Namespace"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"field.cattle.io/projectId": "metadata.name",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
+	})
 	namespaceUpdates = sqltypes.ExternalGVKUpdates{
 		AffectedGVK:               namespaceGVK,
 		ExternalDependencies:      nil,
@@ -282,20 +283,24 @@ var (
 	}
 
 	secretGVK                    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
-	secretProjectLabelDisplayDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Secret"),
-		SourceLabelName:      "management.cattle.io/project-scoped-secret",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	secretProjectLabelDisplayDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Secret"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"management.cattle.io/project-scoped-secret":         "metadata.name",
+			"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
-	secretProjectLabelClusterDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Secret"),
-		SourceLabelName:      "management.cattle.io/project-scoped-secret",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	})
+	secretProjectLabelClusterDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Secret"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"management.cattle.io/project-scoped-secret":         "metadata.name",
+			"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+		},
 		TargetFinalFieldName: "spec.clusterName",
-	}
+	})
 	secretUpdates = sqltypes.ExternalGVKUpdates{
 		AffectedGVK:               secretGVK,
 		ExternalDependencies:      nil,


### PR DESCRIPTION
Backport https://github.com/rancher/steve/pull/1076

> https://github.com/rancher/rancher/issues/52810
> 
> When two Projects are manually created with the same metadata.name on different clusters, the sql queries in pkg/sqlcache/store/store.go checking for projects matching a secret's management.cattle.io/project-scoped-secret label will return both secrets. In order to uniquely identify the Project to link to a project scoped secret, we need to check both the metadata.name AND spec.clusterName.