### PR TITLE
Detect aggregated APIs and add watch-list policy

### DIFF
--- a/pkg/attributes/attributes.go
+++ b/pkg/attributes/attributes.go
@@ -227,3 +227,15 @@ func CRDJSONPathParsers(s *types.APISchema) map[string]*jsonpath.JSONPath {
 
 	return result
 }
+
+// Aggregated reports whether the schema's resource is served by an aggregated (extension) API server rather than by kube-apiserver.
+func Aggregated(s *types.APISchema) bool {
+	if s == nil {
+		return false
+	}
+	return convert.ToBool(s.Attributes["aggregated"])
+}
+
+func SetAggregated(s *types.APISchema, value bool) {
+	setVal(s, "aggregated", value)
+}

--- a/pkg/attributes/attributes_test.go
+++ b/pkg/attributes/attributes_test.go
@@ -1,0 +1,42 @@
+package attributes
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	wschemas "github.com/rancher/wrangler/v3/pkg/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+func newSchema() *types.APISchema {
+	return &types.APISchema{Schema: &wschemas.Schema{}}
+}
+
+func TestAggregated(t *testing.T) {
+	t.Run("nil schema is not aggregated", func(t *testing.T) {
+		assert.False(t, Aggregated(nil))
+	})
+
+	t.Run("unset attribute defaults to not aggregated", func(t *testing.T) {
+		assert.False(t, Aggregated(newSchema()))
+	})
+
+	t.Run("set true", func(t *testing.T) {
+		s := newSchema()
+		SetAggregated(s, true)
+		assert.True(t, Aggregated(s))
+	})
+
+	t.Run("set false", func(t *testing.T) {
+		s := newSchema()
+		SetAggregated(s, false)
+		assert.False(t, Aggregated(s))
+	})
+
+	t.Run("overwrite true with false", func(t *testing.T) {
+		s := newSchema()
+		SetAggregated(s, true)
+		SetAggregated(s, false)
+		assert.False(t, Aggregated(s))
+	})
+}

--- a/pkg/clustercache/controller.go
+++ b/pkg/clustercache/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/attributes"
 	"github.com/rancher/steve/pkg/schema"
+	"github.com/rancher/steve/pkg/watchlist"
 	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/rancher/wrangler/v3/pkg/summary/client"
 	"github.com/rancher/wrangler/v3/pkg/summary/informer"
@@ -150,7 +151,12 @@ func (h *clusterCache) OnSchemas(schemas *schema.Collection) error {
 		opts := &client.Options{
 			Schema: schema.Schema,
 		}
-		summaryInformer := informer.NewFilteredSummaryInformerWithOptions(h.summaryClient, gvr, opts, metav1.NamespaceAll, 2*time.Hour,
+		summaryClient := h.summaryClient
+		if watchlist.Disabled(schema) {
+			// Non-whitelisted aggregated API: disable watch-list (fall back to LIST+WATCH).
+			summaryClient = &noWatchListClient{ExtendedInterface: h.summaryClient}
+		}
+		summaryInformer := informer.NewFilteredSummaryInformerWithOptions(summaryClient, gvr, opts, metav1.NamespaceAll, 2*time.Hour,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, nil)
 		ctx, cancel := context.WithCancel(h.ctx)
 		w := &watcher{
@@ -299,4 +305,13 @@ func callAll(handlers []interface{}, gvr schema2.GroupVersionKind, key string, o
 	}
 
 	return obj, merr.NewErrors(errs...)
+}
+
+// noWatchListClient wraps a summary client so its informer disables watch-list (via IsWatchListSemanticsUnSupported) and falls back to LIST+WATCH.
+type noWatchListClient struct {
+	client.ExtendedInterface
+}
+
+func (n *noWatchListClient) IsWatchListSemanticsUnSupported() bool {
+	return true
 }

--- a/pkg/controllers/schema/schemas.go
+++ b/pkg/controllers/schema/schemas.go
@@ -19,6 +19,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	apiv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -40,14 +41,15 @@ func (s SchemasHandlerFunc) OnSchemas(schemas *schema2.Collection) error {
 type handler struct {
 	sync.Mutex
 
-	ctx       context.Context
-	toSync    int32
-	schemas   *schema2.Collection
-	client    discovery.DiscoveryInterface
-	cols      *common.DynamicColumns
-	crdClient apiextcontrollerv1.CustomResourceDefinitionClient
-	ssar      authorizationv1client.SelfSubjectAccessReviewInterface
-	handler   SchemasHandlerFunc
+	ctx             context.Context
+	toSync          int32
+	schemas         *schema2.Collection
+	client          discovery.DiscoveryInterface
+	cols            *common.DynamicColumns
+	crdClient       apiextcontrollerv1.CustomResourceDefinitionClient
+	apiServiceCache v1.APIServiceCache
+	ssar            authorizationv1client.SelfSubjectAccessReviewInterface
+	handler         SchemasHandlerFunc
 }
 
 func Register(ctx context.Context,
@@ -60,13 +62,14 @@ func Register(ctx context.Context,
 	schemas *schema2.Collection) {
 
 	h := &handler{
-		ctx:       ctx,
-		cols:      cols,
-		client:    discovery,
-		schemas:   schemas,
-		handler:   schemasHandler,
-		crdClient: crd,
-		ssar:      ssar,
+		ctx:             ctx,
+		cols:            cols,
+		client:          discovery,
+		schemas:         schemas,
+		handler:         schemasHandler,
+		crdClient:       crd,
+		apiServiceCache: apiService.Cache(),
+		ssar:            ssar,
 	}
 
 	apiService.OnChange(ctx, "schema", h.OnChangeAPIService)
@@ -159,6 +162,12 @@ func (h *handler) refreshAll(ctx context.Context) error {
 	schemas, err := converter.ToSchemas(h.crdClient, h.client)
 	if err != nil {
 		return err
+	}
+
+	if apiServices, err := h.apiServiceCache.List(labels.Everything()); err != nil {
+		logrus.Warnf("failed to list APIServices for aggregation detection: %v", err)
+	} else {
+		converter.AddAPIServiceAggregation(apiServices, schemas)
 	}
 
 	filteredSchemas := map[string]*types.APISchema{}

--- a/pkg/schema/converter/aggregation.go
+++ b/pkg/schema/converter/aggregation.go
@@ -1,0 +1,35 @@
+package converter
+
+import (
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/attributes"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+// AddAPIServiceAggregation marks schemas whose group/version is served by an aggregated (extension) API server (an APIService with a non-nil .spec.service).
+func AddAPIServiceAggregation(apiServices []*apiregv1.APIService, schemas map[string]*types.APISchema) {
+	type groupVersion struct {
+		group   string
+		version string
+	}
+
+	aggregated := make(map[groupVersion]bool)
+	for _, apiService := range apiServices {
+		if apiService == nil || apiService.Spec.Service == nil {
+			// nil .spec.service => served locally by kube-apiserver (built-in/CRD).
+			continue
+		}
+		aggregated[groupVersion{apiService.Spec.Group, apiService.Spec.Version}] = true
+	}
+
+	if len(aggregated) == 0 {
+		return
+	}
+
+	for _, schema := range schemas {
+		gv := groupVersion{attributes.Group(schema), attributes.Version(schema)}
+		if aggregated[gv] {
+			attributes.SetAggregated(schema, true)
+		}
+	}
+}

--- a/pkg/schema/converter/aggregation_test.go
+++ b/pkg/schema/converter/aggregation_test.go
@@ -1,0 +1,41 @@
+package converter
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/attributes"
+	wschemas "github.com/rancher/wrangler/v3/pkg/schemas"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+func schemaFor(gvk schema.GroupVersionKind) *types.APISchema {
+	s := &types.APISchema{Schema: &wschemas.Schema{}}
+	attributes.SetGVK(s, gvk)
+	return s
+}
+
+func TestAddAPIServiceAggregation(t *testing.T) {
+	aggregated := schema.GroupVersionKind{Group: "ext.example", Version: "v1", Kind: "Foo"}
+	otherVersion := schema.GroupVersionKind{Group: "ext.example", Version: "v2", Kind: "Foo"}
+	builtin := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	schemas := map[string]*types.APISchema{
+		"aggregated":   schemaFor(aggregated),
+		"otherVersion": schemaFor(otherVersion),
+		"builtin":      schemaFor(builtin),
+	}
+	apiServices := []*apiregv1.APIService{
+		{Spec: apiregv1.APIServiceSpec{Group: "ext.example", Version: "v1", Service: &apiregv1.ServiceReference{}}}, // aggregated
+		{Spec: apiregv1.APIServiceSpec{Group: "apps", Version: "v1"}},                                              // local (built-in): nil .spec.service
+		nil,
+	}
+
+	AddAPIServiceAggregation(apiServices, schemas)
+
+	assert.True(t, attributes.Aggregated(schemas["aggregated"]), "aggregated group/version should be tagged")
+	assert.False(t, attributes.Aggregated(schemas["otherVersion"]), "same group, different version should not be tagged")
+	assert.False(t, attributes.Aggregated(schemas["builtin"]), "built-in (local APIService) should not be tagged")
+}

--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -57,7 +57,7 @@ type guardedInformer struct {
 	wg sync.WaitGroup
 }
 
-type newInformer func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespace bool, watchable bool, gcKeepCount int) (*informer.Informer, error)
+type newInformer func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespace bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error)
 
 type Cache struct {
 	informer.ByOptionsLister
@@ -148,7 +148,7 @@ func logCacheInitializationDuration(gvk schema.GroupVersionKind) func() {
 //     a context for a single cache to be able to stop that cache (eg: on schema refresh) without impacting the other caches.
 //
 // Don't forget to call DoneWithCache with the given informer once done with it.
-func (f *CacheFactory) CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (*Cache, error) {
+func (f *CacheFactory) CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) (*Cache, error) {
 	// Second, check if the informer and its accompanying informer-specific mutex exist already in the informers cache
 	// If not, start by creating such informer-specific mutex. That is used later to ensure no two goroutines create
 	// informers for the same GVK at the same type
@@ -171,7 +171,7 @@ func (f *CacheFactory) CacheFor(ctx context.Context, fields map[string]informer.
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		if initialized, err := f.ensureInformerInitialized(gi, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable); err != nil {
+		if initialized, err := f.ensureInformerInitialized(gi, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable, disableWatchList); err != nil {
 			return nil, err
 		} else if gi.informer == nil {
 			// Special case for race condition: if Stop() is called while or immediately after this informer was initialized
@@ -198,7 +198,7 @@ func (f *CacheFactory) CacheFor(ctx context.Context, fields map[string]informer.
 
 // ensureInformerInitialized handles the informer initialization, if needed, in which case, it returns true
 // On success with gi.mutex.RLock() held
-func (f *CacheFactory) ensureInformerInitialized(gi *guardedInformer, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (bool, error) {
+func (f *CacheFactory) ensureInformerInitialized(gi *guardedInformer, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) (bool, error) {
 	// Fast path: read-lock and informer already initialized
 	gi.mutex.RLock()
 	if gi.informer != nil {
@@ -216,7 +216,7 @@ func (f *CacheFactory) ensureInformerInitialized(gi *guardedInformer, fields map
 		return false, nil
 	}
 
-	if err := f.initializeInformerLocked(gi, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable); err != nil {
+	if err := f.initializeInformerLocked(gi, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable, disableWatchList); err != nil {
 		gi.mutex.Unlock()
 		// Error logging is already handled in initializeInformerLocked or caller can handle it
 		return false, err
@@ -228,12 +228,12 @@ func (f *CacheFactory) ensureInformerInitialized(gi *guardedInformer, fields map
 	return true, nil
 }
 
-func (f *CacheFactory) initializeInformerLocked(gi *guardedInformer, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) error {
+func (f *CacheFactory) initializeInformerLocked(gi *guardedInformer, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) error {
 	_, encryptResourceAlways := defaultEncryptedResourceTypes[gvk]
 	shouldEncrypt := f.encryptAll || encryptResourceAlways
 	// In non-test code this invokes pkg/sqlcache/informer/informer.go: NewInformer()
 	// search for "func NewInformer(ctx"
-	i, err := f.newInformer(gi.ctx, client, fields, externalUpdateInfo, selfUpdateInfo, transform, gvk, f.dbClient, shouldEncrypt, namespaced, watchable, f.gcKeepCount)
+	i, err := f.newInformer(gi.ctx, client, fields, externalUpdateInfo, selfUpdateInfo, transform, gvk, f.dbClient, shouldEncrypt, namespaced, watchable, disableWatchList, f.gcKeepCount)
 	if err != nil {
 		log.Errorf("creating informer for %v: %v", gvk, err)
 		return err

--- a/pkg/sqlcache/informer/factory/informer_factory_test.go
+++ b/pkg/sqlcache/informer/factory/informer_factory_test.go
@@ -77,7 +77,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -99,14 +99,14 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(5 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
 		assert.NotNil(t, c.ctx)
 		// this sleep is critical to the test. It ensure there has been enough time for expected function like Run to be invoked in their go routines.
 		time.Sleep(1 * time.Second)
-		c2, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c2, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, c, c2)
 	}})
@@ -128,7 +128,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -149,7 +149,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(1 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		_, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		_, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.NotNil(t, err)
 		time.Sleep(2 * time.Second)
 	}})
@@ -171,7 +171,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -192,7 +192,7 @@ func TestCacheFor(t *testing.T) {
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(1)*time.Second)
 			defer cancel()
-			_, err := f.CacheFor(ctx, fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+			_, err := f.CacheFor(ctx, fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 			errCh <- err
 		}()
 
@@ -223,7 +223,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -241,7 +241,7 @@ func TestCacheFor(t *testing.T) {
 		f.ctx, f.cancel = context.WithCancel(context.Background())
 		f.Stop(expectedGVK)
 
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -265,7 +265,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -287,7 +287,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -316,7 +316,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -338,7 +338,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -366,7 +366,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -388,7 +388,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -416,7 +416,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			// we can't test func == func, so instead we check if the output was as expected
 			input := "someinput"
 			ouput, err := transform(input)
@@ -446,7 +446,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(5 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, transformFunc, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, transformFunc, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -470,7 +470,7 @@ func TestCacheFor(t *testing.T) {
 			SharedIndexInformer: sii,
 			ByOptionsLister:     bloi,
 		}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			assert.Equal(t, client, dynamicClient)
 			assert.Equal(t, fields, fields)
 			assert.Equal(t, expectedGVK, gvk)
@@ -493,7 +493,7 @@ func TestCacheFor(t *testing.T) {
 			time.Sleep(10 * time.Second)
 			f.Stop(expectedGVK)
 		}()
-		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		c, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, i, c.ByOptionsLister)
 		assert.Equal(t, expectedGVK, c.gvk)
@@ -507,7 +507,7 @@ func TestCacheFor(t *testing.T) {
 		field := &informer.JSONPathField{Path: []string{"something"}}
 		fields := map[string]informer.IndexedField{field.ColumnName(): field}
 		expectedGVK := schema.GroupVersionKind{}
-		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, gcKeepCount int) (*informer.Informer, error) {
+		testNewInformer := func(ctx context.Context, client dynamic.ResourceInterface, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool, namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*informer.Informer, error) {
 			return nil, fmt.Errorf("fake error")
 		}
 		f := &CacheFactory{
@@ -517,7 +517,7 @@ func TestCacheFor(t *testing.T) {
 			informers:   map[schema.GroupVersionKind]*guardedInformer{},
 		}
 		f.ctx, f.cancel = context.WithCancel(context.Background())
-		_, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true)
+		_, err := f.CacheFor(context.Background(), fields, nil, nil, nil, dynamicClient, expectedGVK, false, true, false)
 		assert.Error(t, err)
 		err = f.Stop(expectedGVK)
 		assert.NoError(t, err)

--- a/pkg/sqlcache/informer/informer.go
+++ b/pkg/sqlcache/informer/informer.go
@@ -80,7 +80,7 @@ var newInformer = cache.NewSharedIndexInformer
 // NewInformer returns a new SQLite-backed Informer for the type specified by schema in unstructured.Unstructured form
 // using the specified client
 func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields map[string]IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, gvk schema.GroupVersionKind, db db.Client, shouldEncrypt bool,
-	namespaced bool, watchable bool, gcKeepCount int) (*Informer, error) {
+	namespaced bool, watchable bool, disableWatchList bool, gcKeepCount int) (*Informer, error) {
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		return client.Watch(ctx, options)
 	}
@@ -128,9 +128,15 @@ func NewInformer(ctx context.Context, client dynamic.ResourceInterface, fields m
 	// We therefore just disable it right away.
 	resyncPeriod := time.Duration(0)
 
+	// When requested (non-whitelisted aggregated API), disable watch-list so the reflector falls back to LIST+WATCH.
+	var lw cache.ListerWatcher = listWatcher
+	if disableWatchList {
+		lw = &noWatchListListWatcher{ListWatch: listWatcher}
+	}
+
 	// In non-test mode `newInformer` is cache.NewSharedIndexInformer
 	// defined in k8s.io/client-go/tools/cache/shared_informer.go : func NewSharedIndexInformer(lw ...
-	sii := newInformer(listWatcher, example, resyncPeriod, cache.Indexers{})
+	sii := newInformer(lw, example, resyncPeriod, cache.Indexers{})
 	if transform != nil {
 		if err := sii.SetTransform(transform); err != nil {
 			return nil, err
@@ -199,4 +205,13 @@ func SetSyntheticWatchableInterval(interval time.Duration) {
 
 func informerNameFromGVK(gvk schema.GroupVersionKind) string {
 	return gvk.Group + "_" + gvk.Version + "_" + gvk.Kind
+}
+
+// noWatchListListWatcher wraps a ListWatch so its reflector disables watch-list (via IsWatchListSemanticsUnSupported) and falls back to LIST+WATCH.
+type noWatchListListWatcher struct {
+	*cache.ListWatch
+}
+
+func (n *noWatchListListWatcher) IsWatchListSemanticsUnSupported() bool {
+	return true
 }

--- a/pkg/sqlcache/informer/informer_test.go
+++ b/pkg/sqlcache/informer/informer_test.go
@@ -76,10 +76,54 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, false, 0)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
+	}})
+	tests = append(tests, testCase{description: "NewInformer() with disableWatchList wraps the lister-watcher to disable watch-list", test: func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dbClient := NewMockClient(ctrl)
+		txClient := NewMockTxClient(ctrl)
+		dynamicClient := NewMockResourceInterface(ctrl)
+		stmt := NewMockStmt(ctrl)
+		mockInformer := mockInformer{}
+		var capturedLW cache.ListerWatcher
+		newInformer = func(lw cache.ListerWatcher, exampleObject runtime.Object, defaultEventHandlerResyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+			capturedLW = lw
+			return &mockInformer
+		}
+		defer func() { newInformer = cache.NewSharedIndexInformer }()
+
+		field := &JSONPathField{Path: []string{"something"}}
+		fields := map[string]IndexedField{field.ColumnName(): field}
+		gvk := schema.GroupVersionKind{}
+
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(2)
+		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
+			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
+				assert.Nil(t, f(txClient))
+			})
+		dbClient.EXPECT().Prepare(gomock.Any()).Return(stmt, nil).AnyTimes()
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(3)
+		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
+			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
+				assert.Nil(t, f(txClient))
+			})
+		txClient.EXPECT().Exec(gomock.Any()).Return(nil, nil).Times(9)
+		dbClient.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
+			func(ctx context.Context, shouldEncrypt bool, f db.WithTransactionFunction) {
+				assert.Nil(t, f(txClient))
+			})
+
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, true, 0)
+		assert.Nil(t, err)
+
+		wrapped, ok := capturedLW.(*noWatchListListWatcher)
+		assert.True(t, ok, "expected lister-watcher to be wrapped in noWatchListListWatcher when disableWatchList is true")
+		if ok {
+			assert.True(t, wrapped.IsWatchListSemanticsUnSupported())
+		}
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewStore(), should return an error", test: func(t *testing.T) {
 		dbClient := NewMockClient(gomock.NewController(t))
@@ -101,7 +145,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, false, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewIndexer(), should return an error", test: func(t *testing.T) {
@@ -138,7 +182,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, false, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewListOptionIndexer(), should return an error", test: func(t *testing.T) {
@@ -186,7 +230,7 @@ func TestNewInformer(t *testing.T) {
 				}
 			})
 
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, nil, gvk, dbClient, false, true, true, false, 0)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with transform func", test: func(t *testing.T) {
@@ -245,7 +289,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0)
+		informer, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, false, 0)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -282,7 +326,7 @@ func TestNewInformer(t *testing.T) {
 		transformFunc := func(input interface{}) (interface{}, error) {
 			return "someoutput", nil
 		}
-		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, 0)
+		_, err := NewInformer(context.Background(), dynamicClient, fields, nil, nil, transformFunc, gvk, dbClient, false, true, true, false, 0)
 		assert.Error(t, err)
 		newInformer = cache.NewSharedIndexInformer
 	}})

--- a/pkg/sqlcache/integration_test.go
+++ b/pkg/sqlcache/integration_test.go
@@ -501,7 +501,7 @@ func (i *IntegrationSuite) createCacheAndFactory(fields [][]string, transformFun
 		indexedFields[field.ColumnName()] = field
 	}
 
-	cache, err := cacheFactory.CacheFor(context.Background(), indexedFields, nil, nil, transformFunc, dynamicResource, configMapGVK, true, true)
+	cache, err := cacheFactory.CacheFor(context.Background(), indexedFields, nil, nil, transformFunc, dynamicResource, configMapGVK, true, true, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to make cache: %w", err)
 	}

--- a/pkg/stores/sqlproxy/proxy_mocks_test.go
+++ b/pkg/stores/sqlproxy/proxy_mocks_test.go
@@ -285,18 +285,18 @@ func (m *MockCacheFactory) EXPECT() *MockCacheFactoryMockRecorder {
 }
 
 // CacheFor mocks base method.
-func (m *MockCacheFactory) CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced, watchable bool) (*factory.Cache, error) {
+func (m *MockCacheFactory) CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced, watchable, disableWatchList bool) (*factory.Cache, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheFor", ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable)
+	ret := m.ctrl.Call(m, "CacheFor", ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable, disableWatchList)
 	ret0, _ := ret[0].(*factory.Cache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CacheFor indicates an expected call of CacheFor.
-func (mr *MockCacheFactoryMockRecorder) CacheFor(ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable any) *gomock.Call {
+func (mr *MockCacheFactoryMockRecorder) CacheFor(ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable, disableWatchList any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheFor", reflect.TypeOf((*MockCacheFactory)(nil).CacheFor), ctx, fields, externalUpdateInfo, selfUpdateInfo, transform, client, gvk, namespaced, watchable, disableWatchList)
 }
 
 // DoneWithCache mocks base method.

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -37,6 +37,7 @@ import (
 	metricsStore "github.com/rancher/steve/pkg/stores/metrics"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/listprocessor"
 	"github.com/rancher/steve/pkg/stores/sqlproxy/tablelistconvert"
+	"github.com/rancher/steve/pkg/watchlist"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -448,7 +449,7 @@ type Store struct {
 type CacheFactoryInitializer func() (CacheFactory, error)
 
 type CacheFactory interface {
-	CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool) (*factory.Cache, error)
+	CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) (*factory.Cache, error)
 	DoneWithCache(*factory.Cache)
 	Stop(gvk schema.GroupVersionKind) error
 }
@@ -554,7 +555,8 @@ func (s *Store) initializeNamespaceCache() error {
 		tableClient,
 		gvk,
 		false,
-		true)
+		true,
+		watchlist.Disabled(nsSchema))
 	if err != nil {
 		return err
 	}
@@ -1278,7 +1280,7 @@ func (s *Store) cacheFor(ctx context.Context, apiOp *types.APIRequest, apiSchema
 	transformFunc := s.transformBuilder.GetTransformFunc(gvk, cols, attributes.IsCRD(apiSchema), attributes.CRDJSONPathParsers(apiSchema))
 	tableClient := &tablelistconvert.Client{ResourceInterface: client}
 	ns := attributes.Namespaced(apiSchema)
-	inf, err := s.cacheFactory.CacheFor(ctx, fields, externalGVKDependencies[gvk], selfGVKDependencies[gvk], transformFunc, tableClient, gvk, ns, controllerschema.IsListWatchable(apiSchema))
+	inf, err := s.cacheFactory.CacheFor(ctx, fields, externalGVKDependencies[gvk], selfGVKDependencies[gvk], transformFunc, tableClient, gvk, ns, controllerschema.IsListWatchable(apiSchema), watchlist.Disabled(apiSchema))
 	if err != nil {
 		return nil, fmt.Errorf("cachefor %v: %w", gvk, err)
 	}

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -122,7 +122,7 @@ func TestNewProxyStore(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(nsSchema),
 				false,
-				true).Return(c, nil)
+				true, gomock.Any()).Return(c, nil)
 			s, err := NewProxyStore(context.Background(), scc, cg, rn, nil, sc, cf, true)
 			assert.Nil(t, err)
 			assert.Equal(t, scc, s.columnSetter)
@@ -260,7 +260,7 @@ func TestNewProxyStore(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(nsSchema),
 				false,
-				true).Return(nil, fmt.Errorf("error"))
+				true, gomock.Any()).Return(nil, fmt.Errorf("error"))
 
 			s, err := NewProxyStore(context.Background(), scc, cg, rn, nil, sc, cf, true)
 			assert.Nil(t, err)
@@ -379,7 +379,7 @@ func TestListByPartitions(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(schema),
 				attributes.Namespaced(schema),
-				true).Return(c, nil)
+				true, gomock.Any()).Return(c, nil)
 			cf.EXPECT().DoneWithCache(c)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), []common.ColumnDefinition{{Field: "some.field"}}, false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			bloi.EXPECT().ListByOptions(gomock.Cond(isDerivedContext), &opts, partitions, req.Namespace).Return(listToReturn, len(listToReturn.Items), nil, "", nil)
@@ -554,7 +554,7 @@ func TestListByPartitions(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(schema),
 				attributes.Namespaced(schema),
-				false).Return(c, nil)
+				false, gomock.Any()).Return(c, nil)
 			cf.EXPECT().DoneWithCache(c)
 
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), []common.ColumnDefinition{{Field: "some.field"}}, false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
@@ -651,7 +651,7 @@ func TestListByPartitions(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(schema),
 				attributes.Namespaced(schema),
-				true).Return(nil, fmt.Errorf("error"))
+				true, gomock.Any()).Return(nil, fmt.Errorf("error"))
 
 			_, _, _, _, err = s.ListByPartitions(req, schema, partitions)
 			assert.NotNil(t, err)
@@ -746,7 +746,7 @@ func TestListByPartitions(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(schema),
 				attributes.Namespaced(schema),
-				true).Return(c, nil)
+				true, gomock.Any()).Return(c, nil)
 			cf.EXPECT().DoneWithCache(c)
 			bloi.EXPECT().ListByOptions(gomock.Cond(isDerivedContext), &opts, partitions, req.Namespace).Return(nil, 0, nil, "", fmt.Errorf("error"))
 			tb.EXPECT().GetTransformFunc(attributes.GVK(schema), gomock.Any(), false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
@@ -920,7 +920,7 @@ func TestAugmentRelationships(t *testing.T) {
 				gomock.Any(), // can't do (*tablelistconvert.Client)(nil),
 				attributes.GVK(podSchema),
 				attributes.Namespaced(podSchema),
-				true).Return(c, nil)
+				true, gomock.Any()).Return(c, nil)
 			tb.EXPECT().GetTransformFunc(podGVK, gomock.Any(), false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			cf.EXPECT().DoneWithCache(c)
 			bloi.EXPECT().AugmentList(ctx, &originalList, gomock.Any(), gomock.Any(), true, gomock.Any()).Return(nil)
@@ -1053,7 +1053,7 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(theSchema),
 				attributes.Namespaced(theSchema),
-				true).Return(c, nil)
+				true, gomock.Any()).Return(c, nil)
 			cf.EXPECT().DoneWithCache(c)
 			tb.EXPECT().GetTransformFunc(attributes.GVK(theSchema), gomock.Any(), false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 
@@ -1127,7 +1127,7 @@ func TestReset(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(nsSchema),
 				false,
-				true).Return(nsc, nil)
+				true, gomock.Any()).Return(nsc, nil)
 			cf.EXPECT().DoneWithCache(nsc)
 			tb.EXPECT().GetTransformFunc(gvk, gomock.Any(), false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			err := s.Reset(gvk)
@@ -1289,7 +1289,7 @@ func TestReset(t *testing.T) {
 				&tablelistconvert.Client{ResourceInterface: ri},
 				attributes.GVK(nsSchema),
 				false,
-				true).Return(nil, fmt.Errorf("error"))
+				true, gomock.Any()).Return(nil, fmt.Errorf("error"))
 			tb.EXPECT().GetTransformFunc(gvk, gomock.Any(), false, nil).Return(func(obj interface{}) (interface{}, error) { return obj, nil })
 			err := s.Reset(gvk)
 			assert.NotNil(t, err)

--- a/pkg/watchlist/policy.go
+++ b/pkg/watchlist/policy.go
@@ -8,7 +8,10 @@ import (
 )
 
 // Whitelist holds aggregated (external) GVKs known to implement watch-list correctly, which may therefore keep watch-list enabled.
-var Whitelist = map[schema.GroupVersionKind]bool{}
+var Whitelist = map[schema.GroupVersionKind]bool{
+	{Group: "ext.cattle.io", Version: "v1", Kind: "Token"}:      true,
+	{Group: "ext.cattle.io", Version: "v1", Kind: "Kubeconfig"}: true,
+}
 
 // Disabled reports whether watch-list should be disabled for the schema's informer: true only for aggregated, non-whitelisted APIs (nil and built-in stay enabled, failing safe).
 func Disabled(s *types.APISchema) bool {

--- a/pkg/watchlist/policy.go
+++ b/pkg/watchlist/policy.go
@@ -1,0 +1,24 @@
+// Package watchlist decides whether Steve's informers use the client-go watch-list protocol (sendInitialEvents) or fall back to LIST+WATCH.
+package watchlist
+
+import (
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/attributes"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Whitelist holds aggregated (external) GVKs known to implement watch-list correctly, which may therefore keep watch-list enabled.
+var Whitelist = map[schema.GroupVersionKind]bool{}
+
+// Disabled reports whether watch-list should be disabled for the schema's informer: true only for aggregated, non-whitelisted APIs (nil and built-in stay enabled, failing safe).
+func Disabled(s *types.APISchema) bool {
+	if s == nil {
+		return false
+	}
+	if !attributes.Aggregated(s) {
+		// Built-in (core + CRDs): compliant by construction.
+		return false
+	}
+	// Aggregated: only allowed to use watch-list if explicitly whitelisted.
+	return !Whitelist[attributes.GVK(s)]
+}

--- a/pkg/watchlist/policy_test.go
+++ b/pkg/watchlist/policy_test.go
@@ -1,0 +1,53 @@
+package watchlist
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/attributes"
+	wschemas "github.com/rancher/wrangler/v3/pkg/schemas"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func builtinSchema(gvk schema.GroupVersionKind) *types.APISchema {
+	s := &types.APISchema{Schema: &wschemas.Schema{}}
+	attributes.SetGVK(s, gvk)
+	return s
+}
+
+func aggregatedSchema(gvk schema.GroupVersionKind) *types.APISchema {
+	s := builtinSchema(gvk)
+	attributes.SetAggregated(s, true)
+	return s
+}
+
+func TestDisabled(t *testing.T) {
+	deploymentGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	antreaGVK := schema.GroupVersionKind{Group: "controlplane.antrea.io", Version: "v1beta2", Kind: "AddressGroup"}
+
+	t.Run("nil schema keeps watch-list enabled", func(t *testing.T) {
+		assert.False(t, Disabled(nil))
+	})
+
+	t.Run("built-in resource keeps watch-list enabled", func(t *testing.T) {
+		assert.False(t, Disabled(builtinSchema(deploymentGVK)))
+	})
+
+	t.Run("aggregated resource not whitelisted disables watch-list", func(t *testing.T) {
+		assert.True(t, Disabled(aggregatedSchema(antreaGVK)))
+	})
+
+	t.Run("aggregated resource on the whitelist keeps watch-list enabled", func(t *testing.T) {
+		Whitelist[antreaGVK] = true
+		t.Cleanup(func() { delete(Whitelist, antreaGVK) })
+		assert.False(t, Disabled(aggregatedSchema(antreaGVK)))
+	})
+
+	t.Run("whitelisting one aggregated GVK does not enable another", func(t *testing.T) {
+		Whitelist[antreaGVK] = true
+		t.Cleanup(func() { delete(Whitelist, antreaGVK) })
+		otherGVK := schema.GroupVersionKind{Group: "controlplane.antrea.io", Version: "v1beta2", Kind: "AppliedToGroup"}
+		assert.True(t, Disabled(aggregatedSchema(otherGVK)))
+	})
+}


### PR DESCRIPTION
## Problem

- client-go ≥ v0.35 (k8s 1.35) enables `WatchListClient` by default: informers open a watch with `sendInitialEvents=true` and finish initial sync only after a `BOOKMARK` annotated `k8s.io/initial-events-end=true`.
- Built-in resources / CRDs emit it; **aggregated (extension) APIs may not** — e.g. Antrea's `controlplane.antrea.io` → the reflector hangs, `HasSynced` never becomes true.
- The cluster cache's `OnSchemas` holds the write lock across a 15-min `WaitForCacheSync`, so **one stuck informer freezes every reader** (`/v1/counts`, `fleetworkspaces`). (rancher/rancher#55606)

## Fix

1. **Detect** — tag schemas whose group/version is served by an `APIService` with an external `.spec.service` (built-ins/CRDs untagged).
2. **Policy** (`pkg/watchlist`) — disable watch-list for aggregated, non-whitelisted APIs; built-ins keep it. Fails safe (LIST+WATCH always completes); a `Whitelist` lets a verified aggregated API opt back in.
3. **Apply** in both informer paths — clustercache (`noWatchListClient`) and sqlcache (`disableWatchList`); the reflector falls back to LIST+WATCH for that informer.
4. **Harden the lock** — `OnSchemas` releases the write lock before `WaitForCacheSync`, so a never-syncing informer leaves only its own cache empty instead of blocking all reads (the actual #55606 outage fix).