### PR TITLE
[release/v0.7] Close rows before Err in ListOptionIndexer.Watch backfill

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -239,13 +239,7 @@ func (c *client) ReadObjects(rows Rows, typ reflect.Type) ([]any, error) {
 		}
 		result = append(result, dest)
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -267,13 +261,7 @@ func (c *client) ReadStrings(rows Rows) ([]string, error) {
 
 		result = append(result, key)
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -295,13 +283,7 @@ func (c *client) ReadStrings2(rows Rows) ([][]string, error) {
 
 		result = append(result, []string{key1, key2})
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -323,13 +305,7 @@ func (c *client) ReadInt(rows Rows) (int, error) {
 		return 0, closeRowsOnError(rows, err)
 	}
 
-	err = rows.Err()
-	if err != nil {
-		return 0, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return 0, err
 	}
 

--- a/pkg/sqlcache/db/client_test.go
+++ b/pkg/sqlcache/db/client_test.go
@@ -128,7 +128,6 @@ func TestQueryObjects(t *testing.T) {
 			*a[2].(*uint32) = keyId
 		})
 		d.EXPECT().Decrypt(testObjectSerialized, testObjectSerialized, keyId).Return(testObjectSerialized, nil)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
@@ -180,7 +179,6 @@ func TestQueryObjects(t *testing.T) {
 			*a[2].(*uint32) = keyId
 		})
 		d.EXPECT().Decrypt(testObjectSerialized, testObjectSerialized, keyId).Return(testObjectSerialized, nil)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
@@ -194,7 +192,6 @@ func TestQueryObjects(t *testing.T) {
 		d := SetupMockDecryptor(t)
 		r := SetupMockRows(t)
 		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		items, err := client.ReadObjects(r, reflect.TypeOf(testObject))
@@ -230,7 +227,6 @@ func TestQueryStrings(t *testing.T) {
 				*vk = testObject.Id
 			}
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
@@ -252,26 +248,6 @@ func TestQueryStrings(t *testing.T) {
 		assert.NotNil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "ReadStrings(), with one row, and Err() error", test: func(t *testing.T) {
-		c := SetupMockConnection(t)
-		e := SetupMockEncryptor(t)
-		d := SetupMockDecryptor(t)
-		r := SetupMockRows(t)
-		r.EXPECT().Next().Return(true)
-		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
-			for _, v := range a {
-				vk := v.(*string)
-				*vk = testObject.Id
-			}
-		})
-		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(fmt.Errorf("error"))
-		r.EXPECT().Close().Return(nil)
-		client := SetupClient(t, c, e, d)
-		_, err := client.ReadStrings(r)
-		assert.NotNil(t, err)
-	},
-	})
 	tests = append(tests, testCase{description: "ReadStrings(), with one row, and Close() error", test: func(t *testing.T) {
 		c := SetupMockConnection(t)
 		e := SetupMockEncryptor(t)
@@ -284,7 +260,6 @@ func TestQueryStrings(t *testing.T) {
 				*vk = testObject.Id
 			}
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
@@ -298,7 +273,6 @@ func TestQueryStrings(t *testing.T) {
 		d := SetupMockDecryptor(t)
 		r := SetupMockRows(t)
 		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		items, err := client.ReadStrings(r)
@@ -331,7 +305,6 @@ func TestReadInt(t *testing.T) {
 			p := a[0].(*int)
 			*p = testResult
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		result, err := client.ReadInt(r)
@@ -352,22 +325,6 @@ func TestReadInt(t *testing.T) {
 		assert.NotNil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "One row, Err() error", test: func(t *testing.T) {
-		c := SetupMockConnection(t)
-		e := SetupMockEncryptor(t)
-		d := SetupMockDecryptor(t)
-		r := SetupMockRows(t)
-		r.EXPECT().Next().Return(true)
-		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
-			a[0] = testResult
-		})
-		r.EXPECT().Err().Return(fmt.Errorf("error"))
-		r.EXPECT().Close().Return(nil)
-		client := SetupClient(t, c, e, d)
-		_, err := client.ReadInt(r)
-		assert.NotNil(t, err)
-	},
-	})
 	tests = append(tests, testCase{description: "One row, Close() error", test: func(t *testing.T) {
 		c := SetupMockConnection(t)
 		e := SetupMockEncryptor(t)
@@ -377,7 +334,6 @@ func TestReadInt(t *testing.T) {
 		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
 			a[0] = testResult
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
 		_, err := client.ReadInt(r)

--- a/pkg/sqlcache/db/db_mocks_test.go
+++ b/pkg/sqlcache/db/db_mocks_test.go
@@ -55,20 +55,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/db/sqlwraps.go
+++ b/pkg/sqlcache/db/sqlwraps.go
@@ -14,12 +14,25 @@ type Row interface {
 	Scan(dest ...any) error
 }
 
-// Rows represents sql rows. It exposes method to navigate the rows, read their outputs, and close them.
+// Rows represents sql rows. It exposes methods to navigate the rows, read
+// their outputs, and close them.
+//
+// Note: Err is intentionally not part of this interface. Iteration errors
+// must be retrieved via Close, which closes the rows and returns the first
+// iteration error (or any close error). Combining them eliminates a footgun
+// with sql.RawBytes targets in Scan: the database/sql Rows.closemu RLock
+// kept open across Scan(*RawBytes) returns is released by Close but not by
+// Err, so calling Err before Close can deadlock against a concurrent
+// Rows.awaitDone writer queued behind the scan-held RLock. See Go issue
+// 60304 and rancher/steve#1206 for the full story.
 type Rows interface {
 	Next() bool
-	Err() error
-	Close() error
 	Scan(dest ...any) error
+	// Close releases any resources held by the rows and returns the first
+	// error encountered during iteration. If iteration succeeded, returns
+	// any error from closing. Close must be called exactly once after the
+	// caller is done iterating.
+	Close() error
 }
 
 // Stmt is an interface over a subset of sql.Stmt methods
@@ -42,12 +55,20 @@ type rows struct {
 	queryString string
 }
 
-// Err wraps the original *sql.Rows's Err() with a QueryError
-func (r rows) Err() error {
+// Close closes the underlying *sql.Rows and returns the first error
+// encountered during iteration (wrapped in QueryError). If iteration
+// succeeded, returns any error from closing.
+//
+// Close is called before reading Err so that any closemu RLock held open
+// across a prior Scan(*sql.RawBytes) call is released first - calling Err
+// while that RLock is outstanding can deadlock if a concurrent
+// Rows.awaitDone has queued a writer Lock on the same mutex.
+func (r rows) Close() error {
+	closeErr := r.Rows.Close()
 	if err := r.Rows.Err(); err != nil {
 		return &QueryError{QueryString: r.queryString, Err: err}
 	}
-	return nil
+	return closeErr
 }
 
 // stmt implements the Stmt interface, wrapping a sql.Stmt and keeping track of the original query string

--- a/pkg/sqlcache/informer/db_mocks_test.go
+++ b/pkg/sqlcache/informer/db_mocks_test.go
@@ -56,20 +56,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -400,7 +400,11 @@ func (l *ListOptionIndexer) Watch(ctx context.Context, opts WatchOptions, events
 				return ctx.Err()
 			}
 		}
-		return rows.Err()
+		// Close returns both the iteration error and the close error; it
+		// must be called before reading any iteration error to release the
+		// closemu RLock that decryptScanEvent's Scan(*sql.RawBytes) kept
+		// open across return (see db.Rows interface doc).
+		return rows.Close()
 	}); err != nil {
 		return err
 	}

--- a/pkg/sqlcache/store/db_mocks_test.go
+++ b/pkg/sqlcache/store/db_mocks_test.go
@@ -56,20 +56,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/55165

## Summary
- `decryptScanEvent` scans into `sql.RawBytes`, so `database/sql` keeps `Rows.closemu` RLocked across the `Scan` return (Go's `closemuScanHold`, [Go issue 60304](https://github.com/golang/go/issues/60304)).
- If the `Watch` backfill loop exits via `latestRevisionReached` (no further `Next()` call), that RLock is still outstanding when `rows.Err()` runs.
- A racing ctx cancel can wedge `rows.Err()` on a recursive RLock behind a writer queued by `Rows.awaitDone`, which in turn pins `Tx.closemu` so `Tx.rollback` wedges. The SQLite read transaction never closes, the WAL cannot be reset, and writes append unboundedly (observed at 34 GB in production, SURE-11644).
- This PR calls `rows.Close()` explicitly before `rows.Err()` on the happy-path return. `Close` releases the scan-held RLock first and then takes the writer lock cleanly, so the following `rows.Err()` acquires its RLock against an unheld mutex.
- The deferred `rows.Close()` stays as a safety net for the early-return paths inside the loop; it's a no-op after the explicit call (`Close` is idempotent per the stdlib docs).

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./pkg/sqlcache/informer/...`
- [x] Standalone reproducer (Scan into `*sql.RawBytes`, exit loop early, call `Err` before `Close` with racing ctx cancel) deadlocks pre-fix and unwinds cleanly post-fix.
- [x] Standalone reproducer also confirms that with the deadlock active, `PRAGMA wal_checkpoint(RESTART|TRUNCATE)` reports `busy=1` and the WAL file grows unbounded under continued writes from a second connection — matching the production symptom.

## Notes
A deterministic unit test for the wedge condition isn't feasible: the race window is microseconds wide and lives inside a closure that `Watch` doesn't expose hooks into. The `select { case eventsCh <- ev: case <-ctx.Done(): }` in the loop body intercepts any cancellation that arrives during iteration, so the only path that reaches the vulnerable `return rows.Err()` is the `latestRevisionReached` exit. Production hits it via sheer volume of watch establishments × cancellations over long-running deployments, with a permanent consequence per hit (no recovery without restart).