### PR TITLE
Sort POD timestamps according to a specific order

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rancher/steve/pkg/sqlcache/db/logging"
 
@@ -550,12 +551,28 @@ func (c *client) NewConnection(useTempDir bool) (string, error) {
 	if err != nil {
 		return dbPath, err
 	}
+	sqlite.RegisterDeterministicScalarFunction("adjustTimestampForSorting", 1, adjustTimestampForSorting)
 	sqlite.RegisterDeterministicScalarFunction("extractBarredValue", 2, extractBarredValue)
 	sqlite.RegisterDeterministicScalarFunction("hasBarredValue", 2, hasBarredValue)
 	sqlite.RegisterDeterministicScalarFunction("inet_aton", 1, inetAtoN)
 	sqlite.RegisterDeterministicScalarFunction("memoryInBytes", 1, memoryInBytes)
 	c.conn = &connection{sqlDB}
 	return dbPath, nil
+}
+
+func adjustTimestampForSorting(ctx *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+	var arg1 int64
+	switch argTyped := args[0].(type) {
+	case int64:
+		arg1 = argTyped
+	default:
+		return nil, fmt.Errorf("unsupported type for arg1: expected an integer, got :%T", args[0])
+	}
+	if arg1 == 0 {
+		return arg1, nil
+	}
+	arg1 = time.Now().Unix() - arg1
+	return arg1, nil
 }
 
 func extractBarredValue(ctx *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {

--- a/pkg/sqlcache/informer/fields.go
+++ b/pkg/sqlcache/informer/fields.go
@@ -55,6 +55,7 @@ type ComputedField struct {
 	Name         string
 	Type         string
 	GetValueFunc func(obj *unstructured.Unstructured) (any, error)
+	IsTimestamp  bool
 }
 
 func (f *ComputedField) ColumnName() string {

--- a/pkg/sqlcache/informer/sqlgenerator.go
+++ b/pkg/sqlcache/informer/sqlgenerator.go
@@ -376,7 +376,7 @@ func (l *ListOptionIndexer) compileQuery(lo *sqltypes.ListOptions,
 					}
 					filterComponents.orderByClauses = append(filterComponents.orderByClauses, clause)
 				} else {
-					fieldEntry, err := l.getValidFieldEntry(mainFieldPrefix, fields)
+					fieldEntry, err := l.getValidFieldEntry(mainFieldPrefix, fields, true)
 					if err != nil {
 						return nil, err
 					}
@@ -897,7 +897,7 @@ SELECT key, value FROM "%s_labels"
 func (l *ListOptionIndexer) getFieldFilter(filter sqltypes.Filter, prefix string) (string, []any, error) {
 	opString := ""
 	escapeString := ""
-	fieldEntry, err := l.getValidFieldEntry(prefix, filter.Field)
+	fieldEntry, err := l.getValidFieldEntry(prefix, filter.Field, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1098,7 +1098,7 @@ func (l *ListOptionIndexer) getLabelFilter(index int, filter sqltypes.Filter, ma
 
 func (l *ListOptionIndexer) getProjectsOrNamespacesFieldFilter(filter sqltypes.Filter) (string, []any, error) {
 	opString := ""
-	fieldEntry, err := l.getValidFieldEntry("nsf", filter.Field)
+	fieldEntry, err := l.getValidFieldEntry("nsf", filter.Field, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1205,11 +1205,17 @@ func (l *ListOptionIndexer) getStandardColumnNameToDisplay(fieldParts []string, 
 // position.
 // Indices are 0-based.
 
-func (l *ListOptionIndexer) getValidFieldEntry(prefix string, fields []string) (string, error) {
+func (l *ListOptionIndexer) getValidFieldEntry(prefix string, fields []string, inSort bool) (string, error) {
 	fieldID := smartJoin(fields)
 
 	// Try direct field lookup first
 	if field, ok := l.indexedFields[fieldID]; ok {
+		if inSort {
+			computedField, ok := field.(*ComputedField)
+			if ok && computedField.IsTimestamp {
+				return fmt.Sprintf(`adjustTimestampForSorting(%s."%s")`, prefix, computedField.Name), nil
+			}
+		}
 		return fmt.Sprintf(`%s."%s"`, prefix, field.ColumnName()), nil
 	}
 

--- a/pkg/sqlcache/informer/sqlgenerator_test.go
+++ b/pkg/sqlcache/informer/sqlgenerator_test.go
@@ -3902,6 +3902,71 @@ func TestSortPodsOnArrayAccess(t *testing.T) {
 	}
 }
 
+// "
+// Tests to verify sorting pods on "metadata.fields[3][1]"
+func TestSortPodsOnTimestamp(t *testing.T) {
+	type testCase struct {
+		description           string
+		listOptions           sqltypes.ListOptions
+		partitions            []partition.Partition
+		ns                    string
+		expectedCountStmt     string
+		expectedCountStmtArgs []any
+		expectedStmt          string
+		expectedStmtArgs      []any
+		expectedErr           string
+	}
+
+	var tests []testCase
+	tests = append(tests, testCase{
+		description: "TestSortPodsOnTimestamp: sorting a timestamp requires adjusting the value",
+		listOptions: sqltypes.ListOptions{
+			SortList: sqltypes.SortList{
+				SortDirectives: []sqltypes.Sort{
+					{
+						Fields: []string{"metadata", "fields", "3][1"},
+					},
+				},
+			},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN "something_fields" f ON o.key = f.key
+  WHERE
+    FALSE
+  ORDER BY adjustTimestampForSorting(f."metadata.fields[3]_1") ASC`,
+		expectedStmtArgs: []interface{}{},
+	})
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			store := NewMockStore(gomock.NewController(t))
+			i := &Indexer{
+				Store: store,
+			}
+			lii := &ListOptionIndexer{
+				Indexer:       i,
+				indexedFields: toIndexedFieldsFromColumnNames("metadata.queryField1", "status.queryField2", "metadata.fields", "metadata.fields[3][1]"),
+			}
+			computedField, ok := lii.indexedFields["metadata.fields[3][1]"].(*ComputedField)
+			assert.True(t, ok)
+			computedField.Name = "metadata.fields[3]_1"
+			computedField.IsTimestamp = true
+			queryInfo, err := lii.constructQuery(&test.listOptions, test.partitions, test.ns, "something")
+			if test.expectedErr != "" {
+				assert.Equal(t, test.expectedErr, err.Error())
+				return
+			}
+			require.Nil(t, err)
+			assert.Equal(t, test.expectedStmt, queryInfo.query)
+			assert.Equal(t, test.expectedStmtArgs, queryInfo.params)
+			assert.Equal(t, test.expectedCountStmt, queryInfo.countQuery)
+			assert.Equal(t, test.expectedCountStmtArgs, queryInfo.countParams)
+		})
+	}
+}
+
 func TestUserDefinedExtractFunction(t *testing.T) {
 	gvk := corev1.SchemeGroupVersion.WithKind("Pod")
 	makeObj := func(name string, barSeparatedHosts string) map[string]any {

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -117,6 +117,7 @@ var (
 				Name:         "metadata.fields[3]_1",
 				Type:         "INTEGER",
 				GetValueFunc: informer.ExtractPodRestartTimestamp,
+				IsTimestamp:  true,
 			},
 		},
 		gvkKey("", "v1", "ReplicationController"): {

--- a/tests/integration/testdata/podrestarts/podrestarts.test.yaml
+++ b/tests/integration/testdata/podrestarts/podrestarts.test.yaml
@@ -33,14 +33,17 @@ tests:
     expect:
       - name: restarting-pod
 
-  - description: sort-by-restart-timestamp-ascending-stable-first
+# Timestamps are reported as <number><units>
+# so a timestamp like "5m" (5 minutes ago)
+# "feels" like it's less than an older object with a time like "1h" (1 hour ago)
+  - description: sort-by-restart-timestamp-ascending-restarting-first
     namespace: test-restarts
     query: sort=metadata.fields[3][1]
     expect:
       - name: restarting-pod
       - name: stable-pod
 
-  - description: sort-by-restart-timestamp-descending-restarting-first
+  - description: sort-by-restart-timestamp-descending-stable-first
     namespace: test-restarts
     query: sort=-metadata.fields[3][1]
     expect:

--- a/tests/integration/testdata/podrestarts/podrestarts.test.yaml
+++ b/tests/integration/testdata/podrestarts/podrestarts.test.yaml
@@ -37,15 +37,15 @@ tests:
     namespace: test-restarts
     query: sort=metadata.fields[3][1]
     expect:
-      - name: stable-pod
       - name: restarting-pod
+      - name: stable-pod
 
   - description: sort-by-restart-timestamp-descending-restarting-first
     namespace: test-restarts
     query: sort=-metadata.fields[3][1]
     expect:
-      - name: restarting-pod
       - name: stable-pod
+      - name: restarting-pod
 
   - description: list-all-pods-in-namespace
     namespace: test-restarts


### PR DESCRIPTION
Ref issue: [54531](https://github.com/rancher/rancher/issues/54531)

Ascending: When sorting by age, in an ascending sort we want to show the youngest pods first,
and push the NULL-values to the end.

In a descending sort, first show the pods with NULL ages, then the *oldest*, with the youngest at the end.

Since this field, `pod: metadata.fields[3]_1`, is stored as a timestamp, with 0 => null, we need to subtract the
non-0 values from the current timestamp.

This breaks for any pods that were created at midnight Jan 1, 1970 UTC. Fortunately there aren't any.