### PR TITLE
Skip projects cache build for secrets when projects schema is absent on downstream clusters

### DIFF
--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -1203,26 +1203,31 @@ func (s *Store) cacheForWithDeps(ctx context.Context, apiOp *types.APIRequest, a
 			s.cacheFactory.DoneWithCache(mgmtClusterInf)
 		})
 	} else if gvk == secretGVK {
-		mcioProjectSchema := types.APISchema{
-			Schema: &schemas.Schema{
-				Attributes: map[string]interface{}{
-					"group":      "management.cattle.io",
-					"version":    "v3",
-					"kind":       "Project",
-					"resource":   "projects",
-					"verbs":      []string{"get", "list", "watch"},
-					"namespaced": true,
+		// v1.secrets depend on management.cattle.io.projects.
+		// On clusters without the projects CRD — every downstream cluster —
+		// the reflector LIST returns 404 forever, WaitForCacheSync never
+		// returns, and every /v1/secrets request hangs.
+		if id := s.schemas.ByGVK(mcioProjectGvk); id != "" {
+			mcioProjectSchema := types.APISchema{
+				Schema: &schemas.Schema{
+					Attributes: map[string]interface{}{
+						"group":      "management.cattle.io",
+						"version":    "v3",
+						"kind":       "Project",
+						"resource":   "projects",
+						"verbs":      []string{"get", "list", "watch"},
+						"namespaced": true,
+					},
 				},
-			},
+			}
+			mcioProjectInf, err := s.cacheFor(ctx, nil, &mcioProjectSchema)
+			if err != nil {
+				return nil, nil, err
+			}
+			doneCacheFns = append(doneCacheFns, func() {
+				s.cacheFactory.DoneWithCache(mcioProjectInf)
+			})
 		}
-		// v1.secrets depend on management.cattle.io.projects
-		mcioProjectInf, err := s.cacheFor(ctx, nil, &mcioProjectSchema)
-		if err != nil {
-			return nil, nil, err
-		}
-		doneCacheFns = append(doneCacheFns, func() {
-			s.cacheFactory.DoneWithCache(mcioProjectInf)
-		})
 	}
 
 	inf, err := s.cacheFor(ctx, apiOp, apiSchema)


### PR DESCRIPTION
Fixes [rancher/rancher#55180](https://github.com/rancher/rancher/issues/55180).

## Problem

`cacheForWithDeps` builds a `management.cattle.io/v3 Project` cache as a dependency of the `v1 Secret` cache (added in #1079). On clusters without the projects CRD — every downstream cluster — the reflector LIST returns 404 forever, `WaitForCacheSync` never returns, and every `/v1/secrets` request hangs. The Cluster Explorer Secrets page on downstream clusters shows a perpetual spinner.

## Fix

Gate the projects-cache build on whether the project schema is registered on this steve instance : same pattern as the `pcioClusterGvk` codebase above immediately. 