### PR TITLE
Remove Table GVK on converted UnstructuredList

### DIFF
--- a/pkg/stores/sqlproxy/tablelistconvert/client.go
+++ b/pkg/stores/sqlproxy/tablelistconvert/client.go
@@ -108,6 +108,15 @@ func tableToList(obj *unstructured.UnstructuredList) {
 	}
 
 	obj.Items = tableToObjects(obj.Object)
+
+	// client-go v0.36+ reflectors reject lists whose top-level GVK is Table; rewrite to the resource's list GVK.
+	if len(obj.Items) > 0 {
+		obj.Object["kind"] = obj.Items[0].GetKind() + "List"
+		obj.Object["apiVersion"] = obj.Items[0].GetAPIVersion()
+	} else {
+		delete(obj.Object, "kind")
+		delete(obj.Object, "apiVersion")
+	}
 }
 
 func tableToObjects(obj map[string]interface{}) []unstructured.Unstructured {

--- a/pkg/stores/sqlproxy/tablelistconvert/client_test.go
+++ b/pkg/stores/sqlproxy/tablelistconvert/client_test.go
@@ -196,8 +196,8 @@ func TestList(t *testing.T) {
 			}
 			expectedList := &unstructured.UnstructuredList{
 				Object: map[string]interface{}{
-					"kind":       "Table",
-					"apiVersion": "meta.k8s.io/v1",
+					"kind":       "List",
+					"apiVersion": "",
 					"rows": []interface{}{
 						map[string]interface{}{
 							"cells": []interface{}{"cell1", "cell2"},
@@ -249,6 +249,36 @@ func TestList(t *testing.T) {
 			receivedList, err := client.List(context.TODO(), opts)
 			assert.Nil(t, err)
 			assert.Equal(t, initialList, receivedList)
+		},
+	})
+	tests = append(tests, testCase{
+		description: "client List() on a Table response with no rows should drop the Table envelope's " +
+			"kind and apiVersion so client-go reflectors do not reject the result.",
+		test: func(t *testing.T) {
+			ri := NewMockResourceInterface(gomock.NewController(t))
+			opts := metav1.ListOptions{}
+			initialList := &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"kind":       "Table",
+					"apiVersion": "meta.k8s.io/v1",
+					"rows":       []interface{}{},
+				},
+			}
+			expectedList := &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"rows": []interface{}{},
+				},
+				Items: nil,
+			}
+			ri.EXPECT().List(context.TODO(), opts).Return(initialList, nil)
+			client := &Client{ResourceInterface: ri}
+			receivedList, err := client.List(context.TODO(), opts)
+			assert.Nil(t, err)
+			assert.Equal(t, expectedList, receivedList)
+			_, hasKind := receivedList.Object["kind"]
+			_, hasAPIVersion := receivedList.Object["apiVersion"]
+			assert.False(t, hasKind, "kind key should be absent")
+			assert.False(t, hasAPIVersion, "apiVersion key should be absent")
 		},
 	})
 	tests = append(tests, testCase{


### PR DESCRIPTION
client-go for k8s v1.36 reflectors reject lists whose top-level GVK is meta.k8s.io/v1 Kind=Table. After unwrapping the rows into Items, overwrite the list's kind/apiVersion so the reflector accepts the result.