### PR TITLE
Non-sql mode is no longer an option, so remove all the non-sql code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,7 @@ POST /v1/catalog.cattle.io.clusterrepos/rancher-partner-charts?action=install
 ### List-specific query parameters
 
 List requests (`/v1/{type}` and `/v1/{type}/{namespace}`) have additional
-parameters for filtering, sorting and pagination.
-
-Note that the exact meaning and behavior of those parameters may vary if
-Steve is used with SQLite caching of resources, which is configured when
-calling `server.New` via the `server.Options.SQLCache` boolean option.
-Meaning and behavior are the same unless otherwise specified.
+parameters for filtering, sorting, and pagination.
 
 Note that, if SQLite caching of resources is enabled, some of the data
 can be stored in disk, in either encrypted or plain text forms based on:
@@ -69,41 +64,19 @@ all resources are encrypted
  - regardless of the setting's value, any filterable/sortable columns are stored
 in plain text (see `filter` below for the exact list)
 
-#### `limit`
+#### `page`
 
-**If SQLite caching is disabled** (`server.Options.SQLCache=false`),
-set the maximum number of results to retrieve from Kubernetes. The limit is
-passed on as a parameter to the Kubernetes request. The purpose of setting this
-limit is to prevent a huge response from overwhelming Steve and Rancher. For
-more information about setting limits, review the Kubernetes documentation on
-[retrieving results in
-chunks](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks).
+Sets the "page" of results to return where there are more than can be returned in a single request.
+The first page is `1`, not `0`.
 
-The limit controls the size of the set coming from Kubernetes, and then
-filtering, sorting, and pagination are applied on that set. Because of this, if
-the result set is partial, there is no guarantee that the result returned to
-the client is fully sorted across the entire list, only across the returned
-chunk.
+#### `pagesize`
 
-**If SQLite caching is enabled** (`server.Options.SQLCache=true`),
-set the maximum number of results to return from the SQLite cache.
+Sets the maximum number of results to return from the SQLite cache.
 
-If both this parameter and `pagesize` are set, the smallest is taken.
-
-**In both cases**,
-the returned response will include a `continue` token, which indicates that the
-result is partial and must be used in the subsequent request to retrieve the
-next chunk.
-
-The default limit is 100000. To override the default, set `limit=-1`.
-
-#### `continue`
-
-Continue retrieving the next chunk of a partial list. The continue token is
-included in the response of a limited list and indicates that the result is
-partial. This token can then be used as a query parameter to retrieve the next
-chunk. All chunks have been retrieved when the continue field in the response
-is empty.
+If the returned response includes a `continue` token, this indicates that more results are available.
+Clients will need to determine the `page` field of the subsequent
+request to get the next page of data, but this will usually be the increment of
+the current `page` field, or `1` if no `page` field is given.
 
 #### `filter`
 
@@ -221,20 +194,11 @@ Filters can be negated to exclude results:
 /v1/{type}?filter=metadata.name!=foo
 ```
 
-**If SQLite caching is disabled** (`server.Options.SQLCache=false`),
-arrays are searched for matching items. If any item in the array matches, the
-item is included in the list.
-
-```
-/v1/{type}?filter=spec.containers.image=alpine
-```
-
-When SQLite caching is enabled, multiple values are stored separated by "or-bars" (`|`),
+Multiple values are stored separated by "or-bars" (`|`),
 like `abc|def|ghi`. You'll need to use the partial-match operator `~` to match one member,
 like `/v1/{type}?filter=spec.containers.image ~ ghi`.
 
-**If SQLite caching is enabled** (`server.Options.SQLCache=true`),
-filtering is only supported for a subset of attributes:
+**Filtering is only supported for a subset of attributes:
 - `id`, `metadata.name`, `metadata.namespace`, `metadata.state.name`, and `metadata.timestamp` for any resource kind
 - a short list of hardcoded attributes for a selection of specific types listed
 in [typeSpecificIndexFields](https://github.com/rancher/steve/blob/main/pkg/stores/sqlproxy/proxy_store.go#L52-L58)
@@ -313,8 +277,7 @@ Normal sort by namespace, then by name, reverse sort by creation time:
 /v1/{type}?sort=metadata.namespace,metadata.name,-metadata.creationTimestamp
 ```
 
-**If SQLite caching is enabled** (`server.Options.SQLCache=true`),
-sorting is only supported for the set of attributes supported by
+**Sorting is only supported for the set of attributes supported by
 filtering (see above).
 
 Sorting by labels (also requires SQLite caching) can use complex label names.
@@ -342,23 +305,11 @@ Pages are one-indexed, so this is equivalent to
 /v1/{type}?pagesize=10&page=1
 ```
 
-**If SQLite caching is disabled** (`server.Options.SQLCache=false`),
-to retrieve subsequent pages, the page number and the list revision number must
-be included in the request. This ensures the page will be retrieved from the
-cache, rather than making a new request to Kubernetes. If the revision number
-is omitted, a new fetch is performed in order to get the latest revision. The
-revision is included in the list response.
-
-```
-/v1/{type}?pagesize=10&page=2&revision=107440
-```
-
 `page` and `pagesize` can be used alongside the `limit` and `continue`
 parameters supported by Kubernetes. `limit` and `continue` are typically used
 for server-side chunking and do not guarantee results in any order.
 
-**If SQLite caching is enabled** (`server.Options.SQLCache=true`),
-to retrieve subsequent pages, only the page number is necessary, and it
+**To retrieve subsequent pages, only the page number is necessary, and it
 will always return the latest version.
 ```
 /v1/{type}?pagesize=10&page=2
@@ -369,7 +320,7 @@ If both `pagesize` and `limit` are set, the smallest is taken.
 If both `page` and `continue` are set, the result is the `page`-th page
 after the last result specified by `continue`.
 
-**If SQLCache is enabled and `revision` is passed:**
+**If `revision` is passed:**
 `revision` sets a minimum numerical value for resourceVersion in a LIST request. If the server's cached resourceVersion for that GVK is older than the revision provided, an "unknown revision" error is returned. 
 
 **In both cases**,

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ POST /v1/catalog.cattle.io.clusterrepos/rancher-partner-charts?action=install
 List requests (`/v1/{type}` and `/v1/{type}/{namespace}`) have additional
 parameters for filtering, sorting, and pagination.
 
-Note that, if SQLite caching of resources is enabled, some of the data
-can be stored in disk, in either encrypted or plain text forms based on:
+Note that the SQLite database caches Kubernetes resources. The data
+is stored in disk, in either encrypted or plain text forms based on:
  - by default, Secrets and Rancher Tokens (`management.cattle.io/v3, Kind=Token`) are always encrypted
  - if the environment variable `CATTLE_ENCRYPT_CACHE_ALL` is set to "true",
 all resources are encrypted
@@ -90,25 +90,11 @@ Example, filtering by object name:
 /v1/{type}?filter=metadata.name=foo
 ```
 
-When SQLite caching is not enabled, matching works this way:
-
-If a target value is surrounded by single-quotes, it succeeds only on an exact match:
-
 Example, filtering by object name:
 
 ```
 /v1/{type}?filter=metadata.name='match-this-exactly'
 ```
-
-A target value can be delimited by double-quotes, but this will succeed on a partial match:
-
-Example, filtering by object name:
-
-```
-/v1/{type}?filter=metadata.name="can-be-a-substri"
-```
-
-When SQLite caching is enabled, equality is slightly different from non-sql-supported matching.
 Equality can be specified with either one or two '=' signs.
 
 The following matches objects called either 'cat' or 'cows':
@@ -175,7 +161,7 @@ filter=metadata.name="oxford,metadata.labels.comma"
 Without the quotes, the expression would be finding either objects called `oxford`,
 or that have the label "comma", which is very different from objects called `oxford,metadata.labels.comma`.
 
-One filter can list multiple possible fields to match, these are ORed together:
+One filter can list multiple possible fields to match; these are ORed together:
 
 ```
 /v1/{type}?filter=metadata.name=foo,metadata.namespace=foo
@@ -227,7 +213,7 @@ Filtering by a single project or a single namespace:
 /v1/{type}?projectsornamespaces=p1
 ```
 
-Filtering by multiple projects or namespaces is done with a comma separated
+Filtering by multiple projects or namespaces is done with a comma-separated
 list. A resource matching any project or namespace in the list is included in
 the result:
 
@@ -245,13 +231,13 @@ The list can be negated to exclude results:
 
 Results can be sorted lexicographically by any number of columns given in descending order of importance.
 
-Sorting by only a single column, for example name:
+Sorting by only a single column, for example by `name`:
 
 ```
 /v1/{type}?sort=metadata.name
 ```
 
-Reverse sorting by name:
+Reverse sorting by `name`:
 
 ```
 /v1/{type}?sort=-metadata.name
@@ -280,7 +266,7 @@ Normal sort by namespace, then by name, reverse sort by creation time:
 **Sorting is only supported for the set of attributes supported by
 filtering (see above).
 
-Sorting by labels (also requires SQLite caching) can use complex label names.
+Sorting by labels can use complex label names.
 This query sorts by app name within their architectures, with the architectures
 listed in reverse lexicographic order. Note that complex label names need to be
 surrounded by square brackets (which themselves need to be percent-escaped for some web queries)
@@ -434,7 +420,7 @@ use Kubernetes as its data store.
 Steve uses apiserver Stores to transform and store data, mainly in Kubernetes.
 The main mechanism it uses is the proxy store, which is actually a series of
 four nested stores and a "partitioner". It can be instantiated by calling
-[NewProxyStore](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/proxy#NewProxyStore).
+[NewWrappedProxyStore](https://pkg.go.dev/github.com/rancher/steve/pkg/server#NewWrappedProxyStore).
 This gives you:
 
 * [`proxy.errorStore`](https://github.com/rancher/steve/blob/master/pkg/stores/proxy/error_wrapper.go) -
@@ -442,16 +428,15 @@ This gives you:
 * [`proxy.WatchRefresh`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/proxy#WatchRefresh) -
   wraps the nested store's Watch method, canceling the watch if access to the
   watched resource changes
-* [`partition.Store`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/partition#Store) -
+* [`partition.Store`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlpartition#Store) -
   wraps the nested store's List method and parallelizes the request according
   to the given partitioner, and additionally implements filtering, sorting, and
   pagination on the unstructured data from the nested store
 * [`proxy.rbacPartitioner`](https://github.com/rancher/steve/blob/master/pkg/stores/proxy/rbac_store.go) -
   the partitioner fed to the `partition.Store` which allows it to parallelize
   requests based on the user's access to certain namespaces or resources
-* [`proxy.Store`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/proxy#Store) -
-  the Kubernetes proxy store which performs the actual connection to Kubernetes
-  for all operations
+* [`proxy.Store`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlproxy#Store) -
+  the SQLite cache that stores the underlying Kubernetes data for all operations
 
 The default schema additionally wraps this proxy store in
 [`metrics.Store`](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/metrics#Store),
@@ -800,18 +785,18 @@ friendly way.
 
 This feature relies on the concept of [stores](#stores) and the RBAC
 partitioner. The [proxy
-store](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/proxy#Store)
-provides raw access to Kubernetes and returns data as an
+store](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlproxy#Store)
+provides cached access to Kubernetes and returns data as an
 [unstructured.UnstructuredList](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#UnstructuredList).
 The
-[partitioner](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/partition#Partitioner)
+[partitioner](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlpartition#Partitioner)
 calls the
 proxy store in parallel for each segment of resources the user has access to,
 such as for each namespace. The partitioner feeds the results of each parallelized
 request into a stream of
 [unstructured.Unstructured](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured).
 From here, the list is passed to the
-[listprocessor](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/partition/listprocessor)
+[listprocessor](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlpartition/listprocessor)
 to filter, sort, and paginate the list. The partition store formats the list as
 a
 [types.APIObjectList](https://pkg.go.dev/github.com/rancher/apiserver/pkg/types#APIObjectList)
@@ -822,7 +807,7 @@ Most stores in steve are implementations of the apiserver
 interface, which returns apiserver
 [types](https://pkg.go.dev/github.com/rancher/apiserver/pkg/types). The
 partitioner implements its own store type called
-[UnstructuredStore](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/partition#UnstructuredStore)
+[UnstructuredStore](https://pkg.go.dev/github.com/rancher/steve/pkg/stores/sqlpartition#UnstructuredStore)
 which returns
 [unstructured.Unstructured](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured)
 objects. The reason for this is that the filtering and sorting functions in the
@@ -842,14 +827,14 @@ The unit tests for these API features are located in two places:
 
 ##### listprocessor unit tests
 
-[pkg/stores/partition/listprocessor/processor_test.go](./pkg/stores/partition/listprocessor/processor_test.go)
+[pkg/stores/sqlpartition/listprocessor/processor_test.go](./pkg/stores/sqlpartition/listprocessor/processor_test.go)
 contains tests for each individual query handler. All changes to
-[listprocessor](./pkg/stores/partition/listprocessor/) should include a unit
+[listprocessor](./pkg/stores/sqlpartition/listprocessor/) should include a unit
 test in this file.
 
 ##### partition store unit tests
 
-[pkg/stores/partition/store_test.go](./pkg/stores/partition/store_test.go)
+[pkg/stores/sqlpartition/store_test.go](./pkg/stores/sqlpartition/store_test.go)
 contains tests for the `List` operation of the partition store. This is
 especially important for testing the functionality for multiple partitions. It
 also tests all supported query parameters, not limited to the
@@ -858,7 +843,7 @@ should be added here when:
 
   - the change is related to partitioning
   - the change is related to parsing the query parameters
-  - the change is related to the `limit` or `continue` parameters
+  - the change is related to the `page` or `continue` parameters
   - the listprocessor change should be tested with other query parameters
 
 It doesn't hurt to add a test here for any other listprocessor change.

--- a/main.go
+++ b/main.go
@@ -38,7 +38,10 @@ func main() {
 func run(_ *cli.Context) error {
 	ctx := signals.SetupSignalContext()
 	debugconfig.MustSetupDebug()
-	s, err := config.ToServer(ctx, debugconfig.SQLCache)
+	if debugconfig.SqlCacheDeprecated {
+		logrus.Warn("--sql-cache is no longer needed and is always on")
+	}
+	s, err := config.ToServer(ctx)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 func run(_ *cli.Context) error {
 	ctx := signals.SetupSignalContext()
 	debugconfig.MustSetupDebug()
-	if debugconfig.SqlCacheDeprecated {
+	if debugconfig.SQLCacheDeprecated {
 		logrus.Warn("--sql-cache is no longer needed and is always on")
 	}
 	s, err := config.ToServer(ctx)

--- a/pkg/debug/cli.go
+++ b/pkg/debug/cli.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	Debug              bool
 	DebugLevel         int
-	SqlCacheDeprecated bool
+	SQLCacheDeprecated bool
 }
 
 func (c *Config) MustSetupDebug() {
@@ -56,7 +56,7 @@ func Flags(config *Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "sql-cache",
-			Destination: &config.SqlCacheDeprecated,
+			Destination: &config.SQLCacheDeprecated,
 		},
 	}
 }

--- a/pkg/debug/cli.go
+++ b/pkg/debug/cli.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Config struct {
-	Debug      bool
-	DebugLevel int
-	SQLCache   bool
+	Debug              bool
+	DebugLevel         int
+	SqlCacheDeprecated bool
 }
 
 func (c *Config) MustSetupDebug() {
@@ -56,7 +56,7 @@ func Flags(config *Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "sql-cache",
-			Destination: &config.SQLCache,
+			Destination: &config.SqlCacheDeprecated,
 		},
 	}
 }

--- a/pkg/resources/common/formatter.go
+++ b/pkg/resources/common/formatter.go
@@ -15,11 +15,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/steve/pkg/schema"
-	metricsStore "github.com/rancher/steve/pkg/stores/metrics"
-	"github.com/rancher/steve/pkg/stores/proxy"
 	"github.com/rancher/steve/pkg/summarycache"
 	"github.com/rancher/wrangler/v3/pkg/data"
-	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,17 +27,6 @@ import (
 
 type TemplateOptions struct {
 	InSQLMode bool
-}
-
-func DefaultTemplate(clientGetter proxy.ClientGetter,
-	summaryCache *summarycache.SummaryCache,
-	asl accesscontrol.AccessSetLookup,
-	namespaceCache corecontrollers.NamespaceCache,
-	options TemplateOptions) schema.Template {
-	return schema.Template{
-		Store:     metricsStore.NewMetricsStore(proxy.NewProxyStore(clientGetter, summaryCache, asl, namespaceCache)),
-		Formatter: formatter(summaryCache, asl, options),
-	}
 }
 
 // DefaultTemplateForStore provides a default schema template which uses a provided, pre-initialized store. Primarily used when creating a Template that uses a Lasso SQL store internally.

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rancher/apiserver/pkg/subscribe"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/steve/pkg/accesscontrol"
-	"github.com/rancher/steve/pkg/client"
 	"github.com/rancher/steve/pkg/clustercache"
 	"github.com/rancher/steve/pkg/resources/apigroups"
 	"github.com/rancher/steve/pkg/resources/cluster"
@@ -18,7 +17,6 @@ import (
 	"github.com/rancher/steve/pkg/schema"
 	"github.com/rancher/steve/pkg/stores/proxy"
 	"github.com/rancher/steve/pkg/summarycache"
-	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/discovery"
 )
@@ -42,46 +40,6 @@ func DefaultSchemas(ctx context.Context, baseSchema *types.APISchemas, ccache cl
 	return nil
 }
 
-func DefaultSchemaTemplates(cf *client.Factory,
-	baseSchemas *types.APISchemas,
-	summaryCache *summarycache.SummaryCache,
-	lookup accesscontrol.AccessSetLookup,
-	discovery discovery.DiscoveryInterface,
-	namespaceCache corecontrollers.NamespaceCache,
-	options common.TemplateOptions) []schema.Template {
-	return []schema.Template{
-		common.DefaultTemplate(cf, summaryCache, lookup, namespaceCache, options),
-		apigroups.Template(discovery),
-		{
-			ID:        "configmap",
-			Formatter: formatters.HandleHelmData,
-		},
-		{
-			ID:        "secret",
-			Formatter: formatters.HandleHelmData,
-		},
-		{
-			ID:        "pod",
-			Formatter: formatters.Pod,
-		},
-		{
-			ID:        "management.cattle.io.setting",
-			Formatter: formatters.Setting,
-		},
-		{
-			ID:        "namespace",
-			Formatter: formatters.Namespace,
-		},
-		{
-			ID: "management.cattle.io.cluster",
-			Customize: func(apiSchema *types.APISchema) {
-				cluster.AddApply(baseSchemas, apiSchema)
-			},
-		},
-	}
-}
-
-// DefaultSchemaTemplatesForStore returns the same default templates as DefaultSchemaTemplates, only using DefaultSchemaTemplateFoStore internally to construct the templates.
 func DefaultSchemaTemplatesForStore(store types.Store,
 	baseSchemas *types.APISchemas,
 	summaryCache *summarycache.SummaryCache,

--- a/pkg/server/cli/clicontext.go
+++ b/pkg/server/cli/clicontext.go
@@ -36,14 +36,14 @@ type Config struct {
 }
 
 func (c *Config) MustServer(ctx context.Context) *server.Server {
-	cc, err := c.ToServer(ctx, false)
+	cc, err := c.ToServer(ctx)
 	if err != nil {
 		panic(err)
 	}
 	return cc
 }
 
-func (c *Config) ToServer(ctx context.Context, sqlCache bool) (*server.Server, error) {
+func (c *Config) ToServer(ctx context.Context) (*server.Server, error) {
 	var (
 		auth steveauth.Middleware
 	)
@@ -75,7 +75,6 @@ func (c *Config) ToServer(ctx context.Context, sqlCache bool) (*server.Server, e
 	return server.New(ctx, restConfig, &server.Options{
 		AuthMiddleware: auth,
 		Next:           ui.New(c.UIPath),
-		SQLCache:       sqlCache,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCKeepCount:             1000,
 			DBMetricsUpdateInterval: time.Duration(c.MetricsUpdateInterval) * time.Second,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -199,24 +199,10 @@ func setup(ctx context.Context, server *Server) error {
 		return err
 	}
 
-	sqlStore, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, sf, server.cacheFactory, false)
+	sqlStore, store, err := NewWrappedProxyStore(ctx, server.cacheFactory, cols, cf, summaryCache, sf, asl, false)
 	if err != nil {
 		return err
 	}
-
-	errStore := proxy.NewErrorStore(
-		proxy.NewUnformatterStore(
-			proxy.NewWatchRefresh(
-				sqlpartition.NewStore(
-					sqlStore,
-					asl,
-				),
-				asl,
-			),
-		),
-	)
-	store := metricsStore.NewMetricsStore(errStore)
-	// end store setup code
 
 	for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), common.TemplateOptions{InSQLMode: true}) {
 		sf.AddTemplate(template)
@@ -271,6 +257,27 @@ func setup(ctx context.Context, server *Server) error {
 	server.SchemaFactory = sf
 
 	return nil
+}
+
+func NewWrappedProxyStore(ctx context.Context, cacheFactory *factory.CacheFactory, cols *common.DynamicColumns, cf *client.Factory, summaryCache *summarycache.SummaryCache, sf *schema.Collection, asl accesscontrol.AccessSetLookup, needToInitNamespaceCache bool) (*sqlproxy.Store, *metricsStore.Store, error) {
+	sqlStore, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, sf, cacheFactory, needToInitNamespaceCache)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	errStore := proxy.NewErrorStore(
+		proxy.NewUnformatterStore(
+			proxy.NewWatchRefresh(
+				sqlpartition.NewStore(
+					sqlStore,
+					asl,
+				),
+				asl,
+			),
+		),
+	)
+	store := metricsStore.NewMetricsStore(errStore)
+	return sqlStore, store, nil
 }
 
 func (c *Server) start(ctx context.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -75,7 +75,6 @@ type Server struct {
 
 	aggregationSecretNamespace string
 	aggregationSecretName      string
-	SQLCache                   bool
 }
 
 type Options struct {
@@ -90,10 +89,7 @@ type Options struct {
 	AggregationSecretName      string
 	ClusterRegistry            string
 	ServerVersion              string
-	// SQLCache enables the SQLite-based caching mechanism
-	SQLCache bool
-
-	SQLCacheFactoryOptions factory.CacheFactoryOptions
+	SQLCacheFactoryOptions     factory.CacheFactoryOptions
 
 	// ExtensionAPIServer enables an extension API server that will be served
 	// under /ext
@@ -112,29 +108,23 @@ func New(ctx context.Context, restConfig *rest.Config, opts *Options) (*Server, 
 		opts = &Options{}
 	}
 
-	var cacheFactory *factory.CacheFactory
-	if opts.SQLCache {
-		var err error
-		cacheFactory, err = factory.NewCacheFactory(opts.SQLCacheFactoryOptions)
-		if err != nil {
-			return nil, fmt.Errorf("creating SQL cache factory: %w", err)
-		}
+	cacheFactory, err := factory.NewCacheFactory(opts.SQLCacheFactoryOptions)
+	if err != nil {
+		return nil, fmt.Errorf("creating SQL cache factory: %w", err)
 	}
 
 	server := &Server{
-		RESTConfig:                 restConfig,
-		ClientFactory:              opts.ClientFactory,
-		AccessSetLookup:            opts.AccessSetLookup,
-		authMiddleware:             opts.AuthMiddleware,
-		controllers:                opts.Controllers,
-		next:                       opts.Next,
-		router:                     opts.Router,
-		aggregationSecretNamespace: opts.AggregationSecretNamespace,
-		aggregationSecretName:      opts.AggregationSecretName,
-		ClusterRegistry:            opts.ClusterRegistry,
-		Version:                    opts.ServerVersion,
-		// SQLCache enables the SQLite-based lasso caching mechanism
-		SQLCache:                      opts.SQLCache,
+		RESTConfig:                    restConfig,
+		ClientFactory:                 opts.ClientFactory,
+		AccessSetLookup:               opts.AccessSetLookup,
+		authMiddleware:                opts.AuthMiddleware,
+		controllers:                   opts.Controllers,
+		next:                          opts.Next,
+		router:                        opts.Router,
+		aggregationSecretNamespace:    opts.AggregationSecretNamespace,
+		aggregationSecretName:         opts.AggregationSecretName,
+		ClusterRegistry:               opts.ClusterRegistry,
+		Version:                       opts.ServerVersion,
 		cacheFactory:                  cacheFactory,
 		extensionAPIServer:            opts.ExtensionAPIServer,
 		SkipWaitForExtensionAPIServer: opts.SkipWaitForExtensionAPIServer,
@@ -209,49 +199,41 @@ func setup(ctx context.Context, server *Server) error {
 		return err
 	}
 
-	var onSchemasHandler schemacontroller.SchemasHandlerFunc
-	if server.SQLCache {
-		sqlStore, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, sf, server.cacheFactory, false)
-		if err != nil {
-			return err
-		}
+	sqlStore, err := sqlproxy.NewProxyStore(ctx, cols, cf, summaryCache, summaryCache, sf, server.cacheFactory, false)
+	if err != nil {
+		return err
+	}
 
-		errStore := proxy.NewErrorStore(
-			proxy.NewUnformatterStore(
-				proxy.NewWatchRefresh(
-					sqlpartition.NewStore(
-						sqlStore,
-						asl,
-					),
+	errStore := proxy.NewErrorStore(
+		proxy.NewUnformatterStore(
+			proxy.NewWatchRefresh(
+				sqlpartition.NewStore(
+					sqlStore,
 					asl,
 				),
+				asl,
 			),
-		)
-		store := metricsStore.NewMetricsStore(errStore)
-		// end store setup code
+		),
+	)
+	store := metricsStore.NewMetricsStore(errStore)
+	// end store setup code
 
-		for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), common.TemplateOptions{InSQLMode: true}) {
-			sf.AddTemplate(template)
-		}
+	for _, template := range resources.DefaultSchemaTemplatesForStore(store, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), common.TemplateOptions{InSQLMode: true}) {
+		sf.AddTemplate(template)
+	}
 
-		sqlSchemaTracker := schematracker.NewSchemaTracker(sqlStore)
+	sqlSchemaTracker := schematracker.NewSchemaTracker(sqlStore)
 
-		onSchemasHandler = func(schemas *schema.Collection) error {
-			var retErr error
+	onSchemasHandler := func(schemas *schema.Collection) error {
+		var retErr error
 
-			err := ccache.OnSchemas(schemas)
-			retErr = errors.Join(retErr, err)
+		err := ccache.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
 
-			err = sqlSchemaTracker.OnSchemas(schemas)
-			retErr = errors.Join(retErr, err)
+		err = sqlSchemaTracker.OnSchemas(schemas)
+		retErr = errors.Join(retErr, err)
 
-			return retErr
-		}
-	} else {
-		for _, template := range resources.DefaultSchemaTemplates(cf, server.BaseSchemas, summaryCache, asl, server.controllers.K8s.Discovery(), server.controllers.Core.Namespace().Cache(), common.TemplateOptions{InSQLMode: false}) {
-			sf.AddTemplate(template)
-		}
-		onSchemasHandler = ccache.OnSchemas
+		return retErr
 	}
 
 	schemas.SetupWatcher(ctx, server.BaseSchemas, asl, sf)

--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -90,6 +90,9 @@ type Store struct {
 }
 
 // NewProxyStore returns a wrapped types.Store.
+// This is called from
+// rancher/rancher/pkg/api/steve/projects/projects.go:newSchemas()
+// Not sure the project-specific server in r/r can use the sqlite cache
 func NewProxyStore(clientGetter ClientGetter, notifier RelationshipNotifier, lookup accesscontrol.AccessSetLookup, namespaceCache corecontrollers.NamespaceCache) types.Store {
 	return &ErrorStore{
 		Store: &unformatterStore{

--- a/tests/integration/associateddata_test.go
+++ b/tests/integration/associateddata_test.go
@@ -47,7 +47,6 @@ func (i *IntegrationSuite) TestAssociatedData() {
 	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
 
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/association_test.go
+++ b/tests/integration/association_test.go
@@ -26,7 +26,6 @@ var (
 func (i *IntegrationSuite) TestListAssociations() {
 	ctx := i.T().Context()
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/column_test.go
+++ b/tests/integration/column_test.go
@@ -25,7 +25,6 @@ var (
 func (i *IntegrationSuite) TestListColumns() {
 	ctx := i.T().Context()
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/filtering_test.go
+++ b/tests/integration/filtering_test.go
@@ -25,7 +25,6 @@ var (
 func (i *IntegrationSuite) TestListFiltering() {
 	ctx := i.T().Context()
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/list_test.go
+++ b/tests/integration/list_test.go
@@ -56,18 +56,10 @@ func (i *IntegrationSuite) TestList() {
 	})
 	// Cleanup common manifests after all tests complete
 	defer i.doManifestReversed(ctx, commonManifestsFile, i.doDelete)
-
-	// Run SQL mode first, then non-SQL mode sequentially
-	i.Run("SQL", func() {
-		i.runListTest(ctx, true, gvrs)
-	})
-	i.Run("NonSQL", func() {
-		i.runListTest(ctx, false, gvrs)
-	})
+	i.runListTest(ctx, gvrs)
 }
 
-func (i *IntegrationSuite) runListTest(ctx context.Context, sqlCache bool, gvrs map[k8sschema.GroupVersionResource]struct{}) {
-
+func (i *IntegrationSuite) runListTest(ctx context.Context, gvrs map[k8sschema.GroupVersionResource]struct{}) {
 	// Custom authenticator: use impersonation if header present, otherwise admin
 	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
 		info, ok, err := auth.Impersonation(req)
@@ -79,23 +71,13 @@ func (i *IntegrationSuite) runListTest(ctx context.Context, sqlCache bool, gvrs 
 	}
 	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
 
-	var steveHandler http.Handler
-	var err error
-	if sqlCache {
-		steveHandler, err = server.New(ctx, i.restCfg, &server.Options{
-			SQLCache: true,
-			SQLCacheFactoryOptions: factory.CacheFactoryOptions{
-				GCInterval:  15 * time.Minute,
-				GCKeepCount: 1000,
-			},
-			AuthMiddleware: authMiddleware,
-		})
-	} else {
-		steveHandler, err = server.New(ctx, i.restCfg, &server.Options{
-			SQLCache:       false,
-			AuthMiddleware: authMiddleware,
-		})
-	}
+	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+		},
+		AuthMiddleware: authMiddleware,
+	})
 	i.Require().NoError(err)
 
 	httpServer := httptest.NewServer(steveHandler)
@@ -140,7 +122,7 @@ func (i *IntegrationSuite) runListTest(ctx context.Context, sqlCache bool, gvrs 
 				defer i.doManifestReversed(ctx, scenarioManifestsFile, i.doDelete)
 			}
 
-			i.testListScenario(ctx, config, baseURL, sqlCache, csvWriter)
+			i.testListScenario(ctx, config, baseURL, csvWriter)
 		})
 	}
 }
@@ -156,36 +138,10 @@ func (i *IntegrationSuite) readListTestConfig(testFile string) ListTestConfig {
 	return config
 }
 
-func (i *IntegrationSuite) testListScenario(ctx context.Context, config ListTestConfig, baseURL string, sqlCache bool, csvWriter *csv.Writer) {
-	// Track continue token and revision across tests in this scenario
-	var lastContinueToken string
-	var lastRevision string
-
+func (i *IntegrationSuite) testListScenario(ctx context.Context, config ListTestConfig, baseURL string, csvWriter *csv.Writer) {
 	for _, test := range config.Tests {
-		// Skip tests restricted to specific cache modes
-		currentMode := "sql"
-		if !sqlCache {
-			currentMode = "nonsql"
-		}
-		if test.RunOn != "" && test.RunOn != currentMode {
-			continue
-		}
-
 		i.Run(test.Description, func() {
 			query := test.Query
-
-			// Replace nondeterministic placeholders with actual values from previous responses
-			if strings.Contains(query, "nondeterministictoken") {
-				query = strings.Replace(query, "nondeterministictoken", lastContinueToken, 1)
-			}
-			if strings.Contains(query, "nondeterministicint") {
-				query = strings.Replace(query, "nondeterministicint", lastRevision, 1)
-			}
-
-			// Convert labelSelector/fieldSelector to filter format for SQL mode
-			if sqlCache {
-				query = convertQueryForSQLCache(query)
-			}
 			url := buildURLRaw(baseURL, config.SchemaID, test.Namespace, query)
 			fmt.Println(url)
 
@@ -215,14 +171,6 @@ func (i *IntegrationSuite) testListScenario(ctx context.Context, config ListTest
 			var parsed Response
 			err = json.Unmarshal(bodyBytes, &parsed)
 			i.Require().NoError(err)
-
-			// Store continue token and revision for subsequent tests
-			if parsed.Continue != "" {
-				lastContinueToken = parsed.Continue
-			}
-			if parsed.Revision != "" {
-				lastRevision = parsed.Revision
-			}
 
 			// Save JSON response if csvWriter is provided
 			if csvWriter != nil {
@@ -256,43 +204,6 @@ func buildURLRaw(baseURL, schemaID, namespace, query string) string {
 		url += "?" + query
 	}
 	return url
-}
-
-// convertQueryForSQLCache converts labelSelector and fieldSelector params to filter format
-// This mirrors the logic in steve_api_test.go#L2661-L2681
-func convertQueryForSQLCache(query string) string {
-	parts := strings.Split(query, "&")
-	changed := false
-
-	for j, part := range parts {
-		if strings.HasPrefix(part, "labelSelector=") {
-			// labelSelector=test-label=2 -> filter=metadata.labels[test-label]=2
-			rest := strings.TrimPrefix(part, "labelSelector=")
-			eqIdx := strings.Index(rest, "=")
-			if eqIdx > 0 {
-				labelName := rest[:eqIdx]
-				labelValue := rest[eqIdx+1:]
-				parts[j] = fmt.Sprintf("filter=metadata.labels[%s]=%s", labelName, labelValue)
-				changed = true
-			}
-		} else if strings.HasPrefix(part, "fieldSelector=") {
-			// fieldSelector=metadata.namespace=test-ns-1 -> filter=metadata.namespace=test-ns-1
-			// fieldSelector=metadata.name=test1 -> filter=metadata.name=test1
-			rest := strings.TrimPrefix(part, "fieldSelector=")
-			eqIdx := strings.Index(rest, "=")
-			if eqIdx > 0 {
-				field := rest[:eqIdx]
-				value := rest[eqIdx+1:]
-				parts[j] = fmt.Sprintf("filter=%s=%s", field, value)
-				changed = true
-			}
-		}
-	}
-
-	if changed {
-		return strings.Join(parts, "&")
-	}
-	return query
 }
 
 type responseItem struct {

--- a/tests/integration/namespace_formatter_test.go
+++ b/tests/integration/namespace_formatter_test.go
@@ -40,7 +40,6 @@ func (i *IntegrationSuite) TestNamespaceFormatter() {
 	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
 
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/non_listable_resource_test.go
+++ b/tests/integration/non_listable_resource_test.go
@@ -18,7 +18,6 @@ func (i *IntegrationSuite) TestIssue51930() {
 	ctx := i.T().Context()
 	// Start steve with SQL Cache enabled
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/podrestarts_test.go
+++ b/tests/integration/podrestarts_test.go
@@ -38,10 +38,10 @@ func (i *IntegrationSuite) TestPodRestarts() {
 	time.Sleep(8 * time.Second)
 
 	// Run SQL mode only - these tests are specifically for SQL cache with multi-value field support
-	i.runPodRestartsTest(ctx, true, gvrs)
+	i.runPodRestartsTest(ctx, gvrs)
 }
 
-func (i *IntegrationSuite) runPodRestartsTest(ctx context.Context, sqlCache bool, gvrs map[k8sschema.GroupVersionResource]struct{}) {
+func (i *IntegrationSuite) runPodRestartsTest(ctx context.Context, gvrs map[k8sschema.GroupVersionResource]struct{}) {
 	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
 		info, ok, err := auth.Impersonation(req)
 		if ok || err != nil {
@@ -54,7 +54,6 @@ func (i *IntegrationSuite) runPodRestartsTest(ctx context.Context, sqlCache bool
 	var steveHandler http.Handler
 	var err error
 	steveHandler, err = server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
@@ -66,10 +65,8 @@ func (i *IntegrationSuite) runPodRestartsTest(ctx context.Context, sqlCache bool
 	steveServer := httptest.NewServer(steveHandler)
 	defer steveServer.Close()
 
-	// Wait for cache to be populated
-	if sqlCache {
-		time.Sleep(2 * time.Second)
-	}
+	// Wait for the sql cache to be populated
+	time.Sleep(2 * time.Second)
 
 	matches, err := filepath.Glob(filepath.Join(testdataPodRestartsDir, "*.test.yaml"))
 	i.Require().NoError(err)

--- a/tests/integration/schema_refresh_test.go
+++ b/tests/integration/schema_refresh_test.go
@@ -52,7 +52,6 @@ func (i *IntegrationSuite) TestSchemaRefresh() {
 	ctx := i.T().Context()
 
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/sorting_test.go
+++ b/tests/integration/sorting_test.go
@@ -25,7 +25,6 @@ var (
 func (i *IntegrationSuite) TestListSorting() {
 	ctx := i.T().Context()
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
@@ -114,7 +113,6 @@ func (i *IntegrationSuite) testSortScenario(ctx context.Context, scenario string
 func (i *IntegrationSuite) TestListSortPodsByStateName() {
 	ctx := i.T().Context()
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/state_test.go
+++ b/tests/integration/state_test.go
@@ -31,7 +31,6 @@ func (i *IntegrationSuite) TestStateUpdate() {
 	ctx := i.T().Context()
 	// Initialize Steve server with SQL Cache enabled
 	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
-		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,

--- a/tests/integration/summary_test.go
+++ b/tests/integration/summary_test.go
@@ -69,16 +69,12 @@ func (i *IntegrationSuite) TestSummary() {
 	// Cleanup common manifests after all tests complete
 	defer i.doManifestReversed(ctx, commonManifestsFile, i.doDelete)
 
-	// Run SQL mode first, then non-SQL mode sequentially
-	i.Run("SQL", func() {
-		i.runSummaryTest(ctx, true, gvrs)
-	})
-	i.Run("NonSQL", func() {
-		i.runSummaryTest(ctx, false, gvrs)
+	i.Run("Summary Tests", func() {
+		i.runSummaryTest(ctx, gvrs)
 	})
 }
 
-func (i *IntegrationSuite) runSummaryTest(ctx context.Context, sqlCache bool, gvrs map[k8sschema.GroupVersionResource]struct{}) {
+func (i *IntegrationSuite) runSummaryTest(ctx context.Context, gvrs map[k8sschema.GroupVersionResource]struct{}) {
 
 	// Custom authenticator: use impersonation if header present, otherwise admin
 	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
@@ -91,23 +87,13 @@ func (i *IntegrationSuite) runSummaryTest(ctx context.Context, sqlCache bool, gv
 	}
 	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
 
-	var steveHandler http.Handler
-	var err error
-	if sqlCache {
-		steveHandler, err = server.New(ctx, i.restCfg, &server.Options{
-			SQLCache: true,
-			SQLCacheFactoryOptions: factory.CacheFactoryOptions{
-				GCInterval:  15 * time.Minute,
-				GCKeepCount: 1000,
-			},
-			AuthMiddleware: authMiddleware,
-		})
-	} else {
-		steveHandler, err = server.New(ctx, i.restCfg, &server.Options{
-			SQLCache:       false,
-			AuthMiddleware: authMiddleware,
-		})
-	}
+	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+		},
+		AuthMiddleware: authMiddleware,
+	})
 	i.Require().NoError(err)
 
 	httpServer := httptest.NewServer(steveHandler)
@@ -122,7 +108,7 @@ func (i *IntegrationSuite) runSummaryTest(ctx context.Context, sqlCache bool, gv
 
 	defer i.maybeStopAndDebug(baseURL)
 
-	// Set up JSON output directory and CSV writer
+	// Set up the JSON output directory and CSV writer
 	var csvWriter *csv.Writer
 	var csvFile *os.File
 	if os.Getenv("SAVE_JSON_RESPONSES") == "true" {
@@ -152,7 +138,7 @@ func (i *IntegrationSuite) runSummaryTest(ctx context.Context, sqlCache bool, gv
 				defer i.doManifestReversed(ctx, scenarioManifestsFile, i.doDelete)
 			}
 
-			i.testSummaryScenario(ctx, config, baseURL, sqlCache, csvWriter)
+			i.testSummaryScenario(ctx, config, baseURL, csvWriter)
 		})
 	}
 }
@@ -168,30 +154,23 @@ func (i *IntegrationSuite) readSummaryTestConfig(testFile string) SummaryTestCon
 	return config
 }
 
-func (i *IntegrationSuite) testSummaryScenario(ctx context.Context, config SummaryTestConfig, baseURL string, sqlCache bool, csvWriter *csv.Writer) {
+func (i *IntegrationSuite) testSummaryScenario(ctx context.Context, config SummaryTestConfig, baseURL string, csvWriter *csv.Writer) {
 	// Track continue token and revision across tests in this scenario
-	var lastContinueToken string
-	var lastRevision string
-	if !sqlCache {
-		i.T().Skip("Skipping non-sql tests")
-	}
+	//var lastContinueToken string
+	//var lastRevision string
 
 	for _, test := range config.Tests {
 		i.Run(test.Description, func() {
 			query := test.Query
 
 			// Replace nondeterministic placeholders with actual values from previous responses
-			if strings.Contains(query, "nondeterministictoken") {
-				query = strings.Replace(query, "nondeterministictoken", lastContinueToken, 1)
-			}
-			if strings.Contains(query, "nondeterministicint") {
-				query = strings.Replace(query, "nondeterministicint", lastRevision, 1)
-			}
+			//if strings.Contains(query, "nondeterministictoken") {
+			//	query = strings.Replace(query, "nondeterministictoken", lastContinueToken, 1)
+			//}
+			//if strings.Contains(query, "nondeterministicint") {
+			//	query = strings.Replace(query, "nondeterministicint", lastRevision, 1)
+			//}
 
-			// Convert labelSelector/fieldSelector to filter format for SQL mode
-			if sqlCache {
-				query = convertQueryForSQLCache(query)
-			}
 			url := buildURLRaw(baseURL, config.SchemaID, test.Namespace, query)
 			fmt.Println(url)
 
@@ -212,8 +191,6 @@ func (i *IntegrationSuite) testSummaryScenario(ctx context.Context, config Summa
 			// Read full response body for JSON saving
 			bodyBytes, err := io.ReadAll(resp.Body)
 			i.Require().NoError(err)
-			//TODO: Delete this:
-			//fmt.Fprintf(os.Stderr, "body:\n[\n%s\n]\n", string(bodyBytes))
 
 			type Response struct {
 				Data     []responseItem      `json:"data"`
@@ -224,14 +201,6 @@ func (i *IntegrationSuite) testSummaryScenario(ctx context.Context, config Summa
 			var parsed Response
 			err = json.Unmarshal(bodyBytes, &parsed)
 			i.Require().NoError(err)
-
-			// Store continue token and revision for subsequent tests
-			if parsed.Continue != "" {
-				lastContinueToken = parsed.Continue
-			}
-			if parsed.Revision != "" {
-				lastRevision = parsed.Revision
-			}
 
 			// Save JSON response if csvWriter is provided
 			if csvWriter != nil {

--- a/tests/integration/testdata/list/contains.test.yaml
+++ b/tests/integration/testdata/list/contains.test.yaml
@@ -3,7 +3,6 @@ tests:
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/fleetwoodmac:v0.14.2"&sort=metadata.name
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/fleetwoodmac:v0.14.2"&sort=metadata.name
-    runOn: sql
     expect:
       - name: drums
         namespace: bandpractice
@@ -15,7 +14,6 @@ tests:
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/shakira:v2.13.2"&sort=metadata.name
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/shakira:v2.13.2"&sort=metadata.name
-    runOn: sql
     expect:
       - name: bass
         namespace: bandpractice
@@ -24,7 +22,6 @@ tests:
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/santana:v7.1"&sort=metadata.name
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/santana:v7.1"&sort=metadata.name
-    runOn: sql
     expect:
       - name: bass
         namespace: bandpractice
@@ -33,20 +30,17 @@ tests:
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/santana:v7.1.2"&sort=metadata.name
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/santana:v7.1.2"&sort=metadata.name
-    runOn: sql
     expect:
       - name: piano
         namespace: bandpractice
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/fleetwoodmac:v0.14"&sort=metadata.name
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/fleetwoodmac:v0.14"&sort=metadata.name
-    runOn: sql
     expect:
       - name: piano
         namespace: bandpractice
   - description: namespace:bandpractice,query:filter=spec.containers.image+CONTAINS+"band/phish:v4.0.1"
     namespace: bandpractice
     query: filter=spec.containers.image+CONTAINS+"band/phish:v4.0.1"
-    runOn: sql
     expect: []
 

--- a/tests/integration/testdata/list/filtering.test.yaml
+++ b/tests/integration/testdata/list/filtering.test.yaml
@@ -1,9 +1,9 @@
 schemaID: secret
 tests:
-- description: user:user-a,namespace:none,query:labelSelector=test-label=2
+- description: user:user-a,namespace:none,query:filter=metadata.labels[test-label]=2
   user: user-a
   namespace: ''
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-1
@@ -15,17 +15,17 @@ tests:
     namespace: test-ns-4
   - name: test2
     namespace: test-ns-5
-- description: user:user-a,namespace:test-ns-2,query:labelSelector=test-label=2
+- description: user:user-a,namespace:test-ns-2,query:filter=metadata.labels[test-label]=2
   user: user-a
   namespace: test-ns-2
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-2
-- description: user:user-a,namespace:none,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-a,namespace:none,query:filter=metadata.namespace=test-ns-1
   user: user-a
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -37,10 +37,10 @@ tests:
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-a,namespace:none,query:fieldSelector=metadata.name=test1
+- description: user:user-a,namespace:none,query:filter=metadata.name=test1
   user: user-a
   namespace: ''
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -52,10 +52,10 @@ tests:
     namespace: test-ns-4
   - name: test1
     namespace: test-ns-5
-- description: user:user-a,namespace:test-ns-1,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-a,namespace:test-ns-1,query:filter=metadata.namespace=test-ns-1
   user: user-a
   namespace: test-ns-1
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -67,15 +67,15 @@ tests:
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-a,namespace:test-ns-2,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-a,namespace:test-ns-2,query:filter=metadata.namespace=test-ns-1
   user: user-a
   namespace: test-ns-2
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect: []
-- description: user:user-a,namespace:test-ns-1,query:fieldSelector=metadata.name=test1
+- description: user:user-a,namespace:test-ns-1,query:filter=metadata.name=test1
   user: user-a
   namespace: test-ns-1
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -191,7 +191,6 @@ tests:
   user: user-a
   namespace: test-ns-2
   query: filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds
-  runOn: sql
   expect:
   - name: test4
     namespace: test-ns-2
@@ -199,31 +198,30 @@ tests:
   user: user-a
   namespace: test-ns-2
   query: filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=potatoes
-  runOn: sql
   expect: []
-- description: user:user-b,namespace:none,query:labelSelector=test-label=2
+- description: user:user-b,namespace:none,query:filter=metadata.labels[test-label]=2
   user: user-b
   namespace: ''
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-1,query:labelSelector=test-label=2
+- description: user:user-b,namespace:test-ns-1,query:filter=metadata.labels[test-label]=2
   user: user-b
   namespace: test-ns-1
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-2,query:labelSelector=test-label=2
+- description: user:user-b,namespace:test-ns-2,query:filter=metadata.labels[test-label]=2
   user: user-b
   namespace: test-ns-2
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect: []
-- description: user:user-b,namespace:none,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-b,namespace:none,query:filter=metadata.namespace=test-ns-1
   user: user-b
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -235,22 +233,22 @@ tests:
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-b,namespace:none,query:fieldSelector=metadata.namespace=test-ns-2
+- description: user:user-b,namespace:none,query:filter=metadata.namespace=test-ns-2
   user: user-b
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-2
+  query: filter=metadata.namespace=test-ns-2
   expect: []
-- description: user:user-b,namespace:none,query:fieldSelector=metadata.name=test1
+- description: user:user-b,namespace:none,query:filter=metadata.name=test1
   user: user-b
   namespace: ''
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-1,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-b,namespace:test-ns-1,query:filter=metadata.namespace=test-ns-1
   user: user-b
   namespace: test-ns-1
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -262,27 +260,27 @@ tests:
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-2,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-b,namespace:test-ns-2,query:filter=metadata.namespace=test-ns-1
   user: user-b
   namespace: test-ns-2
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect: []
-- description: user:user-b,namespace:test-ns-1,query:fieldSelector=metadata.namespace=test-ns-2
+- description: user:user-b,namespace:test-ns-1,query:filter=metadata.namespace=test-ns-2
   user: user-b
   namespace: test-ns-1
-  query: fieldSelector=metadata.namespace=test-ns-2
+  query: filter=metadata.namespace=test-ns-2
   expect: []
-- description: user:user-b,namespace:test-ns-1,query:fieldSelector=metadata.name=test1
+- description: user:user-b,namespace:test-ns-1,query:filter=metadata.name=test1
   user: user-b
   namespace: test-ns-1
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-2,query:fieldSelector=metadata.name=test1
+- description: user:user-b,namespace:test-ns-2,query:filter=metadata.name=test1
   user: user-b
   namespace: test-ns-2
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect: []
 - description: user:user-b,namespace:none,query:filter=metadata.name=test1
   user: user-b
@@ -344,10 +342,10 @@ tests:
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-c,namespace:none,query:labelSelector=test-label=2
+- description: user:user-c,namespace:none,query:filter=metadata.labels[test-label]=2
   user: user-c
   namespace: ''
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-1
@@ -355,45 +353,45 @@ tests:
     namespace: test-ns-2
   - name: test2
     namespace: test-ns-3
-- description: user:user-c,namespace:test-ns-1,query:labelSelector=test-label=2
+- description: user:user-c,namespace:test-ns-1,query:filter=metadata.labels[test-label]=2
   user: user-c
   namespace: test-ns-1
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect:
   - name: test2
     namespace: test-ns-1
-- description: user:user-c,namespace:test-ns-5,query:labelSelector=test-label=2
+- description: user:user-c,namespace:test-ns-5,query:filter=metadata.labels[test-label]=2
   user: user-c
   namespace: test-ns-5
-  query: labelSelector=test-label=2
+  query: filter=metadata.labels[test-label]=2
   expect: []
-- description: user:user-c,namespace:none,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-c,namespace:none,query:filter=metadata.namespace=test-ns-1
   user: user-c
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
   - name: test2
     namespace: test-ns-1
-- description: user:user-c,namespace:none,query:fieldSelector=metadata.namespace=test-ns-2
+- description: user:user-c,namespace:none,query:filter=metadata.namespace=test-ns-2
   user: user-c
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-2
+  query: filter=metadata.namespace=test-ns-2
   expect:
   - name: test1
     namespace: test-ns-2
   - name: test2
     namespace: test-ns-2
-- description: user:user-c,namespace:none,query:fieldSelector=metadata.namespace=test-ns-5
+- description: user:user-c,namespace:none,query:filter=metadata.namespace=test-ns-5
   user: user-c
   namespace: ''
-  query: fieldSelector=metadata.namespace=test-ns-5
+  query: filter=metadata.namespace=test-ns-5
   expect: []
-- description: user:user-c,namespace:none,query:fieldSelector=metadata.name=test1
+- description: user:user-c,namespace:none,query:filter=metadata.name=test1
   user: user-c
   namespace: ''
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
@@ -401,46 +399,46 @@ tests:
     namespace: test-ns-2
   - name: test1
     namespace: test-ns-3
-- description: user:user-c,namespace:none,query:fieldSelector=metadata.name=test5
+- description: user:user-c,namespace:none,query:filter=metadata.name=test5
   user: user-c
   namespace: ''
-  query: fieldSelector=metadata.name=test5
+  query: filter=metadata.name=test5
   expect: []
-- description: user:user-c,namespace:test-ns-1,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-c,namespace:test-ns-1,query:filter=metadata.namespace=test-ns-1
   user: user-c
   namespace: test-ns-1
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect:
   - name: test1
     namespace: test-ns-1
   - name: test2
     namespace: test-ns-1
-- description: user:user-c,namespace:test-ns-2,query:fieldSelector=metadata.namespace=test-ns-1
+- description: user:user-c,namespace:test-ns-2,query:filter=metadata.namespace=test-ns-1
   user: user-c
   namespace: test-ns-2
-  query: fieldSelector=metadata.namespace=test-ns-1
+  query: filter=metadata.namespace=test-ns-1
   expect: []
-- description: user:user-c,namespace:test-ns-1,query:fieldSelector=metadata.namespace=test-ns-2
+- description: user:user-c,namespace:test-ns-1,query:filter=metadata.namespace=test-ns-2
   user: user-c
   namespace: test-ns-1
-  query: fieldSelector=metadata.namespace=test-ns-2
+  query: filter=metadata.namespace=test-ns-2
   expect: []
-- description: user:user-c,namespace:test-ns-1,query:fieldSelector=metadata.name=test1
+- description: user:user-c,namespace:test-ns-1,query:filter=metadata.name=test1
   user: user-c
   namespace: test-ns-1
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect:
   - name: test1
     namespace: test-ns-1
-- description: user:user-c,namespace:test-ns-5,query:fieldSelector=metadata.name=test1
+- description: user:user-c,namespace:test-ns-5,query:filter=metadata.name=test1
   user: user-c
   namespace: test-ns-5
-  query: fieldSelector=metadata.name=test1
+  query: filter=metadata.name=test1
   expect: []
-- description: user:user-c,namespace:test-ns-1,query:fieldSelector=metadata.name=test5
+- description: user:user-c,namespace:test-ns-1,query:filter=metadata.name=test5
   user: user-c
   namespace: test-ns-1
-  query: fieldSelector=metadata.name=test5
+  query: filter=metadata.name=test5
   expect: []
 - description: user:user-c,namespace:none,query:filter=metadata.name=test1
   user: user-c

--- a/tests/integration/testdata/list/pagination.test.yaml
+++ b/tests/integration/testdata/list/pagination.test.yaml
@@ -1,10 +1,9 @@
 schemaID: secret
 tests:
-- description: user:user-a,namespace:none,query:limit=8
+- description: user:user-a,namespace:none,query:pagesize=8
   user: user-a
   namespace: ''
-  query: limit=8
-  runOn: nonsql
+  query: pagesize=8
   expect:
   - name: test1
     namespace: test-ns-1
@@ -22,11 +21,10 @@ tests:
     namespace: test-ns-2
   - name: test3
     namespace: test-ns-2
-- description: user:user-a,namespace:none,query:limit=8&continue=nondeterministictoken
+- description: user:user-a,namespace:none,query:pagesize=8&page=2
   user: user-a
   namespace: ''
-  query: limit=8&continue=nondeterministictoken
-  runOn: nonsql
+  query: pagesize=8&page=2
   expect:
   - name: test4
     namespace: test-ns-2
@@ -44,11 +42,10 @@ tests:
     namespace: test-ns-3
   - name: test1
     namespace: test-ns-4
-- description: user:user-a,namespace:test-ns-1,query:limit=3
+- description: user:user-a,namespace:test-ns-1,query:pagesize=3
   user: user-a
   namespace: test-ns-1
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect:
   - name: test1
     namespace: test-ns-1
@@ -56,57 +53,64 @@ tests:
     namespace: test-ns-1
   - name: test3
     namespace: test-ns-1
-- description: user:user-a,namespace:test-ns-1,query:limit=3&continue=nondeterministictoken
+- description: user:user-a,namespace:test-ns-1,query:pagesize=3&page=2
   user: user-a
   namespace: test-ns-1
-  query: limit=3&continue=nondeterministictoken
-  runOn: nonsql
+  query: pagesize=3&page=2
   expect:
   - name: test4
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&limit=20
+- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6
   user: user-a
   namespace: ''
-  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&limit=20
-  runOn: nonsql
-  expect:
-  - name: test5
-  - name: test5
-  - name: test5
-  - name: test5
-  - name: test4
-  - name: test4
-- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&page=2&revision=nondeterministicint&limit=20
-  user: user-a
-  namespace: ''
-  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&page=2&revision=nondeterministicint&limit=20
-  runOn: nonsql
-  expect:
-  - name: test4
-  - name: test4
-  - name: test3
-  - name: test3
-  - name: test3
-  - name: test3
-- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&page=1&limit=20&continue=nondeterministictoken
-  user: user-a
-  namespace: ''
-  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&page=1&limit=20&continue=nondeterministictoken
-  runOn: nonsql
+  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6
   expect:
   - name: test5
     namespace: test-ns-5
+  - name: test5
+    namespace: test-ns-4
+  - name: test5
+    namespace: test-ns-3
+  - name: test5
+    namespace: test-ns-2
+  - name: test5
+    namespace: test-ns-1
   - name: test4
     namespace: test-ns-5
+- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6&page=2
+  user: user-a
+  namespace: ''
+  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6&page=2
+  expect:
+  - name: test4
+    namespace: test-ns-4
+  - name: test4
+    namespace: test-ns-3
+  - name: test4
+    namespace: test-ns-2
+  - name: test4
+    namespace: test-ns-1
   - name: test3
     namespace: test-ns-5
-- description: user:user-b,namespace:none,query:limit=3
+  - name: test3
+    namespace: test-ns-4
+- description: user:user-a,namespace:none,query:filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6&page=3
+  user: user-a
+  namespace: ''
+  query: filter=metadata.labels.test-label-gte=3&sort=-metadata.name,-metadata.namespace&pagesize=6&page=3
+  expect:
+  - name: test3
+    namespace: test-ns-3
+  - name: test3
+    namespace: test-ns-2
+  - name: test3
+    namespace: test-ns-1
+- description: user:user-b,namespace:none,query:pagesize=3
   user: user-b
   namespace: ''
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect:
   - name: test1
     namespace: test-ns-1
@@ -114,21 +118,19 @@ tests:
     namespace: test-ns-1
   - name: test3
     namespace: test-ns-1
-- description: user:user-b,namespace:none,query:limit=3&continue=nondeterministictoken
+- description: user:user-b,namespace:none,query:pagesize=3&page=2
   user: user-b
   namespace: ''
-  query: limit=3&continue=nondeterministictoken
-  runOn: nonsql
+  query: pagesize=3&page=2
   expect:
   - name: test4
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-1,query:limit=3
+- description: user:user-b,namespace:test-ns-1,query:pagesize=3
   user: user-b
   namespace: test-ns-1
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect:
   - name: test1
     namespace: test-ns-1
@@ -136,27 +138,24 @@ tests:
     namespace: test-ns-1
   - name: test3
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-1,query:limit=3&continue=nondeterministictoken
+- description: user:user-b,namespace:test-ns-1,query:pagesize=3&page=2
   user: user-b
   namespace: test-ns-1
-  query: limit=3&continue=nondeterministictoken
-  runOn: nonsql
+  query: pagesize=3&page=2
   expect:
   - name: test4
     namespace: test-ns-1
   - name: test5
     namespace: test-ns-1
-- description: user:user-b,namespace:test-ns-5,query:limit=3
+- description: user:user-b,namespace:test-ns-5,query:pagesize=3
   user: user-b
   namespace: test-ns-5
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect: []
-- description: user:user-c,namespace:none,query:limit=3
+- description: user:user-c,namespace:none,query:pagesize=3
   user: user-c
   namespace: ''
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect:
   - name: test1
     namespace: test-ns-1
@@ -164,11 +163,10 @@ tests:
     namespace: test-ns-1
   - name: test1
     namespace: test-ns-2
-- description: user:user-c,namespace:none,query:limit=3&continue=nondeterministictoken
+- description: user:user-c,namespace:none,query:pagesize=3&page=2
   user: user-c
   namespace: ''
-  query: limit=3&continue=nondeterministictoken
-  runOn: nonsql
+  query: pagesize=3&page=2
   expect:
   - name: test2
     namespace: test-ns-2
@@ -176,19 +174,17 @@ tests:
     namespace: test-ns-3
   - name: test2
     namespace: test-ns-3
-- description: user:user-c,namespace:test-ns-1,query:limit=3
+- description: user:user-c,namespace:test-ns-1,query:pagesize=3
   user: user-c
   namespace: test-ns-1
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect:
   - name: test1
     namespace: test-ns-1
   - name: test2
     namespace: test-ns-1
-- description: user:user-c,namespace:test-ns-5,query:limit=3
+- description: user:user-c,namespace:test-ns-5,query:pagesize=3
   user: user-c
   namespace: test-ns-5
-  query: limit=3
-  runOn: nonsql
+  query: pagesize=3
   expect: []


### PR DESCRIPTION
# DNM

## This is for 2.16

Ref [#53996](https://github.com/rancher/rancher/issues/53996)

The integration tests that used `nondeterministictoken` and `nondeterministicint` now just use
`pagesize` and `page` because we expect clients will be tracking page numbers of requests.

The `--sql-cache` option is still accepted but now triggers a warning message that it is no longer needed.
I'll leave it for Product to decide when it should no longer be allowed.

Note that I'm also working on applying this change to rancher/rancher as well -- it affects the way r/r invokes the steve server, as well as the legacy integration tests.