### PR TITLE
[release/v0.7] sqlcache: tolerate DeletedFinalStateUnknown in Store.Delete

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -555,16 +555,8 @@ func (l *ListOptionIndexer) notifyEventModified(key string, obj any, tx db.TxCli
 	return l.notifyEvent(watch.Modified, oldObj, obj, tx)
 }
 
-func (l *ListOptionIndexer) notifyEventDeleted(key string, obj any, tx db.TxClient) error {
-	oldObj, exists, err := l.GetByKey(key)
-	if err != nil {
-		return fmt.Errorf("error getting old object: %w", err)
-	}
-
-	if !exists {
-		return fmt.Errorf("old object %q should be in store but was not", key)
-	}
-	return l.notifyEvent(watch.Deleted, oldObj, obj, tx)
+func (l *ListOptionIndexer) notifyEventDeleted(_ string, obj any, tx db.TxClient) error {
+	return l.notifyEvent(watch.Deleted, obj, obj, tx)
 }
 
 func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, oldObj any, obj any, tx db.TxClient) error {

--- a/pkg/sqlcache/informer/relist_test.go
+++ b/pkg/sqlcache/informer/relist_test.go
@@ -1,0 +1,173 @@
+package informer
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rancher/steve/pkg/sqlcache/db"
+	"github.com/rancher/steve/pkg/sqlcache/encryption"
+	"github.com/rancher/steve/pkg/sqlcache/store"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestRelistAfterWatchError exercises the path the user actually hits in
+// rancher/rancher#55228: the reflector's watch dies, the reflector re-lists
+// from a source whose contents have changed during the gap, and steve's
+// SQLite cache must end up reflecting the new state.
+//
+// This is a behavioral test, deliberately not pinned to any particular
+// client-go FIFO. On client-go v0.34/v0.35 (DeltaFIFO) the deletion travels
+// through processDeltas → Store.Delete(DeletedFinalStateUnknown). On v0.36+
+// with AtomicFIFO it travels through processReplacedAllInfo → Store.Replace.
+// The assertion is the same either way: rows that vanished from the source
+// must vanish from SQLite.
+func TestRelistAfterWatchError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gvk := schema.GroupVersionKind{Group: "fruits.cattle.io", Version: "v1", Kind: "Banana"}
+
+	bananaA := makeRelistBanana("a", "10")
+	bananaB := makeRelistBanana("b", "20")
+
+	src := newRelistSource(gvk)
+	src.setItems([]*unstructured.Unstructured{bananaA, bananaB})
+
+	m, err := encryption.NewManager()
+	require.NoError(t, err)
+	dbClient, dbPath, err := db.NewClient(ctx, nil, m, m, true)
+	require.NoError(t, err)
+	defer cleanTempFiles(dbPath)
+
+	example := &unstructured.Unstructured{}
+	example.SetGroupVersionKind(gvk)
+	s, err := store.NewStore(
+		ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc,
+		dbClient, false, gvk, informerNameFromGVK(gvk), nil, nil,
+	)
+	require.NoError(t, err)
+
+	loi, err := NewListOptionIndexer(ctx, s, ListOptionIndexerOptions{
+		IsNamespaced: false,
+		GCKeepCount:  1000,
+	})
+	require.NoError(t, err)
+
+	sii := cache.NewSharedIndexInformer(
+		src.listWatch(),
+		example,
+		0, // resyncPeriod
+		cache.Indexers{},
+	)
+	UnsafeSet(sii, "indexer", loi)
+
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	go sii.RunWithContext(runCtx)
+	require.True(t, cache.WaitForCacheSync(runCtx.Done(), sii.HasSynced), "informer never synced")
+
+	// Both Bananas land in SQLite after the initial list.
+	require.Eventually(t, func() bool {
+		_, exA, _ := sii.GetStore().GetByKey("a")
+		_, exB, _ := sii.GetStore().GetByKey("b")
+		return exA && exB
+	}, 5*time.Second, 50*time.Millisecond, "Bananas never landed in SQLite")
+
+	// Simulate "B was deleted while the watch was down": remove B from the
+	// source, then close the watch with an error to force the reflector to
+	// abandon ListAndWatch and re-list from scratch.
+	src.setItems([]*unstructured.Unstructured{bananaA})
+	require.Eventually(t, func() bool {
+		return src.currentWatcher() != nil
+	}, 2*time.Second, 50*time.Millisecond, "reflector never opened a watch")
+	src.currentWatcher().Error(&metav1.Status{
+		Status:  metav1.StatusFailure,
+		Reason:  metav1.StatusReasonGone,
+		Code:    410,
+		Message: "test-induced watch close",
+	})
+
+	// After the re-list, A must still be present and B must be gone.
+	require.Eventually(t, func() bool {
+		_, exA, errA := sii.GetStore().GetByKey("a")
+		_, exB, errB := sii.GetStore().GetByKey("b")
+		return errA == nil && errB == nil && exA && !exB
+	}, 10*time.Second, 100*time.Millisecond,
+		"SQLite cache not reconciled after watch-error + re-list (B should be gone, A should remain)")
+}
+
+// relistSource is a test list/watch source that lets the test control both
+// the contents returned by List and the active watcher returned by Watch.
+type relistSource struct {
+	gvk schema.GroupVersionKind
+
+	mu      sync.Mutex
+	items   []*unstructured.Unstructured
+	rv      int
+	watcher *watch.FakeWatcher
+}
+
+func newRelistSource(gvk schema.GroupVersionKind) *relistSource {
+	return &relistSource{gvk: gvk}
+}
+
+func (s *relistSource) setItems(items []*unstructured.Unstructured) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = items
+}
+
+func (s *relistSource) currentWatcher() *watch.FakeWatcher {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watcher
+}
+
+func (s *relistSource) listWatch() *cache.ListWatch {
+	return &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.rv++
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   s.gvk.Group,
+				Version: s.gvk.Version,
+				Kind:    s.gvk.Kind + "List",
+			})
+			list.SetResourceVersion(strconv.Itoa(s.rv))
+			for _, it := range s.items {
+				list.Items = append(list.Items, *it.DeepCopy())
+			}
+			return list, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.watcher = watch.NewFake()
+			return s.watcher, nil
+		},
+	}
+}
+
+func makeRelistBanana(name, rv string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "fruits.cattle.io/v1",
+			"kind":       "Banana",
+			"metadata": map[string]any{
+				"name":            name,
+				"resourceVersion": rv,
+			},
+		},
+	}
+}

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -380,6 +380,17 @@ func (s *Store) Delete(obj any) error {
 	if err != nil {
 		return err
 	}
+	if t, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = t.Obj
+	}
+	if obj == nil {
+		// Tombstone with no payload. DeltaFIFO.Replace synthesizes these
+		// when its knownObjects lookup failed during a re-list — and that
+		// knownObjects is this same Store. There's nothing to delete and
+		// nothing to hand the after-delete hooks.
+		logrus.Warnf("Store.Delete for type %v: tombstone with no payload for key %q; skipping", s.name, key)
+		return nil
+	}
 	err = s.deleteByKey(key, obj)
 	if err != nil {
 		log.Errorf("Error in Store.Delete for type %v: %v", s.name, err)

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 )
 
 func testStoreKeyFunc(obj interface{}) (string, error) {
@@ -383,6 +385,77 @@ func TestDelete(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) { test.test(t, false) })
 		t.Run(fmt.Sprintf("%s with encryption", test.description), func(t *testing.T) { test.test(t, true) })
 	}
+}
+
+// TestDeleteTombstone verifies that Store.Delete honors the cache.Store
+// contract for cache.DeletedFinalStateUnknown wrappers, which the reflector
+// hands to Delete on missed-delete relists. See rancher/rancher#55228:
+// before the fix the wrapper reached the after-delete hook's meta.Accessor
+// call, the hook errored, and the whole DELETE transaction rolled back —
+// so the row survived in the SQLite cache as stale data.
+func TestDeleteTombstone(t *testing.T) {
+	testObject := testStoreObject{Id: "something", Val: "a"}
+
+	t.Run("tombstone with payload — unwraps and deletes", func(t *testing.T) {
+		c, txC := SetupMockDB(t)
+		store := setupTombstoneStore(t, c)
+
+		var hookSawKey string
+		var hookSawObj any
+		store.RegisterAfterDelete(func(key string, obj any, _ db.TxClient) error {
+			hookSawKey = key
+			hookSawObj = obj
+			return nil
+		})
+
+		stmt := NewMockStmt(gomock.NewController(t))
+		txC.EXPECT().Stmt(store.deleteStmt).Return(stmt)
+		stmt.EXPECT().Exec(testObject.Id).Return(nil, nil)
+		c.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ bool, f db.WithTransactionFunction) {
+				require.NoError(t, f(txC))
+			})
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: testObject.Id, Obj: testObject}
+		require.NoError(t, store.Delete(tombstone))
+		require.Equal(t, testObject.Id, hookSawKey)
+		require.Equal(t, testObject, hookSawObj,
+			"after-delete hook must see the unwrapped object, not the tombstone wrapper")
+	})
+
+	t.Run("tombstone with nil payload — short-circuits", func(t *testing.T) {
+		c, _ := SetupMockDB(t)
+		store := setupTombstoneStore(t, c)
+
+		hookCalled := false
+		store.RegisterAfterDelete(func(string, any, db.TxClient) error {
+			hookCalled = true
+			return nil
+		})
+		// No EXPECT on WithTransaction — gomock will fail the test if Delete
+		// reaches the SQL path at all.
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: "ghost", Obj: nil}
+		require.NoError(t, store.Delete(tombstone))
+		require.False(t, hookCalled, "after-delete hook must not run for a nil-payload tombstone")
+	})
+}
+
+// setupTombstoneStore is a SetupStore variant whose keyFunc handles
+// cache.DeletedFinalStateUnknown (matching the real DeletionHandling
+// MetaNamespaceKeyFunc that production callers use).
+func setupTombstoneStore(t *testing.T, client *MockClient) *Store {
+	name := "testStoreObject"
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
+	keyFunc := func(obj any) (string, error) {
+		if t, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			return t.Key, nil
+		}
+		return obj.(testStoreObject).Id, nil
+	}
+	s, err := NewStore(context.Background(), testStoreObject{}, keyFunc, client, false, gvk, name, nil, nil)
+	require.NoError(t, err)
+	return s
 }
 
 // List returns a list of all the currently non-empty accumulators


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/55228

Backport of #1209 (release/v0.8) to release/v0.7 (Rancher 2.13, client-go v0.34). Same code path, same bug, same fix.

## Symptom

With the default `ui-sql-cache=true`, on a moderately busy downstream cluster the `cattle-cluster-agent` (`cluster-register` container) logs hundreds of identical errors per watch resync window:

```
level=error msg="Error in Store.Delete for type _v1_Event: transaction: object does not implement the Object interfaces"
```

Reported volume from one agent restart in the issue: 238 errors in one minute right after `_v1_Secret` informer init, 514 in a later resync minute. The error fires per resource instance, so anything with high churn (Events especially) amplifies the noise. And it's not just noise — see "Functional impact" below.

## Trigger

When the reflector loses its watch (network blip, apiserver-side watch timeout, `410 Gone` from a stale resourceVersion, etc.) and falls back to a fresh `List`, `DeltaFIFO.Replace` performs deletion detection: for every key it knew about that is no longer in the new list, it synthesizes a `Deleted` event wrapping the last-known object in `cache.DeletedFinalStateUnknown{Key, Obj}`. `processDeltas` then calls `clientState.Delete(tombstone)` — and `clientState` is steve's SQLite store.

```mermaid
sequenceDiagram
    autonumber
    participant API as kube-apiserver
    participant R as Reflector
    participant F as DeltaFIFO
    participant P as processDeltas
    participant S as steve Store.Delete<br/>(SQLite)
    participant H as notifyEventDeleted<br/>(after-delete hook)

    R->>API: List
    API-->>R: items [A, B, C]
    R->>F: Replace([A, B, C])
    F->>P: Sync deltas
    P->>S: Add(A), Add(B), Add(C)

    R->>API: Watch (RV)
    Note over R,API: watch dies (network/timeout/410)

    R->>API: List (re-list)
    API-->>R: items [A, C]  (B was deleted while watch was down)
    R->>F: Replace([A, C])
    Note over F: B missing → synthesize<br/>Deleted{DeletedFinalStateUnknown{key=B, Obj=B_lastKnown}}
    F->>P: Deleted delta (tombstone)
    P->>S: Delete(tombstone)

    rect rgb(255, 230, 230)
        S->>H: runAfterDelete(key, tombstone, tx)
        H->>H: meta.Accessor(tombstone) ❌<br/>"object does not implement the Object interfaces"
        H-->>S: error
        Note over S: WithTransaction rolls back<br/>→ SQL DELETE never commits<br/>→ B stays in SQLite cache
    end
```

The `clientState.Delete` call lands in `pkg/sqlcache/store/store.go`. The after-delete hook `notifyEventDeleted` in `pkg/sqlcache/informer/listoption_indexer.go` eventually calls `meta.Accessor` on the raw arg. `cache.DeletedFinalStateUnknown` does not implement `metav1.Object`, so the hook errors. Because the after-delete hook runs inside the same SQL transaction as the `DELETE FROM …`, the error rolls the whole transaction back.

## Functional impact

Not just log spam. Per `db.WithTransaction` in `pkg/sqlcache/db/client.go`, the after-delete hook's error rolls back the surrounding transaction — so the SQLite row that was about to be deleted **survives**. The cache then holds an entry for an object that no longer exists upstream, until the next full resync rebuilds the table. Any reads served from the SQLite cache during that window (the whole point of `ui-sql-cache=true`) will see the deleted object.

## Fix

Two layered changes:

1. **`Store.Delete` unwraps the tombstone.** `cache.Store` consumers are expected to tolerate `DeletedFinalStateUnknown` (that's why `DeletionHandlingMetaNamespaceKeyFunc` exists). After computing the key, unwrap the wrapper so all after-delete hooks see a typed object (or `nil`). If the wrapped `Obj` is `nil`, short-circuit: the FIFO's `knownObjects` is this same Store, so if its lookup failed we have nothing meaningful to do either. Logged at `warn` (not `error`) to keep the rare case visible without re-introducing the log flood.

2. **`notifyEventDeleted` collapses to a one-liner.** With the unwrap upstream, the hook no longer needs the `GetByKey` round-trip that fetched `oldObj`. That also removes its pre-existing `!exists` error path — which would have rolled the DELETE back on a missing cache entry, exactly the same failure shape this PR fixes.

Net effect:
- Bug fixed.
- One fewer SQLite read per delete in the steady-state path.
- The rare nil-payload tombstone degrades to a single warn log and a no-op, instead of an error stream and a stale row.

## Tests

Two new unit tests:

1. **`pkg/sqlcache/store/store_test.go` — `TestDeleteTombstone`** (mock-based, narrow regression).
   - `Store.Delete(DeletedFinalStateUnknown{Key, Obj})` must unwrap before invoking after-delete hooks. Verifies via a registered hook that it receives the typed object, not the tombstone wrapper.
   - `Store.Delete(DeletedFinalStateUnknown{Key, Obj: nil})` must short-circuit — no `WithTransaction`, no hooks. Verified by the absence of any mock `EXPECT` on those calls.

2. **`pkg/sqlcache/informer/relist_test.go` — `TestRelistAfterWatchError`** (behavioral, end-to-end through the reflector machinery).
   - Builds a real SQLite-backed `Store` + `ListOptionIndexer` + `SharedIndexInformer`, fed by a test-controlled `ListWatch` (no apiserver needed — the bug lives entirely inside steve's process once the reflector decides to relist).
   - Sequence: source returns `[A, B]` → informer syncs → both in SQLite → source now returns `[A]` only → fake watcher gets `watch.Error(Status{Gone})` → reflector's `handleWatch` exits with an error → `r.watch` returns → `ListAndWatch` returns → outer `Run` loop re-enters → fresh `List` → `DeltaFIFO.Replace` → tombstone for B → `processDeltas` → `Store.Delete(tombstone)`.
   - Asserts B is gone from SQLite and A is still present.

Without the fix, both tests fail; `TestRelistAfterWatchError` reproduces the exact error message from the issue.

Also verified: existing unit tests in `pkg/sqlcache/store` and `pkg/sqlcache/informer` still pass.

## Diff vs the v0.8 PR

- `notifyEventDeleted` keeps the `tx db.TxClient` parameter that v0.7's `notifyEvent` signature requires (v0.8 dropped that).
- `relist_test.go` doesn't wrap the source in `noWatchListListWatch` (that wrapper doesn't exist on v0.7's older client-go).