### PR TITLE
feat: redact sensitive namespace metadata for implicit RBAC access

### DIFF
--- a/pkg/resources/formatters/namespace.go
+++ b/pkg/resources/formatters/namespace.go
@@ -1,0 +1,78 @@
+package formatters
+
+import (
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/accesscontrol"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var namespaceGR = schema.GroupResource{Group: "", Resource: "namespaces"}
+
+var allowedAnnotations = []string{
+	"management.cattle.io/system-namespace", // system namespace detection
+	"field.cattle.io/projectId",             // project grouping
+}
+
+var allowedLabels = []string{
+	"fleet.cattle.io/managed", // fleet namespace detection
+}
+
+// Namespace strips sensitive metadata from namespace objects the user cannot actually "get".
+// Preserves: name, resourceVersion, status.phase, and allowed annotations/labels for UI.
+func Namespace(request *types.APIRequest, resource *types.RawResource) {
+	accessSet := accesscontrol.AccessSetFromAPIRequest(request)
+	if accessSet == nil {
+		return
+	}
+
+	name := resource.APIObject.Name()
+	if accessSet.Grants("get", namespaceGR, "", name) {
+		return
+	}
+
+	unstr, ok := resource.APIObject.Object.(*unstructured.Unstructured)
+	if !ok {
+		return
+	}
+
+	// Build object with empty structures to avoid nil access issues in UI
+	newObj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name":        name,
+			"labels":      map[string]interface{}{},
+			"annotations": map[string]interface{}{},
+		},
+		"spec":   map[string]interface{}{},
+		"status": map[string]interface{}{},
+	}
+	metadata := newObj["metadata"].(map[string]interface{})
+
+	if rv, ok, _ := unstructured.NestedString(unstr.Object, "metadata", "resourceVersion"); ok {
+		metadata["resourceVersion"] = rv
+	}
+
+	if annotations, ok, _ := unstructured.NestedStringMap(unstr.Object, "metadata", "annotations"); ok {
+		for _, key := range allowedAnnotations {
+			if v, exists := annotations[key]; exists {
+				metadata["annotations"].(map[string]interface{})[key] = v
+			}
+		}
+	}
+
+	if labels, ok, _ := unstructured.NestedStringMap(unstr.Object, "metadata", "labels"); ok {
+		for _, key := range allowedLabels {
+			if v, exists := labels[key]; exists {
+				metadata["labels"].(map[string]interface{})[key] = v
+			}
+		}
+	}
+
+	if phase, ok, _ := unstructured.NestedString(unstr.Object, "status", "phase"); ok {
+		newObj["status"].(map[string]interface{})["phase"] = phase
+	}
+
+	unstr.Object = newObj
+}

--- a/pkg/resources/formatters/namespace_test.go
+++ b/pkg/resources/formatters/namespace_test.go
@@ -1,0 +1,247 @@
+package formatters
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/accesscontrol"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNamespace(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		hasGetAccess   bool
+		expectStripped bool
+	}{
+		{
+			name:           "user with get access sees full namespace",
+			namespace:      "default",
+			hasGetAccess:   true,
+			expectStripped: false,
+		},
+		{
+			name:           "user without get access sees stripped namespace",
+			namespace:      "default",
+			hasGetAccess:   false,
+			expectStripped: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a namespace object with metadata
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name":              tt.namespace,
+						"resourceVersion":   "12345",
+						"creationTimestamp": "2024-01-01T00:00:00Z",
+						"uid":               "abc-123-def",
+						"labels": map[string]interface{}{
+							"env":                   "production",
+							"fleet.cattle.io/managed": "true",
+						},
+						"annotations": map[string]interface{}{
+							"description":                           "sensitive info",
+							"management.cattle.io/system-namespace": "true",
+							"field.cattle.io/projectId":             "local:p-12345",
+						},
+					},
+					"spec": map[string]interface{}{
+						"finalizers": []interface{}{"kubernetes"},
+					},
+					"status": map[string]interface{}{
+						"phase": "Active",
+					},
+				},
+			}
+
+			// Create mock access set
+			accessSet := &accesscontrol.AccessSet{}
+			if tt.hasGetAccess {
+				accessSet.Add("get", namespaceGR, accesscontrol.Access{
+					Namespace:    accesscontrol.All,
+					ResourceName: tt.namespace,
+				})
+			}
+
+			// Create request with access set on schemas
+			schemas := types.EmptyAPISchemas()
+			accesscontrol.SetAccessSetAttribute(schemas, accessSet)
+			request := &types.APIRequest{
+				Schemas: schemas,
+			}
+
+			resource := &types.RawResource{
+				APIObject: types.APIObject{Object: obj},
+			}
+
+			// Run formatter
+			Namespace(request, resource)
+
+			// Check results
+			resultObj := resource.APIObject.Object.(*unstructured.Unstructured)
+			metadata := resultObj.Object["metadata"].(map[string]interface{})
+
+			if tt.expectStripped {
+				// Should have name
+				assert.Equal(t, tt.namespace, metadata["name"])
+
+				// Should have resourceVersion (needed for watch/caching)
+				assert.Equal(t, "12345", metadata["resourceVersion"])
+
+				// Should have allowed annotations
+				annotations, hasAnnotations := metadata["annotations"].(map[string]interface{})
+				assert.True(t, hasAnnotations, "should have annotations")
+				assert.Equal(t, "true", annotations["management.cattle.io/system-namespace"])
+				assert.Equal(t, "local:p-12345", annotations["field.cattle.io/projectId"])
+				assert.NotContains(t, annotations, "description", "sensitive annotation should be stripped")
+
+				// Should have allowed labels
+				labels, hasLabels := metadata["labels"].(map[string]interface{})
+				assert.True(t, hasLabels, "should have labels")
+				assert.Equal(t, "true", labels["fleet.cattle.io/managed"])
+				assert.NotContains(t, labels, "env", "sensitive label should be stripped")
+
+				// Should have status.phase
+				status, hasStatus := resultObj.Object["status"].(map[string]interface{})
+				assert.True(t, hasStatus, "should have status")
+				assert.Equal(t, "Active", status["phase"])
+
+				// Should NOT have sensitive fields
+				assert.NotContains(t, metadata, "creationTimestamp", "creationTimestamp should be stripped")
+				assert.NotContains(t, metadata, "uid", "uid should be stripped")
+				// spec and status should be empty objects (not omitted)
+				spec := resultObj.Object["spec"].(map[string]interface{})
+				assert.Empty(t, spec, "spec should be empty")
+			} else {
+				// Should have full object
+				assert.Equal(t, tt.namespace, metadata["name"])
+				labels := metadata["labels"].(map[string]interface{})
+				assert.Equal(t, "production", labels["env"], "all labels should be present")
+				annotations := metadata["annotations"].(map[string]interface{})
+				assert.Equal(t, "sensitive info", annotations["description"], "all annotations should be present")
+				assert.Contains(t, metadata, "creationTimestamp", "creationTimestamp should be present")
+				assert.Contains(t, metadata, "uid", "uid should be present")
+			}
+		})
+	}
+}
+
+func TestNamespace_NilAccessSet(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "default",
+				"labels": map[string]interface{}{
+					"env": "production",
+				},
+			},
+		},
+	}
+
+	// Request without access set
+	request := &types.APIRequest{}
+	resource := &types.RawResource{
+		APIObject: types.APIObject{Object: obj},
+	}
+
+	// Should not panic and not modify object
+	Namespace(request, resource)
+
+	resultObj := resource.APIObject.Object.(*unstructured.Unstructured)
+	metadata := resultObj.Object["metadata"].(map[string]interface{})
+	assert.Contains(t, metadata, "labels", "object should not be modified when access set is nil")
+}
+
+func TestNamespace_MinimalObject(t *testing.T) {
+	// Test with a namespace that has no optional fields
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "minimal-ns",
+			},
+		},
+	}
+
+	accessSet := &accesscontrol.AccessSet{}
+	schemas := types.EmptyAPISchemas()
+	accesscontrol.SetAccessSetAttribute(schemas, accessSet)
+	request := &types.APIRequest{
+		Schemas: schemas,
+	}
+
+	resource := &types.RawResource{
+		APIObject: types.APIObject{Object: obj},
+	}
+
+	Namespace(request, resource)
+
+	resultObj := resource.APIObject.Object.(*unstructured.Unstructured)
+	metadata := resultObj.Object["metadata"].(map[string]interface{})
+
+	// Should have name
+	assert.Equal(t, "minimal-ns", metadata["name"])
+
+	// Should have empty annotations/labels (not omitted, to avoid nil access in UI)
+	annotations := metadata["annotations"].(map[string]interface{})
+	labels := metadata["labels"].(map[string]interface{})
+	assert.Empty(t, annotations, "annotations should be empty")
+	assert.Empty(t, labels, "labels should be empty")
+}
+
+func TestNamespace_OnlyAllowedAnnotations(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "test-ns",
+				"annotations": map[string]interface{}{
+					"custom-annotation":                     "should be stripped",
+					"another.io/secret":                     "also stripped",
+					"management.cattle.io/system-namespace": "true",
+					"field.cattle.io/projectId":             "local:p-abc",
+				},
+				"labels": map[string]interface{}{
+					"custom-label":            "should be stripped",
+					"fleet.cattle.io/managed": "true",
+				},
+			},
+		},
+	}
+
+	accessSet := &accesscontrol.AccessSet{}
+	schemas := types.EmptyAPISchemas()
+	accesscontrol.SetAccessSetAttribute(schemas, accessSet)
+	request := &types.APIRequest{
+		Schemas: schemas,
+	}
+
+	resource := &types.RawResource{
+		APIObject: types.APIObject{Object: obj},
+	}
+
+	Namespace(request, resource)
+
+	resultObj := resource.APIObject.Object.(*unstructured.Unstructured)
+	metadata := resultObj.Object["metadata"].(map[string]interface{})
+
+	annotations := metadata["annotations"].(map[string]interface{})
+	assert.Len(t, annotations, 2, "should only have 2 allowed annotations")
+	assert.Equal(t, "true", annotations["management.cattle.io/system-namespace"])
+	assert.Equal(t, "local:p-abc", annotations["field.cattle.io/projectId"])
+
+	labels := metadata["labels"].(map[string]interface{})
+	assert.Len(t, labels, 1, "should only have 1 allowed label")
+	assert.Equal(t, "true", labels["fleet.cattle.io/managed"])
+}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -69,6 +69,10 @@ func DefaultSchemaTemplates(cf *client.Factory,
 			Formatter: formatters.Setting,
 		},
 		{
+			ID:        "namespace",
+			Formatter: formatters.Namespace,
+		},
+		{
 			ID: "management.cattle.io.cluster",
 			Customize: func(apiSchema *types.APISchema) {
 				cluster.AddApply(baseSchemas, apiSchema)
@@ -103,6 +107,10 @@ func DefaultSchemaTemplatesForStore(store types.Store,
 		{
 			ID:        "management.cattle.io.setting",
 			Formatter: formatters.Setting,
+		},
+		{
+			ID:        "namespace",
+			Formatter: formatters.Namespace,
 		},
 		{
 			ID: "management.cattle.io.cluster",

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -116,6 +116,29 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 			}
 		}
 
+		// Grant synthetic namespace access for UI dropdown functionality.
+		// Users with access to resources in a namespace need to see the namespace
+		// in the UI even without direct K8s namespace GET permission.
+		// The namespace formatter strips sensitive metadata from these responses.
+		mustAllowList := false
+		if len(verbAccess) == 0 {
+			if gr.Group == "" && gr.Resource == "namespaces" {
+				var accessList accesscontrol.AccessList
+				for _, ns := range access.Namespaces() {
+					accessList = append(accessList, accesscontrol.Access{
+						Namespace:    accesscontrol.All,
+						ResourceName: ns,
+					})
+				}
+				verbAccess["get"] = accessList
+				verbAccess["watch"] = accessList
+				if len(accessList) == 0 {
+					// make sure we add GET to collection later
+					mustAllowList = true
+				}
+			}
+		}
+
 		s = s.DeepCopy()
 		attributes.SetAccess(s, verbAccess)
 		sm := newSchemaMethodsFromSchema(s)
@@ -125,6 +148,10 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 				return "blocked-" + method
 			}
 			return method
+		}
+
+		if mustAllowList {
+			sm.addCollection(http.MethodGet)
 		}
 
 		if verbAccess.AnyVerb("list", "get") {

--- a/pkg/schema/factory.go
+++ b/pkg/schema/factory.go
@@ -116,25 +116,6 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 			}
 		}
 
-		mustAllowList := false
-		if len(verbAccess) == 0 {
-			if gr.Group == "" && gr.Resource == "namespaces" {
-				var accessList accesscontrol.AccessList
-				for _, ns := range access.Namespaces() {
-					accessList = append(accessList, accesscontrol.Access{
-						Namespace:    accesscontrol.All,
-						ResourceName: ns,
-					})
-				}
-				verbAccess["get"] = accessList
-				verbAccess["watch"] = accessList
-				if len(accessList) == 0 {
-					// make sure we add GET to collection later
-					mustAllowList = true
-				}
-			}
-		}
-
 		s = s.DeepCopy()
 		attributes.SetAccess(s, verbAccess)
 		sm := newSchemaMethodsFromSchema(s)
@@ -144,10 +125,6 @@ func (c *Collection) schemasForSubject(access *accesscontrol.AccessSet) (*types.
 				return "blocked-" + method
 			}
 			return method
-		}
-
-		if mustAllowList {
-			sm.addCollection(http.MethodGet)
 		}
 
 		if verbAccess.AnyVerb("list", "get") {

--- a/pkg/schema/factory_test.go
+++ b/pkg/schema/factory_test.go
@@ -58,11 +58,11 @@ func TestSchemas(t *testing.T) {
 			},
 		},
 		{
-			name: "namespaces with no explicit access returns no methods",
+			name: "namespaces with no explicit access still allows list",
 			config: schemaTestConfig{
 				permissionVerbs:        []string{}, // intentionally empty
 				desiredResourceVerbs:   []string{},
-				desiredCollectionVerbs: []string{}, // no bypass - no methods
+				desiredCollectionVerbs: []string{"GET"}, // special-case should add this
 				errDesired:             false,
 				resourceID:             "namespaces",
 			},
@@ -198,13 +198,6 @@ func runSchemaTest(t *testing.T, config schemaTestConfig, lookup *mockAccessSetL
 			testSchema = userSchema
 		}
 	}
-
-	// If no methods expected, schema should be nil (not included)
-	if len(config.desiredResourceVerbs) == 0 && len(config.desiredCollectionVerbs) == 0 {
-		assert.Nil(t, testSchema, "expected schema to be nil when no methods are expected")
-		return
-	}
-
 	assert.NotNil(t, testSchema, "expected a test schema, but was nil")
 	assert.Len(t, testSchema.ResourceMethods, len(config.desiredResourceVerbs), "did not get as many verbs as expected for resource methods")
 	assert.Len(t, testSchema.CollectionMethods, len(config.desiredCollectionVerbs), "did not get as many verbs as expected for collection methods")
@@ -240,15 +233,17 @@ func TestTaintedCacheDoesNotCauseDuplicates(t *testing.T) {
 	collection := NewCollection(context.TODO(), types.EmptyAPISchemas(), mockLookup)
 	collection.schemas = map[string]*types.APISchema{"namespaces": makeNamespaceSchema()}
 
-	// User A: No permissions on namespaces.
+	// User A: No permissions. Prior to our refactoring, this would add GET to the base schema
 	userA := &user.DefaultInfo{Name: "user-a"}
 	mockLookup.AddAccessForUser(userA, "get", k8sSchema.GroupResource{Group: "test.k8s.io", Resource: "dummy"}, "*", "*")
 
 	schemasA, err := collection.Schemas(userA)
 	assert.NoError(t, err)
 	nsSchemaA := schemasA.Schemas["namespaces"]
-	// With no perms, namespace schema should not be included (no methods = not added)
-	assert.Nil(t, nsSchemaA)
+	assert.NotNil(t, nsSchemaA)
+	// With no perms, should get a GET for list.
+	assert.Len(t, nsSchemaA.CollectionMethods, 1)
+	assert.Equal(t, "GET", nsSchemaA.CollectionMethods[0])
 
 	// User B: Has 'get' permission on namespaces.
 	userB := &user.DefaultInfo{Name: "user-b"}

--- a/pkg/schema/factory_test.go
+++ b/pkg/schema/factory_test.go
@@ -58,11 +58,11 @@ func TestSchemas(t *testing.T) {
 			},
 		},
 		{
-			name: "namespaces with no explicit access still allows list",
+			name: "namespaces with no explicit access returns no methods",
 			config: schemaTestConfig{
 				permissionVerbs:        []string{}, // intentionally empty
 				desiredResourceVerbs:   []string{},
-				desiredCollectionVerbs: []string{"GET"}, // special-case should add this
+				desiredCollectionVerbs: []string{}, // no bypass - no methods
 				errDesired:             false,
 				resourceID:             "namespaces",
 			},
@@ -198,6 +198,13 @@ func runSchemaTest(t *testing.T, config schemaTestConfig, lookup *mockAccessSetL
 			testSchema = userSchema
 		}
 	}
+
+	// If no methods expected, schema should be nil (not included)
+	if len(config.desiredResourceVerbs) == 0 && len(config.desiredCollectionVerbs) == 0 {
+		assert.Nil(t, testSchema, "expected schema to be nil when no methods are expected")
+		return
+	}
+
 	assert.NotNil(t, testSchema, "expected a test schema, but was nil")
 	assert.Len(t, testSchema.ResourceMethods, len(config.desiredResourceVerbs), "did not get as many verbs as expected for resource methods")
 	assert.Len(t, testSchema.CollectionMethods, len(config.desiredCollectionVerbs), "did not get as many verbs as expected for collection methods")
@@ -233,17 +240,15 @@ func TestTaintedCacheDoesNotCauseDuplicates(t *testing.T) {
 	collection := NewCollection(context.TODO(), types.EmptyAPISchemas(), mockLookup)
 	collection.schemas = map[string]*types.APISchema{"namespaces": makeNamespaceSchema()}
 
-	// User A: No permissions. Prior to our refactoring, this would add GET to the base schema
+	// User A: No permissions on namespaces.
 	userA := &user.DefaultInfo{Name: "user-a"}
 	mockLookup.AddAccessForUser(userA, "get", k8sSchema.GroupResource{Group: "test.k8s.io", Resource: "dummy"}, "*", "*")
 
 	schemasA, err := collection.Schemas(userA)
 	assert.NoError(t, err)
 	nsSchemaA := schemasA.Schemas["namespaces"]
-	assert.NotNil(t, nsSchemaA)
-	// With no perms, should get a GET for list.
-	assert.Len(t, nsSchemaA.CollectionMethods, 1)
-	assert.Equal(t, "GET", nsSchemaA.CollectionMethods[0])
+	// With no perms, namespace schema should not be included (no methods = not added)
+	assert.Nil(t, nsSchemaA)
 
 	// User B: Has 'get' permission on namespaces.
 	userB := &user.DefaultInfo{Name: "user-b"}

--- a/tests/integration/namespace_formatter_test.go
+++ b/tests/integration/namespace_formatter_test.go
@@ -77,8 +77,10 @@ func (i *IntegrationSuite) TestNamespaceFormatter() {
 		assert.Equal(i.T(), "local:p-test", annotations["field.cattle.io/projectId"])
 	})
 
-	i.Run("user without namespace GET sees stripped metadata", func() {
-		ns := i.getNamespaceByUser(ctx, baseURL, "ns-formatter-test", "user-ns-no-get")
+	// This is the real issue scenario: user has pod access in namespace but NO namespace permissions
+	// Steve grants synthetic namespace access for UI dropdown, but should strip sensitive metadata
+	i.Run("user with pod access but no namespace GET sees stripped metadata", func() {
+		ns := i.getNamespaceByUser(ctx, baseURL, "ns-formatter-test", "user-pod-only")
 
 		metadata := ns["metadata"].(map[string]interface{})
 		labels := metadata["labels"].(map[string]interface{})

--- a/tests/integration/namespace_formatter_test.go
+++ b/tests/integration/namespace_formatter_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"time"
+
+	"github.com/rancher/steve/pkg/auth"
+	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// TestNamespaceFormatter tests that namespace metadata is properly stripped for users without GET access.
+func (i *IntegrationSuite) TestNamespaceFormatter() {
+	ctx := i.T().Context()
+
+	manifestsFile := filepath.Join(testdataListDir, "namespace-formatter.manifests.yaml")
+	gvrs := make(map[k8sschema.GroupVersionResource]struct{})
+	i.doManifest(ctx, manifestsFile, func(ctx context.Context, obj *unstructured.Unstructured, gvr k8sschema.GroupVersionResource) error {
+		gvrs[gvr] = struct{}{}
+		return i.doApply(ctx, obj, gvr)
+	})
+	defer i.doManifestReversed(ctx, manifestsFile, i.doDelete)
+
+	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
+		info, ok, err := auth.Impersonation(req)
+		if ok || err != nil {
+			return info, ok, err
+		}
+		return auth.AlwaysAdmin(req)
+	}
+	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
+
+	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+		SQLCache: true,
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+		},
+		AuthMiddleware: authMiddleware,
+	})
+	i.Require().NoError(err)
+
+	httpServer := httptest.NewServer(steveHandler)
+	defer httpServer.Close()
+
+	baseURL := httpServer.URL
+
+	for gvr := range gvrs {
+		i.waitForSchema(baseURL, gvr)
+	}
+
+	defer i.maybeStopAndDebug(baseURL)
+
+	i.Run("user with namespace GET sees full metadata", func() {
+		ns := i.getNamespaceByUser(ctx, baseURL, "ns-formatter-test", "user-ns-get")
+
+		metadata := ns["metadata"].(map[string]interface{})
+		labels := metadata["labels"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+
+		// Should have all labels
+		assert.Equal(i.T(), "production", labels["env"])
+		assert.Equal(i.T(), "true", labels["fleet.cattle.io/managed"])
+
+		// Should have all annotations
+		assert.Equal(i.T(), "sensitive-info", annotations["description"])
+		assert.Equal(i.T(), "true", annotations["management.cattle.io/system-namespace"])
+		assert.Equal(i.T(), "local:p-test", annotations["field.cattle.io/projectId"])
+	})
+
+	i.Run("user without namespace GET sees stripped metadata", func() {
+		ns := i.getNamespaceByUser(ctx, baseURL, "ns-formatter-test", "user-ns-no-get")
+
+		metadata := ns["metadata"].(map[string]interface{})
+		labels := metadata["labels"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+
+		// Should have name
+		assert.Equal(i.T(), "ns-formatter-test", metadata["name"])
+
+		// Should only have allowed labels
+		assert.Equal(i.T(), "true", labels["fleet.cattle.io/managed"])
+		assert.NotContains(i.T(), labels, "env", "sensitive label should be stripped")
+
+		// Should only have allowed annotations
+		assert.Equal(i.T(), "true", annotations["management.cattle.io/system-namespace"])
+		assert.Equal(i.T(), "local:p-test", annotations["field.cattle.io/projectId"])
+		assert.NotContains(i.T(), annotations, "description", "sensitive annotation should be stripped")
+
+		// Should have empty spec/status (not nil)
+		assert.NotNil(i.T(), ns["spec"], "spec should exist")
+		assert.NotNil(i.T(), ns["status"], "status should exist")
+	})
+}
+
+func (i *IntegrationSuite) getNamespaceByUser(ctx context.Context, baseURL, name, user string) map[string]interface{} {
+	// Use LIST endpoint and find our namespace
+	url := fmt.Sprintf("%s/v1/namespaces", baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	i.Require().NoError(err)
+
+	if user != "" {
+		req.Header.Set("Impersonate-User", user)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	i.Require().NoError(err)
+	defer resp.Body.Close()
+
+	i.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	i.Require().NoError(err)
+
+	for _, ns := range result.Data {
+		if ns["id"] == name {
+			return ns
+		}
+	}
+	i.Require().Fail("namespace not found: " + name)
+	return nil
+}

--- a/tests/integration/testdata/list/namespace-formatter.manifests.yaml
+++ b/tests/integration/testdata/list/namespace-formatter.manifests.yaml
@@ -11,7 +11,7 @@ metadata:
     management.cattle.io/system-namespace: "true"
     field.cattle.io/projectId: local:p-test
 ---
-# User with full namespace GET access
+# User with full namespace GET access (should see all metadata)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,25 +34,29 @@ roleRef:
   name: ns-formatter-get-role
   apiGroup: rbac.authorization.k8s.io
 ---
-# User with namespace LIST but not GET (can list namespaces but not get details)
+# User with POD access in the namespace but NO namespace permissions
+# This is the real issue scenario: user can see pods in ns-formatter-test
+# but should NOT see sensitive namespace metadata
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: ns-formatter-list-only-role
+  name: ns-formatter-pod-role
+  namespace: ns-formatter-test
 rules:
   - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["list"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: ns-formatter-list-only-binding
+  name: ns-formatter-pod-binding
+  namespace: ns-formatter-test
 subjects:
   - kind: User
-    name: user-ns-no-get
+    name: user-pod-only
     apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: ClusterRole
-  name: ns-formatter-list-only-role
+  kind: Role
+  name: ns-formatter-pod-role
   apiGroup: rbac.authorization.k8s.io

--- a/tests/integration/testdata/list/namespace-formatter.manifests.yaml
+++ b/tests/integration/testdata/list/namespace-formatter.manifests.yaml
@@ -1,0 +1,58 @@
+# Namespace for testing the formatter
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-formatter-test
+  labels:
+    env: production
+    fleet.cattle.io/managed: "true"
+  annotations:
+    description: sensitive-info
+    management.cattle.io/system-namespace: "true"
+    field.cattle.io/projectId: local:p-test
+---
+# User with full namespace GET access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ns-formatter-get-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ns-formatter-get-binding
+subjects:
+  - kind: User
+    name: user-ns-get
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ns-formatter-get-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# User with namespace LIST but not GET (can list namespaces but not get details)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ns-formatter-list-only-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ns-formatter-list-only-binding
+subjects:
+  - kind: User
+    name: user-ns-no-get
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ns-formatter-list-only-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher-security/issues/1339

In Steve's RBAC implementation, users who have access to resources within a specific namespace are granted visibility to the parent Namespace object itself. This is necessary to ensure the Rancher UI can correctly group and navigate resources.

## Security Risk:
Because the full Namespace object is exposed, sensitive information stored in labels or annotations can be accessed by users who do not have explicit permissions to view the namespace.

## Solution:
This PR introduces a Namespace Formatter that redacts non-essential metadata. When access is granted implicitly, the formatter strips the majority of the data, leaving only the minimal fields required for the UI to function. This ensures that organizational metadata remains secure while maintaining a seamless user experience.