### PR TITLE
Disable Go minor/major version bumps on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,6 +61,13 @@
       "enabled": false
     },
     {
+      "description": "Do not bump the Go minor/major version on release branches",
+      "matchDepNames": ["go"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchBaseBranches": ["/^release\\//"],
+      "enabled": false
+    },
+    {
       "description": "Group all GitHub Actions updates into a single PR per branch",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Issue:  https://github.com/rancher/rancher/issues/50186

Adds the "Do not bump the Go minor/major version on release branches" packageRule

The per-release-line presets only cap the go/golang-version `allowedVersions` ceiling, they don't block minor bumps within it.
