### PR TITLE
Retry sort/filter integration assertions until the SQL cache catches up

### DIFF
--- a/tests/integration/sorting_test.go
+++ b/tests/integration/sorting_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rancher/steve/pkg/server"
 	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -85,26 +86,37 @@ func (i *IntegrationSuite) testSortScenario(ctx context.Context, scenario string
 		i.Run(test.Query, func() {
 			url := fmt.Sprintf("%s/v1/%s?%s", baseURL, sortTestConfig.SchemaID, test.Query)
 			fmt.Println(url)
-			resp, err := http.Get(url)
-			i.Require().NoError(err)
-			defer resp.Body.Close()
 
-			i.Require().Equal(http.StatusOK, resp.StatusCode)
+			// The SQL cache indexer processes newly-applied objects
+			// asynchronously, so the freshly-applied fixtures may not be
+			// fully indexed yet. Retry until the expected data shows up.
+			i.Require().EventuallyWithT(func(c *assert.CollectT) {
+				resp, err := http.Get(url)
+				if !assert.NoError(c, err) {
+					return
+				}
+				defer resp.Body.Close()
 
-			type Response struct {
-				Data []struct {
-					ID string `json:"id"`
-				} `json:"data"`
-			}
-			var parsed Response
-			err = json.NewDecoder(resp.Body).Decode(&parsed)
-			i.Require().NoError(err)
+				if !assert.Equal(c, http.StatusOK, resp.StatusCode) {
+					return
+				}
 
-			var ids []string
-			for _, data := range parsed.Data {
-				ids = append(ids, data.ID)
-			}
-			i.Require().Equal(test.Expected, ids)
+				type Response struct {
+					Data []struct {
+						ID string `json:"id"`
+					} `json:"data"`
+				}
+				var parsed Response
+				if !assert.NoError(c, json.NewDecoder(resp.Body).Decode(&parsed)) {
+					return
+				}
+
+				var ids []string
+				for _, data := range parsed.Data {
+					ids = append(ids, data.ID)
+				}
+				assert.Equal(c, test.Expected, ids)
+			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}
 }


### PR DESCRIPTION
Related to:  https://github.com/rancher/steve/pull/794

testSortScenario applies fixtures, waits for the resource type's schema to
register via `waitForSchema`, then does a single one-shot HTTP GET + compare
against the sort/filter API. `waitForSchema` only confirms the resource type
is registered in Steve's schema.  It doesn't confirm the SQL cache indexer
has finished processing the specific objects just applied.

This was previously masked by incidental timing — enough wall-clock elapsed
between fixture-apply and query for indexing to settle in practice. It became
visible when testify v1.11.1 changed `EventuallyWithT` to check its condition immediately instead
of after the first tick, shaving off just enough of that incidental buffer to
expose the race.

To fix this, we now wrap the request + comparison in `EventuallyWithT`,
using assert.CollectT throughout so each failure is scoped correctly and retried rather than
immediately failing the subtest.