### PR TITLE
[v2.13] Add multiple label and field pair support in ExternalLabelDepe…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
       uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
       with:
         version: v1.64.8
+    - name: Install env-test
+      run: go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260324065417-8c5081a9b6ba
     - name: Build
       run: make build-bin
     - name: Test

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 	"github.com/rancher/steve/pkg/stores/sqlproxy"
 	"github.com/rancher/steve/pkg/summarycache"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -49,9 +51,27 @@ import (
 )
 
 const testNamespace = "sql-test"
+const defaultTestNamespace = "sql-test"
+const testLabel = "capitals.cattle.io/test"
+const mdTestLabel = "metadata.labels[" + testLabel + "]"
+const testFilter = "filter=" + mdTestLabel
 
 var defaultPartition = partition.Partition{
 	All: true,
+}
+
+// Always use a filter-test instead of a namespace test because some of the resources we care about
+// in this test don't have namespaces, but all resources have labels.
+func getFilteredQuery(query string, labelTest string) string {
+	if strings.Contains(query, mdTestLabel+"=") {
+		return query
+	}
+	continuationToken := "&"
+	if len(query) == 0 {
+		continuationToken = ""
+	}
+	return fmt.Sprintf("%s%s%s=%s", query, continuationToken, testFilter, labelTest)
+
 }
 
 type IntegrationSuite struct {
@@ -121,6 +141,34 @@ func createMCIO(ctx context.Context, client dynamic.ResourceInterface, gvr k8ssc
 	return client.Update(ctx, newObj, metav1.UpdateOptions{})
 }
 
+func createMCIOProject(ctx context.Context, client dynamic.ResourceInterface, gvr k8sschema.GroupVersionResource, thisTestLabel, name, clusterName, displayName string, otherLabels map[string]string) error {
+	labels := map[string]interface{}{
+		testLabel: thisTestLabel,
+	}
+	if otherLabels != nil {
+		for k, v := range otherLabels {
+			labels[k] = v
+		}
+	}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvr.Group + "/" + gvr.Version,
+			"kind":       "Project",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": defaultTestNamespace,
+				"labels":    labels,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": clusterName,
+				"displayName": displayName,
+			},
+		},
+	}
+	_, err := client.Create(ctx, obj, metav1.CreateOptions{})
+	return err
+}
+
 func createPCIO(ctx context.Context, client dynamic.ResourceInterface, gvr k8sschema.GroupVersionResource, name, clusterName string) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -144,6 +192,37 @@ func createPCIO(ctx context.Context, client dynamic.ResourceInterface, gvr k8ssc
 	// This call is needed to get the above status fields stored in the object
 	// PCIO CRDs have subresources, so we call `client.UpdateStatus` instead of `client.Update`
 	return client.UpdateStatus(ctx, newObj, metav1.UpdateOptions{})
+}
+
+func (i *IntegrationSuite) createNamespace(ctx context.Context, name string, thisTestLabel string, projectLabel string) error {
+	obj := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"field.cattle.io/projectId": projectLabel,
+				testLabel:                   thisTestLabel,
+			},
+		},
+	}
+	_, err := i.clientset.CoreV1().Namespaces().Create(ctx, obj, metav1.CreateOptions{})
+	return err
+}
+
+func (i *IntegrationSuite) createSecret(ctx context.Context, thisTestLabel string, name string, projectLabel string, clusterName string, secretType string) error {
+	obj := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: defaultTestNamespace,
+			Labels: map[string]string{
+				"management.cattle.io/project-scoped-secret":         projectLabel,
+				"management.cattle.io/project-scoped-secret-cluster": clusterName,
+				testLabel: thisTestLabel,
+			},
+		},
+		Type: v1.SecretType(secretType),
+	}
+	_, err := i.clientset.CoreV1().Secrets(defaultTestNamespace).Create(ctx, obj, metav1.CreateOptions{})
+	return err
 }
 
 func (i *IntegrationSuite) TestSQLCacheFilters() {
@@ -447,6 +526,32 @@ func (i *IntegrationSuite) waitForCacheReady(readyResourceNames []string, namesp
 			gotNames.Insert(name)
 		}
 		return wantNames.Equal(gotNames), nil
+	})
+}
+
+func waitForObjectsBySchema(ctx context.Context, proxyStore *sqlproxy.Store, schema *types.APISchema, labelTest string, expectedNum int) error {
+	q := getFilteredQuery("", labelTest)
+	t1 := time.Now()
+	return wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
+		req, err := http.NewRequest("GET", "http://localhost:8080?"+q, nil)
+		if err != nil {
+			return false, err
+		}
+		apiOp := &types.APIRequest{
+			Request: req,
+		}
+		partitions := []partition.Partition{defaultPartition}
+		_, total, _, err := proxyStore.ListByPartitions(apiOp, schema, partitions)
+		if err != nil {
+			logrus.Errorf("waitForObjectsBySchema: error getting list of objects for schema %s, labelTest %s at time %v: %v", schema.ID, labelTest, time.Since(t1), err)
+			// note that we don't return the error since that would stop the polling
+			return false, nil
+		}
+		if total != expectedNum {
+			logrus.Errorf("waitForObjectsBySchema: schema %s, labelTest %s at time %v: want %d objects, got %d", schema.ID, labelTest, time.Since(t1), expectedNum, total)
+			return false, nil
+		}
+		return true, nil
 	})
 }
 
@@ -965,6 +1070,345 @@ func (i *IntegrationSuite) TestProvisioningManagementClusterDependencies() {
 	}
 }
 
+func (i *IntegrationSuite) TestNamespaceProjectDependencies() {
+	ctx, cancel := context.WithCancel(i.T().Context())
+	defer cancel()
+	requireT := i.Require()
+
+	cols, ccache, ctrl, sf, proxyStore, err := i.setupTest(ctx)
+	requireT.NoError(err)
+	requireT.NotNil(proxyStore)
+	labelTest := "NamespaceProjectDependencies"
+
+	resetMCIOCh := make(chan struct{}, 10)
+
+	mcioGVK := k8sschema.GroupVersionKind{
+		Group:   "management.cattle.io",
+		Version: "v3",
+		Kind:    "Project",
+	}
+	mcioGVR := k8sschema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "projects",
+	}
+
+	sqlSchemaTracker := schematracker.NewSchemaTracker(ResetFunc(func(gvk k8sschema.GroupVersionKind) error {
+		proxyStore.Reset(gvk)
+		if gvk == mcioGVK {
+			resetMCIOCh <- struct{}{}
+		}
+		return nil
+	}))
+
+	onSchemasHandler := func(schemas *schema.Collection) error {
+		var retErr error
+
+		err := ccache.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
+
+		err = sqlSchemaTracker.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
+
+		return retErr
+	}
+	schemacontroller.Register(ctx,
+		cols,
+		ctrl.K8s.Discovery(),
+		ctrl.CRD.CustomResourceDefinition(),
+		ctrl.API.APIService(),
+		ctrl.K8s.AuthorizationV1().SelfSubjectAccessReviews(),
+		onSchemasHandler,
+		sf)
+
+	err = ctrl.Start(ctx)
+	requireT.NoError(err)
+	namespaceInfo := [][2]string{
+		{"namibia", "windhoek"},
+		{"togo", "lome"},
+		{"nigeria", "abuja"},
+		{"principe", "saotome"},
+	}
+	for _, info := range namespaceInfo {
+		err = i.createNamespace(ctx, info[0], labelTest, info[1])
+		requireT.NoError(err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(i.restCfg)
+	requireT.NoError(err)
+	mcioClient := dynamicClient.Resource(mcioGVR).Namespace(defaultTestNamespace)
+	mcioProjectInfo := [][2]string{
+		{"windhoek", "afrikaans"},
+		{"lome", "french"},
+		{"abuja", "english"},
+		{"saotome", "portuguese"},
+	}
+	for _, info := range mcioProjectInfo {
+		err = createMCIOProject(ctx, mcioClient, mcioGVR, labelTest, info[0], "", info[1], nil)
+		requireT.NoError(err)
+	}
+
+	var mcioSchema *types.APISchema
+	requireT.EventuallyWithT(func(c *assert.CollectT) {
+		mcioSchema = sf.Schema("management.cattle.io.project")
+		require.NotNil(c, mcioSchema)
+	}, 15*time.Second, 500*time.Millisecond)
+	nsSchema := sf.Schema("namespace")
+
+	tests := []struct {
+		name      string
+		query     string
+		wantNames []string
+	}{
+		{
+			name:  "sorts by name",
+			query: "sort=metadata.name",
+			wantNames: []string{
+				"namibia",
+				"nigeria",
+				"principe",
+				"togo",
+			},
+		},
+		{
+			name:  "sorts by field.cattle.io/projectId",
+			query: "sort=metadata.labels[field.cattle.io/projectId],metadata.name",
+			wantNames: []string{
+				"nigeria",  // abuja
+				"togo",     // lome
+				"principe", // sao tome
+				"namibia",  // windhoek
+			},
+		},
+		{
+			name:  "sorts by spec.displayName",
+			query: "sort=spec.displayName,metadata.name",
+			wantNames: []string{
+				"namibia",  // afrikaans
+				"nigeria",  // english
+				"togo",     // french
+				"principe", // portuguese
+			},
+		},
+		{
+			name:  "filter on spec.displayName",
+			query: "filter=spec.displayName~en",
+			wantNames: []string{
+				"nigeria", // english
+				"togo",    // french
+			},
+		},
+	}
+
+	err = waitForObjectsBySchema(ctx, proxyStore, mcioSchema, labelTest, len(mcioProjectInfo))
+	requireT.NoError(err)
+	err = waitForObjectsBySchema(ctx, proxyStore, nsSchema, labelTest, len(namespaceInfo))
+	requireT.NoError(err)
+
+	partitions := []partition.Partition{defaultPartition}
+	for _, test := range tests {
+		test := test
+		i.Run(test.name, func() {
+			q := getFilteredQuery(test.query, labelTest)
+			req, err := http.NewRequest("GET", "http://localhost:8080?"+q, nil)
+			requireT.NoError(err)
+			apiOp := &types.APIRequest{
+				Request: req,
+			}
+
+			got, total, continueToken, err := proxyStore.ListByPartitions(apiOp, nsSchema, partitions)
+			if err != nil {
+				i.Assert().NoError(err)
+				return
+			}
+			i.Assert().Equal(len(test.wantNames), total)
+			i.Assert().Equal("", continueToken)
+			i.Assert().Len(got.Items, len(test.wantNames))
+			gotNames := stringsFromULIst(got)
+			i.Assert().Equal(test.wantNames, gotNames)
+		})
+	}
+}
+
+func (i *IntegrationSuite) TestSecretProjectDependencies() {
+	ctx, cancel := context.WithCancel(i.T().Context())
+	defer cancel()
+	requireT := i.Require()
+	labelTest := "SecretProjectDependencies"
+
+	cols, ccache, ctrl, sf, proxyStore, err := i.setupTest(ctx)
+	requireT.NoError(err)
+	requireT.NotNil(proxyStore)
+
+	resetMCIOCh := make(chan struct{}, 10)
+
+	mcioGVK := k8sschema.GroupVersionKind{
+		Group:   "management.cattle.io",
+		Version: "v3",
+		Kind:    "Project",
+	}
+	mcioGVR := k8sschema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "projects",
+	}
+
+	sqlSchemaTracker := schematracker.NewSchemaTracker(ResetFunc(func(gvk k8sschema.GroupVersionKind) error {
+		proxyStore.Reset(gvk)
+		if gvk == mcioGVK {
+			resetMCIOCh <- struct{}{}
+		}
+		return nil
+	}))
+
+	onSchemasHandler := func(schemas *schema.Collection) error {
+		var retErr error
+
+		err := ccache.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
+
+		err = sqlSchemaTracker.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
+
+		return retErr
+	}
+	schemacontroller.Register(ctx,
+		cols,
+		ctrl.K8s.Discovery(),
+		ctrl.CRD.CustomResourceDefinition(),
+		ctrl.API.APIService(),
+		ctrl.K8s.AuthorizationV1().SelfSubjectAccessReviews(),
+		onSchemasHandler,
+		sf)
+
+	err = ctrl.Start(ctx)
+	requireT.NoError(err)
+	secretInfo := [][4]string{
+		// name | project name | cluster name | secret type
+		{"morocco", "rabat", "arabic", "france"},
+		{"eritrea", "asmara", "tigrinya", "italy"},
+		{"kenya", "nairobi", "english", "england"},
+		{"benin", "portonovo", "french", "france"},
+	}
+	projectInfo := [][3]string{
+		// name | clusterName | displayName
+		{"rabat", "arabic", "casablanca"},
+		{"asmara", "tigrinya", "keren"},
+		{"nairobi", "english", "mombasa"},
+		{"portonovo", "french", "cotonou"},
+	}
+	for _, info := range secretInfo {
+		err = i.createSecret(ctx, labelTest, info[0], info[1], info[2], info[3])
+		requireT.NoError(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(i.restCfg)
+	requireT.NoError(err)
+	mcioClient := dynamicClient.Resource(mcioGVR).Namespace(defaultTestNamespace)
+	for _, info := range projectInfo {
+		err = createMCIOProject(ctx, mcioClient, mcioGVR, labelTest, info[0], info[1], info[2], nil)
+		requireT.NoError(err)
+	}
+
+	var mcioSchema *types.APISchema
+	requireT.EventuallyWithT(func(c *assert.CollectT) {
+		mcioSchema = sf.Schema("management.cattle.io.project")
+		require.NotNil(c, mcioSchema)
+	}, 15*time.Second, 500*time.Millisecond)
+	secretSchema := sf.Schema("secret")
+
+	tests := []struct {
+		name      string
+		query     string
+		wantNames []string
+	}{
+		{
+			name:  "sorts by name",
+			query: "sort=metadata.name",
+			wantNames: []string{
+				"benin",
+				"eritrea",
+				"kenya",
+				"morocco",
+			},
+		},
+		{
+			name:  "sorts by foreign-key label",
+			query: "sort=metadata.labels[management.cattle.io/project-scoped-secret],metadata.name",
+			wantNames: []string{
+				"eritrea", // asmara
+				"kenya",   // nairobi
+				"benin",   // portonovo
+				"morocco", // rabat
+			},
+		},
+		{
+			name:  "sorts by spec.displayName (other city)",
+			query: "sort=spec.displayName,metadata.name",
+			wantNames: []string{
+				"morocco", // casablanca
+				"benin",   // cotonou
+				"eritrea", // keren
+				"kenya",   // mombasa
+			},
+		},
+		{
+			name:  "sorts by spec.clusterName (language)",
+			query: "sort=spec.clusterName,metadata.name",
+			wantNames: []string{
+				"morocco", // arabic
+				"kenya",   // english
+				"benin",   // french
+				"eritrea", // tigrinya
+			},
+		},
+		{
+			name:  "filter on spec.clusterName (language)",
+			query: "filter=spec.clusterName~en",
+			wantNames: []string{
+				"benin", // french
+				"kenya", // english
+			},
+		},
+		{
+			name:  "filter on spec.displayName (other city)",
+			query: "filter=spec.displayName~as",
+			wantNames: []string{
+				"kenya",   // mombasa
+				"morocco", // casablanca
+			},
+		},
+	}
+
+	err = waitForObjectsBySchema(ctx, proxyStore, mcioSchema, labelTest, len(projectInfo))
+	requireT.NoError(err)
+	err = waitForObjectsBySchema(ctx, proxyStore, secretSchema, labelTest, len(secretInfo))
+	requireT.NoError(err)
+
+	partitions := []partition.Partition{defaultPartition}
+	for _, test := range tests {
+		test := test
+		i.Run(test.name, func() {
+			q := getFilteredQuery(test.query, labelTest)
+			req, err := http.NewRequest("GET", "http://localhost:8080?"+q, nil)
+			requireT.NoError(err)
+			apiOp := &types.APIRequest{
+				Request: req,
+			}
+
+			got, total, continueToken, err := proxyStore.ListByPartitions(apiOp, secretSchema, partitions)
+			if err != nil {
+				i.Assert().NoError(err)
+				return
+			}
+			i.Assert().Equal(len(test.wantNames), total)
+			i.Assert().Equal("", continueToken)
+			i.Assert().Len(got.Items, len(test.wantNames))
+			gotNames := stringsFromULIst(got)
+			i.Assert().Equal(test.wantNames, gotNames)
+		})
+	}
+}
+
 func stringsFromULIst(ulist *unstructured.UnstructuredList) []string {
 	names := make([]string, len(ulist.Items))
 	for i, item := range ulist.Items {
@@ -996,4 +1440,44 @@ func TestIntegrationSuite(t *testing.T) {
 	// For testing we'll just ignore the logs since they won't be useful
 	ctrl.SetLogger(logr.New(ctrllog.NullLogSink{}))
 	suite.Run(t, new(IntegrationSuite))
+}
+
+func (i *IntegrationSuite) setupTest(ctx context.Context) (cols *common.DynamicColumns, ccache clustercache.ClusterCache, svrController *server.Controllers, sf *schema.Collection, proxyStore *sqlproxy.Store, err error) {
+	var cf *client.Factory
+	var cacheFactory *factory.CacheFactory
+
+	if cols, err = common.NewDynamicColumns(i.restCfg); err != nil {
+		return
+	}
+	if cf, err = client.NewFactory(i.restCfg, false); err != nil {
+		return
+	}
+
+	baseSchemas := types.EmptyAPISchemas()
+
+	ccache = clustercache.NewClusterCache(ctx, cf.AdminDynamicClient())
+
+	if svrController, err = server.NewController(i.restCfg, nil); err != nil {
+		return
+	}
+
+	asl := accesscontrol.NewAccessStore(ctx, true, svrController.RBAC)
+	sf = schema.NewCollection(ctx, baseSchemas, asl)
+
+	if err = resources.DefaultSchemas(ctx, baseSchemas, ccache, cf, sf, ""); err != nil {
+		return
+	}
+
+	definitions.Register(ctx, baseSchemas, svrController.K8s.Discovery(),
+		svrController.CRD.CustomResourceDefinition(), svrController.API.APIService())
+
+	summaryCache := summarycache.New(sf, ccache)
+	summaryCache.Start(ctx)
+
+	if cacheFactory, err = factory.NewCacheFactoryWithContext(ctx, factory.CacheFactoryOptions{}); err != nil {
+		return
+	}
+
+	proxyStore, err = sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, sf, cacheFactory, true)
+	return
 }

--- a/pkg/sqlcache/sqltypes/types.go
+++ b/pkg/sqlcache/sqltypes/types.go
@@ -1,6 +1,12 @@
 package sqltypes
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 type Op string
 
@@ -83,11 +89,79 @@ type ExternalDependency struct {
 }
 
 type ExternalLabelDependency struct {
-	SourceGVK            string
-	SourceLabelName      string
-	TargetGVK            string
-	TargetKeyFieldName   string
+	SourceGVK string
+	TargetGVK string
+
+	SourceLabelTargetField map[string]string
+
 	TargetFinalFieldName string
+
+	generatedQuery string
+}
+
+// NewExternalLabelDependency pre-generates the query needed for the label and key pairs. No labels in
+// ExternalLabelDependency are user supplied, making risk of potential SQL injection minimal.
+func NewExternalLabelDependency(eld ExternalLabelDependency) (ExternalLabelDependency, error) {
+	if len(eld.SourceLabelTargetField) == 0 {
+		return ExternalLabelDependency{}, fmt.Errorf("ExternalLabelDependency must have at least 1 label and field pair")
+	}
+
+	type pair struct {
+		sourceLabelName string
+		targetFieldName string
+	}
+
+	pairs := make([]pair, 0, len(eld.SourceLabelTargetField))
+	for sourceLabelName, targetFieldName := range eld.SourceLabelTargetField {
+		pairs = append(pairs, pair{sourceLabelName: sourceLabelName, targetFieldName: targetFieldName})
+	}
+
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].sourceLabelName == pairs[j].sourceLabelName {
+			return pairs[i].targetFieldName < pairs[j].targetFieldName
+		}
+
+		return pairs[i].sourceLabelName < pairs[j].sourceLabelName
+	})
+
+	joinClauses := make([]string, 0, len(pairs))
+	onClauses := make([]string, 0, len(pairs))
+	whereClauses := make([]string, 0, len(pairs))
+
+	for i, pair := range pairs {
+		joinClauses = append(joinClauses, fmt.Sprintf(`LEFT OUTER JOIN "%s_labels" lt%d ON f.key = lt%d.key`, eld.SourceGVK, i, i))
+		onClauses = append(onClauses, fmt.Sprintf(`lt%d.value = ex2."%s"`, i, pair.targetFieldName))
+		whereClauses = append(whereClauses, fmt.Sprintf(`lt%d.label = "%s"`, i, pair.sourceLabelName))
+	}
+
+	eld.generatedQuery = fmt.Sprintf(`SELECT DISTINCT f.key, ex2."%s" FROM "%s_fields" f
+	%s
+	JOIN "%s_fields" ex2 ON (%s)
+	WHERE (%s) AND f."%s" != ex2."%s"`,
+		eld.TargetFinalFieldName,
+		eld.SourceGVK,
+		strings.Join(joinClauses, "\n\t"),
+		eld.TargetGVK,
+		strings.Join(onClauses, " AND "),
+		strings.Join(whereClauses, " AND "),
+		eld.TargetFinalFieldName,
+		eld.TargetFinalFieldName,
+	)
+
+	return eld, nil
+}
+
+func MustNewExternalLabelDependency(eld ExternalLabelDependency) ExternalLabelDependency {
+	eld, err := NewExternalLabelDependency(eld)
+	if err != nil {
+		panic(err)
+	}
+
+	return eld
+}
+
+func (d ExternalLabelDependency) Query() string {
+	return d.generatedQuery
 }
 
 type ExternalGVKUpdates struct {

--- a/pkg/sqlcache/sqltypes/types_test.go
+++ b/pkg/sqlcache/sqltypes/types_test.go
@@ -1,0 +1,76 @@
+package sqltypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewExternalLabelDependency(t *testing.T) {
+	cases := []struct {
+		name string
+		eld  ExternalLabelDependency
+
+		expectedQuery string
+		err           string
+	}{
+		{
+			name: "missing label and field pairs",
+			eld: ExternalLabelDependency{
+				SourceGVK:              "_v1_Secret",
+				TargetGVK:              "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{},
+				TargetFinalFieldName:   "spec.clusterName",
+			},
+
+			err: "ExternalLabelDependency must have at least 1 label and field pair",
+		},
+		{
+			name: "one label and field pair",
+
+			eld: ExternalLabelDependency{
+				SourceGVK: "_v1_Namespace",
+				TargetGVK: "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{
+					"field.cattle.io/projectId": "metadata.name",
+				},
+				TargetFinalFieldName: "spec.displayName",
+			},
+
+			expectedQuery: `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
+	LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+	WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`,
+		},
+		{
+			name: "two label and field pairs",
+			eld: ExternalLabelDependency{
+				SourceGVK: "_v1_Secret",
+				TargetGVK: "management.cattle.io_v3_Project",
+				SourceLabelTargetField: map[string]string{
+					"management.cattle.io/project-scoped-secret":         "metadata.name",
+					"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+				},
+				TargetFinalFieldName: "spec.displayName",
+			},
+
+			expectedQuery: `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Secret_fields" f
+	LEFT OUTER JOIN "_v1_Secret_labels" lt0 ON f.key = lt0.key
+	LEFT OUTER JOIN "_v1_Secret_labels" lt1 ON f.key = lt1.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name" AND lt1.value = ex2."spec.clusterName")
+	WHERE (lt0.label = "management.cattle.io/project-scoped-secret" AND lt1.label = "management.cattle.io/project-scoped-secret-cluster") AND f."spec.displayName" != ex2."spec.displayName"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			eld, err := NewExternalLabelDependency(c.eld)
+
+			if c.err != "" {
+				assert.EqualError(t, err, c.err)
+			} else {
+				assert.Equal(t, c.expectedQuery, eld.Query())
+			}
+		})
+	}
+}

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -186,8 +186,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				labelDep.SourceGVK, labelDep.TargetFinalFieldName)
 			err = func() error {
 				preparedStmt := s.Prepare(rawStmt)
+				defer preparedStmt.Close()
 				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
-				preparedStmt.Close()
 				return err
 			}()
 			if err != nil {
@@ -239,8 +239,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				nonLabelDep.SourceGVK, nonLabelDep.TargetFinalFieldName)
 			err = func() error {
 				preparedStmt := s.Prepare(rawStmt)
+				defer preparedStmt.Close()
 				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
-				preparedStmt.Close()
 				return err
 			}()
 			if err != nil {

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -156,20 +156,10 @@ func (s *Store) checkUpdateExternalInfo(key string) {
 
 func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInfo *sqltypes.ExternalGVKUpdates) error {
 	for _, labelDep := range externalUpdateInfo.ExternalLabelDependencies {
-		rawGetStmt := fmt.Sprintf(`SELECT DISTINCT f.key, ex2."%s" FROM "%s_fields" f
-  LEFT OUTER JOIN "%s_labels" lt1 ON f.key = lt1.key
-  JOIN "%s_fields" ex2 ON lt1.value = ex2."%s"
- WHERE lt1.label = ? AND f."%s" != ex2."%s"`,
-			labelDep.TargetFinalFieldName,
-			labelDep.SourceGVK,
-			labelDep.SourceGVK,
-			labelDep.TargetGVK,
-			labelDep.TargetKeyFieldName,
-			labelDep.TargetFinalFieldName,
-			labelDep.TargetFinalFieldName,
-		)
+		rawGetStmt := labelDep.Query()
+
 		getStmt := s.Prepare(rawGetStmt)
-		rows, err := s.QueryForRows(s.ctx, getStmt, labelDep.SourceLabelName)
+		rows, err := s.QueryForRows(s.ctx, getStmt)
 		getStmt.Close()
 		if err != nil {
 			if !isDBError(err) {
@@ -196,8 +186,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				labelDep.SourceGVK, labelDep.TargetFinalFieldName)
 			err = func() error {
 				preparedStmt := s.Prepare(rawStmt)
-				defer preparedStmt.Close()
 				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+				preparedStmt.Close()
 				return err
 			}()
 			if err != nil {
@@ -249,8 +239,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				nonLabelDep.SourceGVK, nonLabelDep.TargetFinalFieldName)
 			err = func() error {
 				preparedStmt := s.Prepare(rawStmt)
-				defer preparedStmt.Close()
 				_, err := tx.Stmt(preparedStmt).Exec(finalTargetValue, sourceKey)
+				preparedStmt.Close()
 				return err
 			}()
 			if err != nil {
@@ -264,8 +254,8 @@ func (s *Store) updateExternalInfo(tx db.TxClient, key string, externalUpdateInf
 				finalTargetValue)
 		}
 	}
-	return nil
 
+	return nil
 }
 
 // If the new value will change a non-empty current value, return [true, error:nil]

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -797,12 +797,12 @@ func TestAddWithOneUpdate(t *testing.T) {
 					}
 				}).Times(2)
 			rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
+				LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+				JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+				WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
+			args1 := []any{}
 			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
-			args1 := []any{"field.cattle.io/projectId"}
-			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
+			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
 			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings2(gomock.Any()).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
@@ -870,13 +870,13 @@ func TestAddWithExternalUpdates(t *testing.T) {
 				}
 			}).Times(2)
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
+			LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+			JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+			WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
-		args1 := []any{"field.cattle.io/projectId"}
-		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
-		preparedStmt.EXPECT().Close()
+		args1 := []any{}
+		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
+		preparedStmt.EXPECT().Close().Times(2)
 		c.EXPECT().ReadStrings2(gomock.Any()).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
 		// Override check:
@@ -899,9 +899,8 @@ func TestAddWithExternalUpdates(t *testing.T) {
          WHERE f."spec.projectName" != ex2."spec.projectName"`
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt3)).Return(preparedStmt)
 		args2 := []any{}
-		c.EXPECT().QueryForRows(gomock.Any(), 
-preparedStmt, args2)
-		preparedStmt.EXPECT().Close()
+		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args2)
+		// preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings2(gomock.Any()).Return([][]string{{"lego.cattle.io/fields2", "moose2"}}, nil)
 
 		// Override check:
@@ -955,12 +954,12 @@ func TestAddWithSelfUpdates(t *testing.T) {
 				}
 			}).Times(2)
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-			LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-			JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-			WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
+	LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+	JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+	WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
-		args1 := []any{"field.cattle.io/projectId"}
-		c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
+		args1 := []any{}
+		c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
 		preparedStmt.EXPECT().Close()
 		c.EXPECT().ReadStrings2(gomock.Any()).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 
@@ -1030,12 +1029,12 @@ func TestAddWithBothUpdates(t *testing.T) {
 		store := SetupStoreWithExternalDependencies(t, c, true, true)
 
 		rawStmt := `SELECT DISTINCT f.key, ex2."spec.displayName" FROM "_v1_Namespace_fields" f
-  LEFT OUTER JOIN "_v1_Namespace_labels" lt1 ON f.key = lt1.key
-  JOIN "management.cattle.io_v3_Project_fields" ex2 ON lt1.value = ex2."metadata.name"
-  WHERE lt1.label = ? AND f."spec.displayName" != ex2."spec.displayName"`
+			LEFT OUTER JOIN "_v1_Namespace_labels" lt0 ON f.key = lt0.key
+			JOIN "management.cattle.io_v3_Project_fields" ex2 ON (lt0.value = ex2."metadata.name")
+			WHERE (lt0.label = "field.cattle.io/projectId") AND f."spec.displayName" != ex2."spec.displayName"`
 		rawStmt3 := `SELECT DISTINCT f.key, ex2."spec.projectName" FROM "_v1_Pods_fields" f
-  JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2 ON f."field.cattle.io/fixer" = ex2."metadata.name"
-  WHERE f."spec.projectName" != ex2."spec.projectName"`
+			JOIN "provisioner.cattle.io_v3_Cluster_fields" ex2 ON f."field.cattle.io/fixer" = ex2."metadata.name"
+			WHERE f."spec.projectName" != ex2."spec.projectName"`
 
 		c.EXPECT().Serialize(testObject, false).Return(testObjectSerialized, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "testStoreObject", testObjectSerialized).Return(nil)
@@ -1055,8 +1054,8 @@ func TestAddWithBothUpdates(t *testing.T) {
 					}
 				})
 			c.EXPECT().Prepare(WSIgnoringMatcher(rawStmt)).Return(preparedStmt)
-			args1 := []any{"field.cattle.io/projectId"}
-			c.EXPECT().QueryForRows(gomock.Any(), preparedStmt, args1)
+			args1 := []any{}
+			c.EXPECT().QueryForRows(gomock.Any(), gomock.Any(), args1)
 			preparedStmt.EXPECT().Close()
 			c.EXPECT().ReadStrings2(gomock.Any()).Return([][]string{{"lego.cattle.io/fields1", "moose1"}}, nil)
 			// Override check:
@@ -1134,6 +1133,7 @@ func SetupMockDB(t *testing.T) (*MockClient, *MockTxClient) {
 
 	return dbC, txC
 }
+
 func SetupStore(t *testing.T, client *MockClient, shouldEncrypt bool) *Store {
 	name := "testStoreObject"
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
@@ -1151,13 +1151,14 @@ func gvkKey(group, version, kind string) string {
 func SetupStoreWithExternalDependencies(t *testing.T, client *MockClient, updateExternal bool, updateSelf bool) *Store {
 	name := "testStoreObject"
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
-	namespaceProjectLabelDep := sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Namespace"),
-		SourceLabelName:      "field.cattle.io/projectId",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	namespaceProjectLabelDep := sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Namespace"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"field.cattle.io/projectId": "metadata.name",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
+	})
 	namespaceNonLabelDep := sqltypes.ExternalDependency{
 		SourceGVK:            gvkKey("", "v1", "Pods"),
 		SourceFieldName:      "field.cattle.io/fixer",

--- a/pkg/sqlcache/testdata/crds/management.cattle.io_projects.yaml
+++ b/pkg/sqlcache/testdata/crds/management.cattle.io_projects.yaml
@@ -1,0 +1,350 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: projects.management.cattle.io
+spec:
+  group: management.cattle.io
+  names:
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    singular: project
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.backingNamespace
+      name: BACKINGNAMESPACE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Project is a group of namespaces.
+          Projects are used to create a multi-tenant environment within a Kubernetes cluster by managing namespace operations,
+          such as role assignments or quotas, as a group.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the specification of the desired configuration for
+              the project.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the cluster the project belongs
+                  to. Immutable.
+                type: string
+              containerDefaultResourceLimit:
+                description: |-
+                  ContainerDefaultResourceLimit is a specification for the default LimitRange for the namespace.
+                  See https://kubernetes.io/docs/concepts/policy/limit-range/ for more details.
+                properties:
+                  limitsCpu:
+                    description: LimitsCPU is the CPU limits across all pods in a
+                      non-terminal state.
+                    type: string
+                  limitsMemory:
+                    description: LimitsMemory is the memory limits across all pods
+                      in a non-terminal state.
+                    type: string
+                  requestsCpu:
+                    description: RequestsCPU is the CPU requests limit across all
+                      pods in a non-terminal state.
+                    type: string
+                  requestsMemory:
+                    description: RequestsMemory is the memory requests limit across
+                      all pods in a non-terminal state.
+                    type: string
+                type: object
+              description:
+                description: Description is a human-readable description of the project.
+                type: string
+              displayName:
+                description: DisplayName is the human-readable name for the project.
+                type: string
+              namespaceDefaultResourceQuota:
+                description: |-
+                  NamespaceDefaultResourceQuota is a specification of the default ResourceQuota that a namespace will receive if none is provided.
+                  Must provide ResourceQuota if NamespaceDefaultResourceQuota is specified.
+                  See https://kubernetes.io/docs/concepts/policy/resource-quotas/ for more details.
+                properties:
+                  limit:
+                    description: Limit is the default quota limits applied to new
+                      namespaces.
+                    properties:
+                      configMaps:
+                        description: ConfigMaps is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      extended:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Extended contains additional limits a user may wish to impose beyond
+                          the limits set by the preceding fields. The keys have to be parseable
+                          as resource names, while the values have to be parseable as resource
+                          quantities. See also
+                          https://kubernetes.io/docs/concepts/policy/resource-quotas
+                        type: object
+                      limitsCpu:
+                        description: LimitsCPU is the CPU limits across all pods in
+                          a non-terminal state.
+                        type: string
+                      limitsMemory:
+                        description: LimitsMemory is the memory limits across all
+                          pods in a non-terminal state.
+                        type: string
+                      persistentVolumeClaims:
+                        description: PersistentVolumeClaims is the total number of
+                          PersistentVolumeClaims that can exist in the namespace.
+                        type: string
+                      pods:
+                        description: Pods is the total number of Pods in a non-terminal
+                          state that can exist in the namespace. A pod is in a terminal
+                          state if .status.phase in (Failed, Succeeded) is true.
+                        type: string
+                      replicationControllers:
+                        description: ReplicationControllers is total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      requestsCpu:
+                        description: RequestsCPU is the CPU requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsMemory:
+                        description: RequestsMemory is the memory requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsStorage:
+                        description: RequestsStorage is the storage requests limit
+                          across all persistent volume claims.
+                        type: string
+                      secrets:
+                        description: Secrets is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      services:
+                        description: Services is the total number of Services that
+                          can exist in the namespace.
+                        type: string
+                      servicesLoadBalancers:
+                        description: ServicesLoadBalancers is the total number of
+                          Services of type LoadBalancer that can exist in the namespace.
+                        type: string
+                      servicesNodePorts:
+                        description: ServiceNodePorts is the total number of Services
+                          of type NodePort that can exist in the namespace.
+                        type: string
+                    type: object
+                type: object
+              resourceQuota:
+                description: |-
+                  ResourceQuota is a specification for the total amount of quota for standard resources that will be shared by all namespaces in the project.
+                  Must provide NamespaceDefaultResourceQuota if ResourceQuota is specified.
+                  See https://kubernetes.io/docs/concepts/policy/resource-quotas/ for more details.
+                properties:
+                  limit:
+                    description: Limit is the total allowable quota limits shared
+                      by all namespaces in the project.
+                    properties:
+                      configMaps:
+                        description: ConfigMaps is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      extended:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Extended contains additional limits a user may wish to impose beyond
+                          the limits set by the preceding fields. The keys have to be parseable
+                          as resource names, while the values have to be parseable as resource
+                          quantities. See also
+                          https://kubernetes.io/docs/concepts/policy/resource-quotas
+                        type: object
+                      limitsCpu:
+                        description: LimitsCPU is the CPU limits across all pods in
+                          a non-terminal state.
+                        type: string
+                      limitsMemory:
+                        description: LimitsMemory is the memory limits across all
+                          pods in a non-terminal state.
+                        type: string
+                      persistentVolumeClaims:
+                        description: PersistentVolumeClaims is the total number of
+                          PersistentVolumeClaims that can exist in the namespace.
+                        type: string
+                      pods:
+                        description: Pods is the total number of Pods in a non-terminal
+                          state that can exist in the namespace. A pod is in a terminal
+                          state if .status.phase in (Failed, Succeeded) is true.
+                        type: string
+                      replicationControllers:
+                        description: ReplicationControllers is total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      requestsCpu:
+                        description: RequestsCPU is the CPU requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsMemory:
+                        description: RequestsMemory is the memory requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsStorage:
+                        description: RequestsStorage is the storage requests limit
+                          across all persistent volume claims.
+                        type: string
+                      secrets:
+                        description: Secrets is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      services:
+                        description: Services is the total number of Services that
+                          can exist in the namespace.
+                        type: string
+                      servicesLoadBalancers:
+                        description: ServicesLoadBalancers is the total number of
+                          Services of type LoadBalancer that can exist in the namespace.
+                        type: string
+                      servicesNodePorts:
+                        description: ServiceNodePorts is the total number of Services
+                          of type NodePort that can exist in the namespace.
+                        type: string
+                    type: object
+                  usedLimit:
+                    description: UsedLimit is the currently allocated quota for all
+                      namespaces in the project.
+                    properties:
+                      configMaps:
+                        description: ConfigMaps is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      extended:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Extended contains additional limits a user may wish to impose beyond
+                          the limits set by the preceding fields. The keys have to be parseable
+                          as resource names, while the values have to be parseable as resource
+                          quantities. See also
+                          https://kubernetes.io/docs/concepts/policy/resource-quotas
+                        type: object
+                      limitsCpu:
+                        description: LimitsCPU is the CPU limits across all pods in
+                          a non-terminal state.
+                        type: string
+                      limitsMemory:
+                        description: LimitsMemory is the memory limits across all
+                          pods in a non-terminal state.
+                        type: string
+                      persistentVolumeClaims:
+                        description: PersistentVolumeClaims is the total number of
+                          PersistentVolumeClaims that can exist in the namespace.
+                        type: string
+                      pods:
+                        description: Pods is the total number of Pods in a non-terminal
+                          state that can exist in the namespace. A pod is in a terminal
+                          state if .status.phase in (Failed, Succeeded) is true.
+                        type: string
+                      replicationControllers:
+                        description: ReplicationControllers is total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      requestsCpu:
+                        description: RequestsCPU is the CPU requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsMemory:
+                        description: RequestsMemory is the memory requests limit across
+                          all pods in a non-terminal state.
+                        type: string
+                      requestsStorage:
+                        description: RequestsStorage is the storage requests limit
+                          across all persistent volume claims.
+                        type: string
+                      secrets:
+                        description: Secrets is the total number of ReplicationControllers
+                          that can exist in the namespace.
+                        type: string
+                      services:
+                        description: Services is the total number of Services that
+                          can exist in the namespace.
+                        type: string
+                      servicesLoadBalancers:
+                        description: ServicesLoadBalancers is the total number of
+                          Services of type LoadBalancer that can exist in the namespace.
+                        type: string
+                      servicesNodePorts:
+                        description: ServiceNodePorts is the total number of Services
+                          of type NodePort that can exist in the namespace.
+                        type: string
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - displayName
+            type: object
+          status:
+            description: Status is the most recently observed status of the project.
+            properties:
+              backingNamespace:
+                description: BackingNamespace is the name of the namespace that contains
+                  resources associated with the project.
+                type: string
+              conditions:
+                description: Conditions are a set of indicators about aspects of the
+                  project.
+                items:
+                  description: ProjectCondition is the status of an aspect of the
+                    project.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of project condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -226,13 +226,14 @@ var (
 	namespaceGVK             = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 	mcioProjectGvk           = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
 	pcioClusterGvk           = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
-	namespaceProjectLabelDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Namespace"),
-		SourceLabelName:      "field.cattle.io/projectId",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	namespaceProjectLabelDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Namespace"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"field.cattle.io/projectId": "metadata.name",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
+	})
 	namespaceUpdates = sqltypes.ExternalGVKUpdates{
 		AffectedGVK:               namespaceGVK,
 		ExternalDependencies:      nil,
@@ -240,20 +241,24 @@ var (
 	}
 
 	secretGVK                    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
-	secretProjectLabelDisplayDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Secret"),
-		SourceLabelName:      "management.cattle.io/project-scoped-secret",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	secretProjectLabelDisplayDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Secret"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"management.cattle.io/project-scoped-secret":         "metadata.name",
+			"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+		},
 		TargetFinalFieldName: "spec.displayName",
-	}
-	secretProjectLabelClusterDep = sqltypes.ExternalLabelDependency{
-		SourceGVK:            gvkKey("", "v1", "Secret"),
-		SourceLabelName:      "management.cattle.io/project-scoped-secret",
-		TargetGVK:            gvkKey("management.cattle.io", "v3", "Project"),
-		TargetKeyFieldName:   "metadata.name",
+	})
+	secretProjectLabelClusterDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
+		SourceGVK: gvkKey("", "v1", "Secret"),
+		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
+		SourceLabelTargetField: map[string]string{
+			"management.cattle.io/project-scoped-secret":         "metadata.name",
+			"management.cattle.io/project-scoped-secret-cluster": "spec.clusterName",
+		},
 		TargetFinalFieldName: "spec.clusterName",
-	}
+	})
 	secretUpdates = sqltypes.ExternalGVKUpdates{
 		AffectedGVK:               secretGVK,
 		ExternalDependencies:      nil,


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/54674

> https://github.com/rancher/rancher/issues/52810
>
> When two Projects are manually created with the same metadata.name on different clusters, the sql queries in pkg/sqlcache/store/store.go checking for projects matching a secret's management.cattle.io/project-scoped-secret label will return both secrets. In order to uniquely identify the Project to link to a project scoped secret, we need to check both the metadata.name AND spec.clusterName.