### PR TITLE
Fix panic when sorting non-SQL lists by a boolean field (rancher/rancher#55593)

### DIFF
--- a/pkg/stores/partition/listprocessor/processor.go
+++ b/pkg/stores/partition/listprocessor/processor.go
@@ -380,7 +380,7 @@ func SortList(list []unstructured.Unstructured, s Sort) []unstructured.Unstructu
 		for j, fields := range s.Fields {
 			val, ok := data.GetValueFromAny(list[i].Object, fields...)
 			if ok {
-				td.stringValues[j] = val.(string)
+				td.stringValues[j] = convert.ToString(val)
 			} else {
 				logrus.Debugf("Failed to walk list item %d with fields %s", i, fields)
 				td.stringValues[j] = ""

--- a/pkg/stores/partition/listprocessor/processor_test.go
+++ b/pkg/stores/partition/listprocessor/processor_test.go
@@ -2665,6 +2665,61 @@ func TestSortList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sort by boolean field metadata.state.error",
+			objects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "pod",
+						"metadata": map[string]interface{}{
+							"name": "alpha",
+							"state": map[string]interface{}{
+								"error": true,
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "pod",
+						"metadata": map[string]interface{}{
+							"name": "bravo",
+							"state": map[string]interface{}{
+								"error": false,
+							},
+						},
+					},
+				},
+			},
+			sort: Sort{
+				Fields: [][]string{{"metadata", "state", "error"}},
+				Orders: []SortOrder{ASC},
+			},
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"kind": "pod",
+						"metadata": map[string]interface{}{
+							"name": "bravo",
+							"state": map[string]interface{}{
+								"error": false,
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"kind": "pod",
+						"metadata": map[string]interface{}{
+							"name": "alpha",
+							"state": map[string]interface{}{
+								"error": true,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Sorting a non-SQL list by a boolean field panics and kills the request handler, so Cluster Explorer renders blank:

```
http: panic serving ...: interface conversion: interface {} is bool, not string
    listprocessor.SortList(...) processor.go:383
```

## Cause

`SortList` did an unchecked `val.(string)` on values from `data.GetValueFromAny`, but sortable fields aren't always strings — e.g. `metadata.state.error` (a bool, behind the dashboard's **State** column). Regressed in #618, which dropped the earlier `convert.ToString(...)`. Non-SQL path only; the SQL cache sorts via `ORDER BY`.

## Fix

Restore `convert.ToString(val)`; add a `TestSortList` regression case for boolean/missing fields.

Fixes rancher/rancher#55593
