### PR TITLE
[release/v0.7] fix: nodemetric version comparison (#969)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /dist
 *.swp
 .idea
+.vscode
 steve
 
 informer_object_cache.db


### PR DESCRIPTION
Backport of #969 to `release/v0.7`.

Cherry-picked from commit 89138d26a7bce25fd272e1411084df2120a8c195 with no conflicts (only a trivial `.gitignore` auto-merge).

## Why backport this?

The fix landed on `release/v0.8` (v0.8.14) and `release/v0.9` (v0.9.0) but was never backported to `release/v0.7`, which is the steve line consumed by Rancher v2.13.x. As a result, the Steve `/v1/metrics.k8s.io.nodes` list endpoint returns a stale, frozen-at-startup snapshot on v2.13 — the cache for `NodeMetrics` is fed by the synthetic watcher, and `NodeMetrics` keeps the same `resourceVersion` across refreshes, so no `Modified` event is ever emitted.

Original PR addresses: https://github.com/rancher/rancher/issues/53151

## Verification

Built `rancher/rancher` from `release/v2.13` HEAD with steve replaced by this branch (`v0.7.46 + cherry-pick`) and deployed on a fresh k3d cluster:

| | Pre-stress | After stress (call 1) | +10s | +20s |
|---|---|---|---|---|
| **Unpatched v0.7.38 (v2.13.3)** | 120m | 120m (same ts) | 120m (same ts) | — |
| **Patched v0.7.46 (this PR)** | 146m | 2196m | 2164m | 2171m |

The list endpoint now refreshes per-call and tracks the actual node load, matching the behavior on `main` / `release/v0.8` / `release/v0.9`.