### PR TITLE
Fold Rows.Err into Close to fix WAL-pinning deadlock

### DIFF
--- a/pkg/sqlcache/db/client.go
+++ b/pkg/sqlcache/db/client.go
@@ -284,13 +284,7 @@ func (c *client) ReadObjects(rows Rows, typ reflect.Type) ([]any, error) {
 		}
 		result = append(result, dest)
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -312,13 +306,7 @@ func (c *client) ReadStrings(rows Rows) ([]string, error) {
 
 		result = append(result, key)
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -342,13 +330,7 @@ func (c *client) ReadStringIntString(rows Rows) ([][]string, error) {
 
 		result = append(result, []string{val1, strconv.Itoa(val2), val3})
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -375,13 +357,7 @@ func (c *client) ReadStringsN(rows Rows, numColumns int) ([][]string, error) {
 		}
 		result = append(result, stringList)
 	}
-	err := rows.Err()
-	if err != nil {
-		return nil, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
@@ -403,13 +379,7 @@ func (c *client) ReadInt(rows Rows) (int, error) {
 		return 0, closeRowsOnError(rows, err)
 	}
 
-	err = rows.Err()
-	if err != nil {
-		return 0, closeRowsOnError(rows, err)
-	}
-
-	err = rows.Close()
-	if err != nil {
+	if err := rows.Close(); err != nil {
 		return 0, err
 	}
 

--- a/pkg/sqlcache/db/client_test.go
+++ b/pkg/sqlcache/db/client_test.go
@@ -131,7 +131,6 @@ func TestQueryObjects(t *testing.T) {
 			*a[2].(*uint32) = keyId
 		})
 		d.EXPECT().Decrypt(testObjectSerialized, testObjectSerialized, keyId).Return(testObjectSerialized, nil)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
@@ -183,7 +182,6 @@ func TestQueryObjects(t *testing.T) {
 			*a[2].(*uint32) = keyId
 		})
 		d.EXPECT().Decrypt(testObjectSerialized, testObjectSerialized, keyId).Return(testObjectSerialized, nil)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
@@ -197,7 +195,6 @@ func TestQueryObjects(t *testing.T) {
 		d := SetupMockDecryptor(t)
 		r := SetupMockRows(t)
 		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		items, err := client.ReadObjects(r, reflect.TypeOf(testObject))
@@ -233,7 +230,6 @@ func TestQueryStrings(t *testing.T) {
 				*vk = testObject.Id
 			}
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
@@ -255,26 +251,6 @@ func TestQueryStrings(t *testing.T) {
 		assert.NotNil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "ReadStrings(), with one row, and Err() error", test: func(t *testing.T) {
-		c := SetupMockConnection(t)
-		e := SetupMockEncryptor(t)
-		d := SetupMockDecryptor(t)
-		r := SetupMockRows(t)
-		r.EXPECT().Next().Return(true)
-		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
-			for _, v := range a {
-				vk := v.(*string)
-				*vk = testObject.Id
-			}
-		})
-		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(fmt.Errorf("error"))
-		r.EXPECT().Close().Return(nil)
-		client := SetupClient(t, c, e, d)
-		_, err := client.ReadStrings(r)
-		assert.NotNil(t, err)
-	},
-	})
 	tests = append(tests, testCase{description: "ReadStrings(), with one row, and Close() error", test: func(t *testing.T) {
 		c := SetupMockConnection(t)
 		e := SetupMockEncryptor(t)
@@ -287,7 +263,6 @@ func TestQueryStrings(t *testing.T) {
 				*vk = testObject.Id
 			}
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Next().Return(false)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
@@ -301,7 +276,6 @@ func TestQueryStrings(t *testing.T) {
 		d := SetupMockDecryptor(t)
 		r := SetupMockRows(t)
 		r.EXPECT().Next().Return(false)
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		items, err := client.ReadStrings(r)
@@ -334,7 +308,6 @@ func TestReadInt(t *testing.T) {
 			p := a[0].(*int)
 			*p = testResult
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(nil)
 		client := SetupClient(t, c, e, d)
 		result, err := client.ReadInt(r)
@@ -355,22 +328,6 @@ func TestReadInt(t *testing.T) {
 		assert.NotNil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "One row, Err() error", test: func(t *testing.T) {
-		c := SetupMockConnection(t)
-		e := SetupMockEncryptor(t)
-		d := SetupMockDecryptor(t)
-		r := SetupMockRows(t)
-		r.EXPECT().Next().Return(true)
-		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
-			a[0] = testResult
-		})
-		r.EXPECT().Err().Return(fmt.Errorf("error"))
-		r.EXPECT().Close().Return(nil)
-		client := SetupClient(t, c, e, d)
-		_, err := client.ReadInt(r)
-		assert.NotNil(t, err)
-	},
-	})
 	tests = append(tests, testCase{description: "One row, Close() error", test: func(t *testing.T) {
 		c := SetupMockConnection(t)
 		e := SetupMockEncryptor(t)
@@ -380,7 +337,6 @@ func TestReadInt(t *testing.T) {
 		r.EXPECT().Scan(gomock.Any()).Do(func(a ...any) {
 			a[0] = testResult
 		})
-		r.EXPECT().Err().Return(nil)
 		r.EXPECT().Close().Return(fmt.Errorf("error"))
 		client := SetupClient(t, c, e, d)
 		_, err := client.ReadInt(r)

--- a/pkg/sqlcache/db/db_mocks_test.go
+++ b/pkg/sqlcache/db/db_mocks_test.go
@@ -55,20 +55,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/db/sqlwraps.go
+++ b/pkg/sqlcache/db/sqlwraps.go
@@ -14,12 +14,25 @@ type Row interface {
 	Scan(dest ...any) error
 }
 
-// Rows represents sql rows. It exposes method to navigate the rows, read their outputs, and close them.
+// Rows represents sql rows. It exposes methods to navigate the rows, read
+// their outputs, and close them.
+//
+// Note: Err is intentionally not part of this interface. Iteration errors
+// must be retrieved via Close, which closes the rows and returns the first
+// iteration error (or any close error). Combining them eliminates a footgun
+// with sql.RawBytes targets in Scan: the database/sql Rows.closemu RLock
+// kept open across Scan(*RawBytes) returns is released by Close but not by
+// Err, so calling Err before Close can deadlock against a concurrent
+// Rows.awaitDone writer queued behind the scan-held RLock. See Go issue
+// 60304 and rancher/steve#1206 for the full story.
 type Rows interface {
 	Next() bool
-	Err() error
-	Close() error
 	Scan(dest ...any) error
+	// Close releases any resources held by the rows and returns the first
+	// error encountered during iteration. If iteration succeeded, returns
+	// any error from closing. Close must be called exactly once after the
+	// caller is done iterating.
+	Close() error
 }
 
 // Stmt is an interface over a subset of sql.Stmt methods
@@ -42,12 +55,20 @@ type rows struct {
 	queryString string
 }
 
-// Err wraps the original *sql.Rows's Err() with a QueryError
-func (r rows) Err() error {
+// Close closes the underlying *sql.Rows and returns the first error
+// encountered during iteration (wrapped in QueryError). If iteration
+// succeeded, returns any error from closing.
+//
+// Close is called before reading Err so that any closemu RLock held open
+// across a prior Scan(*sql.RawBytes) call is released first - calling Err
+// while that RLock is outstanding can deadlock if a concurrent
+// Rows.awaitDone has queued a writer Lock on the same mutex.
+func (r rows) Close() error {
+	closeErr := r.Rows.Close()
 	if err := r.Rows.Err(); err != nil {
 		return &QueryError{QueryString: r.queryString, Err: err}
 	}
-	return nil
+	return closeErr
 }
 
 // stmt implements the Stmt interface, wrapping a sql.Stmt and keeping track of the original query string

--- a/pkg/sqlcache/informer/db_mocks_test.go
+++ b/pkg/sqlcache/informer/db_mocks_test.go
@@ -56,20 +56,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()

--- a/pkg/sqlcache/store/db_mocks_test.go
+++ b/pkg/sqlcache/store/db_mocks_test.go
@@ -56,20 +56,6 @@ func (mr *MockRowsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRows)(nil).Close))
 }
 
-// Err mocks base method.
-func (m *MockRows) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockRowsMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRows)(nil).Err))
-}
-
 // Next mocks base method.
 func (m *MockRows) Next() bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Backport of #1206 (`release/v0.7`) to `main`.

# Issue https://github.com/rancher/rancher/issues/55409

## Summary
- `decryptScanEvent` scans into `sql.RawBytes`, so `database/sql` keeps `Rows.closemu` RLocked across the `Scan` return (Go's `closemuScanHold`, [Go issue 60304](https://github.com/golang/go/issues/60304)).
- Calling `rows.Err()` before `rows.Close()` while that RLock is outstanding can wedge `rows.Err()` on a recursive RLock behind a writer queued by `Rows.awaitDone` (woken by a racing ctx cancel). The still-open `Rows` pins `Tx.closemu` so `Tx.rollback` wedges too. The SQLite read transaction never closes, the WAL cannot be reset, and writes append unboundedly (observed at 34 GB in production, SURE-11644).
- This PR removes `Err` from the `db.Rows` interface entirely. `Close` now returns the first iteration error (or any close error), so the unsafe ordering cannot be expressed at the type level. The wrapper's `Close` calls the underlying `sql.Rows.Close` first (which releases any scan-held RLock via `closemuRUnlockIfHeldByScan`), then reads `Err` safely.
- Callers in `pkg/sqlcache/db/client.go` (`ReadObjects`, `ReadStrings`, `ReadStringIntString`, `ReadStringsN`, `ReadInt`) collapse to a single `rows.Close()` at the end of iteration. Mocks regenerated; tests updated to drop redundant `Err` expectations.

## Differences vs the v0.7 PR
- The original PR also updated `ListOptionIndexer.Watch`'s backfill loop, which was the deadlock's entry point in production. On `main` `Watch` no longer reads from `sql.Rows` at all (it reads from an in-memory `eventLog`), so that file is untouched here. The interface change still applies.
- `ReadStringIntString` is new on `main` (didn't exist on v0.7) and used the old `Err`-before-`Close` pattern. It's updated here for consistency with the other readers.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test -count=1 ./pkg/sqlcache/db/... ./pkg/sqlcache/informer/... ./pkg/sqlcache/store/...\`