### PR TITLE
Work around rows.Err() deadlock

### DIFF
--- a/pkg/sqlcache/db/sqlwraps.go
+++ b/pkg/sqlcache/db/sqlwraps.go
@@ -44,6 +44,20 @@ type rows struct {
 
 // Err wraps the original *sql.Rows's Err() with a QueryError
 func (r rows) Err() error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		// Workaround for database/sql deadlock behavior after context cancellation:
+		// Context cancellation can cause deadlock, while calling Next() or Close() releases
+		// https://github.com/golang/go/issues/64498
+		select {
+		case <-done:
+		case <-time.After(100 * time.Millisecond):
+			// Force deadlock release if Err() is not immediate
+			_ = r.Close()
+		}
+	}()
+
 	if err := r.Rows.Err(); err != nil {
 		return &QueryError{QueryString: r.queryString, Err: err}
 	}


### PR DESCRIPTION
I asked Copilot to create a small stress unit test that would exercise the deadlock from calling `rows.Err()` before `rows.Close()` (expected behavior, `Close()` is normally deferred) while the context used for the query is canceled in the meantime.

<details>
<summary>Stress test</summary>

```
func TestRowsErrBeforeCloseAfterCancel_Stress(t *testing.T) {
	c := &client{}
	_, err := c.NewConnection(true)
	require.NoError(t, err)

	sqlDB := c.conn.(*connection).DB
	t.Cleanup(func() { _ = sqlDB.Close() })

	_, err = sqlDB.Exec(`CREATE TABLE IF NOT EXISTS deadlock_test (id BLOB)`)
	require.NoError(t, err)
	_, err = sqlDB.Exec(`DELETE FROM deadlock_test`)
	require.NoError(t, err)
	_, err = sqlDB.Exec(`INSERT INTO deadlock_test (id) VALUES (?)`, []byte("x"))
	require.NoError(t, err)

	stmt := c.Prepare("SELECT id from deadlock_test LIMIT 1")
	defer stmt.Close()

	const iterations = 100
	const timeout = 200 * time.Millisecond

	for i := 0; i < iterations; i++ {
		errCh := make(chan error, 1)
		go func() {
			defer close(errCh)
			ctx, cancel := context.WithCancel(context.Background())
			defer cancel()

			rows, err := stmt.QueryContext(ctx)
			if err != nil {
				errCh <- err
				return
			}
			defer rows.Close()

			var raw sql.RawBytes
			if rows.Next() {
				if err := rows.Scan(&raw); err != nil {
					errCh <- err
					return
				}
			}

			cancel()
			time.Sleep(time.Millisecond)
			_ = rows.Err()
		}()

		select {
		case err, ok := <-errCh:
			if ok {
				t.Error(err)
			}
		case <-time.After(timeout):
			t.Fatalf("hang detected at iteration %d", i)
		}
	}
}

```

</details>

Running it on `main` consistently fails at iteration 0 or 1 (sometimes later, but still quite early):
```
❯ go test ./pkg/sqlcache/db -run TestRowsErrBeforeCloseAfterCancel_Stress -count=10
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 0
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 0
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 2
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 1
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 0
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 3
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.22s)
    sqlrows_stress_test.go:66: hang detected at iteration 0
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 1
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 0
--- FAIL: TestRowsErrBeforeCloseAfterCancel_Stress (0.21s)
    sqlrows_stress_test.go:66: hang detected at iteration 2
FAIL
FAIL	github.com/rancher/steve/pkg/sqlcache/db	2.547s
FAIL
```
After these changes, it works on all iterations:
```
❯ go test ./pkg/sqlcache/db -run TestRowsErrBeforeCloseAfterCancel_Stress -count=10
ok  	github.com/rancher/steve/pkg/sqlcache/db	2.222s
```