### PR TITLE
Support new versions for cluster.x-k8s.io.{machines,machinedeployments}.

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -186,6 +186,12 @@ var (
 		gvkKey("cluster.x-k8s.io", "v1beta1", "MachineDeployment"): {
 			"spec.clusterName": &informer.JSONPathField{Path: []string{"spec", "clusterName"}},
 		},
+		gvkKey("cluster.x-k8s.io", "v1beta2", "Machine"): {
+			"spec.clusterName": &informer.JSONPathField{Path: []string{"spec", "clusterName"}},
+		},
+		gvkKey("cluster.x-k8s.io", "v1beta2", "MachineDeployment"): {
+			"spec.clusterName": &informer.JSONPathField{Path: []string{"spec", "clusterName"}},
+		},
 		gvkKey("management.cattle.io", "v3", "Cluster"): {
 			"spec.internal":                &informer.JSONPathField{Path: []string{"spec", "internal"}},
 			"spec.displayName":             &informer.JSONPathField{Path: []string{"spec", "displayName"}},


### PR DESCRIPTION
Ref [#54656](https://github.com/rancher/rancher/issues/54656)

V 1.11.0 of kubernetes-sigs/cluster-api bumps a lot of CRDs from `v1beta1` to `v1beta2`,
and version 2.14 of rancher bumps our use of `sigs.k8s.io/cluster-api` from `v1.10.x` to `v1.11.x`

So now we need to support two known versions of the two `cluster.x-k8s.io` kinds.

These happen to be the only beta-version GVKs currently indexed, so this isn't likely to happen often.
But it's another thing we'd be better off staying on top of.