### PR TITLE
[2.14] Backport 54478:54596: Close the prepared SQL-statements after use.

### DIFF
--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -184,8 +184,12 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 			}
 			rawStmt := fmt.Sprintf(`UPDATE "%s_fields" SET "%s" = ? WHERE key = ?`,
 				labelDep.SourceGVK, labelDep.TargetFinalFieldName)
-			preparedStmt := s.Prepare(rawStmt)
-			_, err = tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+			err = func() error {
+				preparedStmt := s.Prepare(rawStmt)
+				defer preparedStmt.Close()
+				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+				return err
+			}()
 			if err != nil {
 				logrus.Infof("Error running %s(%s, %s): %s", rawStmt, finalTargetValue, sourceKey, err)
 				continue
@@ -205,8 +209,11 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 			nonLabelDep.TargetFinalFieldName)
 		// TODO: Try to fold the two blocks together
 
-		getStmt := s.Prepare(rawGetStmt)
-		rows, err := s.QueryForRows(s.ctx, getStmt)
+		rows, err := func() (db.Rows, error) {
+			getStmt := s.Prepare(rawGetStmt)
+			defer getStmt.Close()
+			return s.QueryForRows(s.ctx, getStmt)
+		}()
 		if err != nil {
 			if !isDBError(err) {
 				logrus.Infof("Error getting external info for table %s, key %s: %v", nonLabelDep.TargetGVK, key, err)
@@ -230,8 +237,12 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 			}
 			rawStmt := fmt.Sprintf(`UPDATE "%s_fields" SET "%s" = ? WHERE key = ?`,
 				nonLabelDep.SourceGVK, nonLabelDep.TargetFinalFieldName)
-			preparedStmt := s.Prepare(rawStmt)
-			_, err = tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+			err = func() error {
+				preparedStmt := s.Prepare(rawStmt)
+				defer preparedStmt.Close()
+				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+				return err
+			}()
 			if err != nil {
 				logrus.Infof("Error running %s(%s, %s): %s", rawStmt, finalTargetValue, sourceKey, err)
 				continue
@@ -251,8 +262,11 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 func (s *Store) overrideCheck(finalFieldName, sourceGVK, sourceKey, finalTargetValue string) (bool, error) {
 	rawGetValueStmt := fmt.Sprintf(`SELECT f."%s" FROM  "%s_fields" f WHERE f.key = ?`,
 		finalFieldName, sourceGVK)
-	getValueStmt := s.Prepare(rawGetValueStmt)
-	rows, err := s.QueryForRows(s.ctx, getValueStmt, sourceKey)
+	rows, err := func() (db.Rows, error) {
+		getValueStmt := s.Prepare(rawGetValueStmt)
+		defer getValueStmt.Close()
+		return s.QueryForRows(s.ctx, getValueStmt, sourceKey)
+	}()
 	if err != nil {
 		logrus.Debugf("Checking the field, got error %s", err)
 		return false, err

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -802,38 +802,43 @@ func TestAddWithOneUpdate(t *testing.T) {
 				WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 			args1 := []any{}
 			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
 			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
 			rawStmt2 := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2))
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), gomock.Any())
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2)).Return(preparedStmt)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, gomock.Any())
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings(gomock.Any())
 
 			rawStmt2a := `UPDATE "_v1_Namespace_fields" SET "spec.displayName" = ? WHERE key = ?`
-			c.EXPECT().Prepare(rawStmt2a)
-			txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+			c.EXPECT().Prepare(rawStmt2a).Return(preparedStmt)
+			txC.EXPECT().Stmt(preparedStmt).Return(stmts)
+			preparedStmt.EXPECT().Close()
 			stmts.EXPECT().Exec("moose1", "lego.cattle.io/fields1")
 
 			rawStmt3 := `SELECT DISTINCT f.key, ex2."spec.projectName" FROM "_v1_Pods_fields" f
 			JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2 ON f."field.cattle.io/fixer" = ex2."metadata.name"
 			WHERE f."spec.projectName" != ex2."spec.projectName"`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3))
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 			args2 := []any{}
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args2)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
+			preparedStmt.EXPECT().Close()
 
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields2", "moose2"}}, nil)
 			// Override check:
 			rawStmt2 = `SELECT f."spec.projectName" FROM  "_v1_Pods_fields" f WHERE f.key = ?`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2))
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), gomock.Any())
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2)).Return(preparedStmt)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, gomock.Any())
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings(gomock.Any())
 
 			rawStmt4 := `UPDATE "_v1_Pods_fields" SET "spec.projectName" = ? WHERE key = ?`
-			c.EXPECT().Prepare(rawStmt4)
-			txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+			c.EXPECT().Prepare(rawStmt4).Return(preparedStmt)
+			txC.EXPECT().Stmt(preparedStmt).Return(stmts)
 			stmts.EXPECT().Exec("moose2", "lego.cattle.io/fields2")
+			preparedStmt.EXPECT().Close()
 
 			err := store.Add(testObject)
 			assert.Nil(t, err)
@@ -870,19 +875,22 @@ func TestAddWithExternalUpdates(t *testing.T) {
 			WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
 		args1 := []any{}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
 		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
+		// Override check:
 		rawStmt1b := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt1b))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt1b)).Return(preparedStmt)
 		args1b := []any{"lego.cattle.io/fields1"}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1b)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1b)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings(gomock.Any()).Return([]string{"flipper"}, nil)
 
 		rawStmt2 := `UPDATE "_v1_Namespace_fields" SET "spec.displayName" = ? WHERE key = ?`
-		c.EXPECT().Prepare(rawStmt2)
-		txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+		c.EXPECT().Prepare(rawStmt2).Return(preparedStmt)
+		txC.EXPECT().Stmt(preparedStmt).Return(stmts)
+		preparedStmt.EXPECT().Close()
 		stmts.EXPECT().Exec("moose1", "lego.cattle.io/fields1")
 
 		rawStmt3 := `SELECT DISTINCT f.key, ex2."spec.projectName"
@@ -892,19 +900,22 @@ func TestAddWithExternalUpdates(t *testing.T) {
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 		args2 := []any{}
 		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
-		// preparedStmt.EXPECT().Close()
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields2", "moose2"}}, nil)
 
+		// Override check:
 		rawStmt3b := `SELECT f."spec.projectName" FROM  "_v1_Pods_fields" f WHERE f.key = ?`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3b))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3b)).Return(preparedStmt)
 		args3b := []any{"lego.cattle.io/fields2"}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args3b)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args3b)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings(gomock.Any()).Return([]string{"snorkel"}, nil)
 
 		rawStmt4 := `UPDATE "_v1_Pods_fields" SET "spec.projectName" = ? WHERE key = ?`
-		c.EXPECT().Prepare(rawStmt4)
-		txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+		c.EXPECT().Prepare(rawStmt4).Return(preparedStmt)
+		txC.EXPECT().Stmt(preparedStmt).Return(stmts)
 		stmts.EXPECT().Exec("moose2", "lego.cattle.io/fields2")
+		preparedStmt.EXPECT().Close()
 
 		err := store.Add(testObject)
 		assert.Nil(t, err)
@@ -948,40 +959,46 @@ func TestAddWithSelfUpdates(t *testing.T) {
 	WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
 		args1 := []any{}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
 		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
 		rawStmt1b := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt1b))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt1b)).Return(preparedStmt)
 		args1b := []any{"lego.cattle.io/fields1"}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1b)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1b)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings(gomock.Any()).Return([]string{"flipper"}, nil)
 
 		rawStmt2 := `UPDATE "_v1_Namespace_fields" SET "spec.displayName" = ? WHERE key = ?`
-		c.EXPECT().Prepare(rawStmt2)
-		txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+		c.EXPECT().Prepare(rawStmt2).Return(preparedStmt)
+		txC.EXPECT().Stmt(preparedStmt).Return(stmts)
+		preparedStmt.EXPECT().Close()
 		stmts.EXPECT().Exec("moose1", "lego.cattle.io/fields1")
 
 		rawStmt3 := `SELECT DISTINCT f.key, ex2."spec.projectName"
          FROM "_v1_Pods_fields" f JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2
          ON f."field.cattle.io/fixer" = ex2."metadata.name"
          WHERE f."spec.projectName" != ex2."spec.projectName"`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 		args2 := []any{}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args2)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"field.cattle.io/fixer", "moose1"}}, nil)
 
+		// Override check:
 		rawStmt3b := `SELECT f."spec.projectName" FROM  "_v1_Pods_fields" f WHERE f.key = ?`
-		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3b))
+		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3b)).Return(preparedStmt)
 		args3b := []any{"field.cattle.io/fixer"}
-		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args3b)
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args3b)
+		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings(gomock.Any()).Return([]string{"snorkel"}, nil)
 
 		rawStmt4 := `UPDATE "_v1_Pods_fields" SET "spec.projectName" = ? WHERE key = ?`
-		c.EXPECT().Prepare(rawStmt4)
-		txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+		c.EXPECT().Prepare(rawStmt4).Return(preparedStmt)
+		txC.EXPECT().Stmt(preparedStmt).Return(stmts)
 		stmts.EXPECT().Exec("moose1", "field.cattle.io/fixer")
+		preparedStmt.EXPECT().Close()
 
 		err := store.Add(testObject)
 		assert.Nil(t, err)
@@ -1037,37 +1054,42 @@ func TestAddWithBothUpdates(t *testing.T) {
 				})
 			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
 			args1 := []any{}
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
 			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
 			rawStmt2 := `SELECT f."spec.displayName" FROM  "_v1_Namespace_fields" f WHERE f.key = ?`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2))
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2)).Return(preparedStmt)
 			args1b := []any{"lego.cattle.io/fields1"}
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1b)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1b)
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings(gomock.Any())
 
 			rawStmt2a := `UPDATE "_v1_Namespace_fields" SET "spec.displayName" = ? WHERE key = ?`
-			c.EXPECT().Prepare(rawStmt2a)
-			txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+			c.EXPECT().Prepare(rawStmt2a).Return(preparedStmt)
+			txC.EXPECT().Stmt(preparedStmt).Return(stmts)
+			preparedStmt.EXPECT().Close()
 			stmts.EXPECT().Exec("moose1", "lego.cattle.io/fields1")
 
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3))
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 			args2 := []any{}
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args2)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
+			preparedStmt.EXPECT().Close()
 
 			c.EXPECT().ReadStringsN(gomock.Any(), 2).Return([][]string{{"field.cattle.io/fixer", "moose1"}}, nil)
 			// Override check:
 			rawStmt2 = `SELECT f."spec.projectName" FROM  "_v1_Pods_fields" f WHERE f.key = ?`
-			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2))
+			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt2)).Return(preparedStmt)
 			args3b := []any{"field.cattle.io/fixer"}
-			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args3b)
+			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args3b)
+			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings(gomock.Any())
 
 			rawStmt4 := `UPDATE "_v1_Pods_fields" SET "spec.projectName" = ? WHERE key = ?`
-			c.EXPECT().Prepare(rawStmt4)
-			txC.EXPECT().Stmt(gomock.Any()).Return(stmts)
+			c.EXPECT().Prepare(rawStmt4).Return(preparedStmt)
+			txC.EXPECT().Stmt(preparedStmt).Return(stmts)
 			stmts.EXPECT().Exec("moose1", "field.cattle.io/fixer")
+			preparedStmt.EXPECT().Close()
 			// And again for the other object
 		}
 


### PR DESCRIPTION
Backport of main issue [#54478](https://github.com/rancher/rancher/issues/54478)

Backport issue: [#54596](https://github.com/rancher/rancher/issues/54596)

Main PR: [#1081](https://github.com/rancher/steve/pull/1081)