### PR TITLE
Bump github.com/rancher/apiserver to v0.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rancher/apiserver v0.9.1
+	github.com/rancher/apiserver v0.9.3
 	github.com/rancher/dynamiclistener v0.7.4-rc.2
 	github.com/rancher/kubernetes-provider-detector v0.1.6-0.20240606163014-fcae75779379
 	github.com/rancher/lasso v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/rancher/apiserver v0.9.1 h1:XIMgnj7CpCu9qGrkOgD8dWzWNdCesUz4z4SbYxjiu0w=
-github.com/rancher/apiserver v0.9.1/go.mod h1:O7bN3BYxi9kWZfqDrh/ULOss+6eZ1ZWwES/3ZbwitkA=
+github.com/rancher/apiserver v0.9.3 h1:aAxq3+w7IaghIK2eSMGaLgJHqlRs5bkIUywBb6UKQfU=
+github.com/rancher/apiserver v0.9.3/go.mod h1:O7bN3BYxi9kWZfqDrh/ULOss+6eZ1ZWwES/3ZbwitkA=
 github.com/rancher/dynamiclistener v0.7.4-rc.2 h1:rmsTukH0QUx4v6BpV3hArFccu+6LDuloKwl9cRwHy2Y=
 github.com/rancher/dynamiclistener v0.7.4-rc.2/go.mod h1:Xuq3XpoFO+6j8te9w/3rlrhhALME47jw5xWhueT5iYY=
 github.com/rancher/kubernetes-provider-detector v0.1.6-0.20240606163014-fcae75779379 h1:/DKzOm5Du2jPLE5rXPGhsb0XeT68kWEIRi6jnzMeyGk=


### PR DESCRIPTION
Automated bump of `github.com/rancher/apiserver` to `v0.9.3` on `main`.

Tracker: https://github.com/tomleb/frameworks-automation/issues/110

This PR was opened by the release-automation reconciler. CI will run on push; review and merge as usual.
