### PR TITLE
Drop unsupported versions from VERSION.md

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -8,7 +8,3 @@ Steve follows a pre-release (v0.x) strategy of semver. There is no compatibility
 | release/v0.7 | v0.7 | v2.13 |
 | release/v0.6 | v0.6 | v2.12 |
 | release/v0.5 | v0.5 | v2.11 |
-| release/v0.4 | v0.4 | v2.10 |
-| release/v0.3 | v0.3 | v2.9 |
-| release/v0.2 | v0.2 | v2.8 |
-| release/v0.1 | v0.1 | v2.7 |


### PR DESCRIPTION
Remove release/v0.1-v0.4 (rancher v2.7-v2.10) from the supported-versions table as they are no longer supported
