### PR TITLE
Provide a better response for '--version'.

### DIFF
--- a/scripts/build-bin.sh
+++ b/scripts/build-bin.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-CGO_ENABLED=0 go build -ldflags "-extldflags -static -s" -o ./bin/steve
+
+shopt -s extglob
+
+FULLTAG=$(git describe --tags --long)
+VERSION=$(echo $FULLTAG | cut -d- -f1)
+NUM=$(echo $FULLTAG | cut -d- -f2)
+COMMIT=$(echo $FULLTAG | cut -d- -f3)
+if [[ -n "${NUM:-}" ]] ; then
+    VERSION=$VERSION-$NUM
+fi
+if [[ -z "${COMMIT:-}" ]] then
+   COMMIT=$(git rev-parse --short HEAD)
+fi
+
+CGO_ENABLED=0 go build -ldflags "-extldflags -static -s -X github.com/rancher/steve/pkg/version.Version=$VERSION  -X github.com/rancher/steve/pkg/version.GitCommit=$COMMIT" -o ./bin/steve


### PR DESCRIPTION
Otherwise `./bin/steve --version` doesn't give any useful info. This can help QA ensure that they're testing a recent-enough version of steve with alpha-releases or rancher.