### PR TITLE
[release/v0.9] sqlcache: tolerate DeletedFinalStateUnknown in Store.Delete

### DIFF
--- a/pkg/sqlcache/informer/listoption_indexer.go
+++ b/pkg/sqlcache/informer/listoption_indexer.go
@@ -361,16 +361,8 @@ func (l *ListOptionIndexer) notifyEventModified(key string, obj any, _ db.TxClie
 	return l.notifyEvent(watch.Modified, oldObj, obj)
 }
 
-func (l *ListOptionIndexer) notifyEventDeleted(key string, obj any, _ db.TxClient) error {
-	oldObj, exists, err := l.GetByKey(key)
-	if err != nil {
-		return fmt.Errorf("error getting old object: %w", err)
-	}
-
-	if !exists {
-		return fmt.Errorf("old object %q should be in store but was not", key)
-	}
-	return l.notifyEvent(watch.Deleted, oldObj, obj)
+func (l *ListOptionIndexer) notifyEventDeleted(_ string, obj any, _ db.TxClient) error {
+	return l.notifyEvent(watch.Deleted, obj, obj)
 }
 
 func (l *ListOptionIndexer) notifyEvent(eventType watch.EventType, old any, current any) error {

--- a/pkg/sqlcache/informer/relist_test.go
+++ b/pkg/sqlcache/informer/relist_test.go
@@ -1,0 +1,173 @@
+package informer
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rancher/steve/pkg/sqlcache/db"
+	"github.com/rancher/steve/pkg/sqlcache/encryption"
+	"github.com/rancher/steve/pkg/sqlcache/store"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestRelistAfterWatchError exercises the path the user actually hits in
+// rancher/rancher#55228: the reflector's watch dies, the reflector re-lists
+// from a source whose contents have changed during the gap, and steve's
+// SQLite cache must end up reflecting the new state.
+//
+// This is a behavioral test, deliberately not pinned to any particular
+// client-go FIFO. On client-go v0.34/v0.35 (DeltaFIFO) the deletion travels
+// through processDeltas → Store.Delete(DeletedFinalStateUnknown). On v0.36+
+// with AtomicFIFO it travels through processReplacedAllInfo → Store.Replace.
+// The assertion is the same either way: rows that vanished from the source
+// must vanish from SQLite.
+func TestRelistAfterWatchError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gvk := schema.GroupVersionKind{Group: "fruits.cattle.io", Version: "v1", Kind: "Banana"}
+
+	bananaA := makeRelistBanana("a", "10")
+	bananaB := makeRelistBanana("b", "20")
+
+	src := newRelistSource(gvk)
+	src.setItems([]*unstructured.Unstructured{bananaA, bananaB})
+
+	m, err := encryption.NewManager()
+	require.NoError(t, err)
+	dbClient, dbPath, err := db.NewClient(ctx, nil, m, m, true)
+	require.NoError(t, err)
+	defer cleanTempFiles(dbPath)
+
+	example := &unstructured.Unstructured{}
+	example.SetGroupVersionKind(gvk)
+	s, err := store.NewStore(
+		ctx, example, cache.DeletionHandlingMetaNamespaceKeyFunc,
+		dbClient, false, gvk, informerNameFromGVK(gvk), nil, nil,
+	)
+	require.NoError(t, err)
+
+	loi, err := NewListOptionIndexer(ctx, s, ListOptionIndexerOptions{
+		IsNamespaced: false,
+		GCKeepCount:  1000,
+	})
+	require.NoError(t, err)
+
+	sii := cache.NewSharedIndexInformer(
+		&noWatchListListWatcher{ListWatch: src.listWatch()},
+		example,
+		0, // resyncPeriod
+		cache.Indexers{},
+	)
+	UnsafeSet(sii, "indexer", loi)
+
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	go sii.RunWithContext(runCtx)
+	require.True(t, cache.WaitForCacheSync(runCtx.Done(), sii.HasSynced), "informer never synced")
+
+	// Both Bananas land in SQLite after the initial list.
+	require.Eventually(t, func() bool {
+		_, exA, _ := sii.GetStore().GetByKey("a")
+		_, exB, _ := sii.GetStore().GetByKey("b")
+		return exA && exB
+	}, 5*time.Second, 50*time.Millisecond, "Bananas never landed in SQLite")
+
+	// Simulate "B was deleted while the watch was down": remove B from the
+	// source, then close the watch with an error to force the reflector to
+	// abandon ListAndWatch and re-list from scratch.
+	src.setItems([]*unstructured.Unstructured{bananaA})
+	require.Eventually(t, func() bool {
+		return src.currentWatcher() != nil
+	}, 2*time.Second, 50*time.Millisecond, "reflector never opened a watch")
+	src.currentWatcher().Error(&metav1.Status{
+		Status:  metav1.StatusFailure,
+		Reason:  metav1.StatusReasonGone,
+		Code:    410,
+		Message: "test-induced watch close",
+	})
+
+	// After the re-list, A must still be present and B must be gone.
+	require.Eventually(t, func() bool {
+		_, exA, errA := sii.GetStore().GetByKey("a")
+		_, exB, errB := sii.GetStore().GetByKey("b")
+		return errA == nil && errB == nil && exA && !exB
+	}, 10*time.Second, 100*time.Millisecond,
+		"SQLite cache not reconciled after watch-error + re-list (B should be gone, A should remain)")
+}
+
+// relistSource is a test list/watch source that lets the test control both
+// the contents returned by List and the active watcher returned by Watch.
+type relistSource struct {
+	gvk schema.GroupVersionKind
+
+	mu      sync.Mutex
+	items   []*unstructured.Unstructured
+	rv      int
+	watcher *watch.FakeWatcher
+}
+
+func newRelistSource(gvk schema.GroupVersionKind) *relistSource {
+	return &relistSource{gvk: gvk}
+}
+
+func (s *relistSource) setItems(items []*unstructured.Unstructured) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = items
+}
+
+func (s *relistSource) currentWatcher() *watch.FakeWatcher {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watcher
+}
+
+func (s *relistSource) listWatch() *cache.ListWatch {
+	return &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.rv++
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   s.gvk.Group,
+				Version: s.gvk.Version,
+				Kind:    s.gvk.Kind + "List",
+			})
+			list.SetResourceVersion(strconv.Itoa(s.rv))
+			for _, it := range s.items {
+				list.Items = append(list.Items, *it.DeepCopy())
+			}
+			return list, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.watcher = watch.NewFake()
+			return s.watcher, nil
+		},
+	}
+}
+
+func makeRelistBanana(name, rv string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "fruits.cattle.io/v1",
+			"kind":       "Banana",
+			"metadata": map[string]any{
+				"name":            name,
+				"resourceVersion": rv,
+			},
+		},
+	}
+}

--- a/pkg/sqlcache/store/store.go
+++ b/pkg/sqlcache/store/store.go
@@ -451,6 +451,17 @@ func (s *Store) Delete(obj any) error {
 	if err != nil {
 		return err
 	}
+	if t, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = t.Obj
+	}
+	if obj == nil {
+		// Tombstone with no payload. DeltaFIFO.Replace synthesizes these
+		// when its knownObjects lookup failed during a re-list — and that
+		// knownObjects is this same Store. There's nothing to delete and
+		// nothing to hand the after-delete hooks.
+		logrus.Warnf("Store.Delete for type %v: tombstone with no payload for key %q; skipping", s.name, key)
+		return nil
+	}
 	err = s.deleteByKey(key, obj)
 	if err != nil {
 		log.Errorf("Error in Store.Delete for type %v: %v", s.name, err)

--- a/pkg/sqlcache/store/store_test.go
+++ b/pkg/sqlcache/store/store_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 )
 
 func testStoreKeyFunc(obj interface{}) (string, error) {
@@ -383,6 +385,77 @@ func TestDelete(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) { test.test(t, false) })
 		t.Run(fmt.Sprintf("%s with encryption", test.description), func(t *testing.T) { test.test(t, true) })
 	}
+}
+
+// TestDeleteTombstone verifies that Store.Delete honors the cache.Store
+// contract for cache.DeletedFinalStateUnknown wrappers, which the reflector
+// hands to Delete on missed-delete relists. See rancher/rancher#55228:
+// before the fix the wrapper reached the after-delete hook's meta.Accessor
+// call, the hook errored, and the whole DELETE transaction rolled back —
+// so the row survived in the SQLite cache as stale data.
+func TestDeleteTombstone(t *testing.T) {
+	testObject := testStoreObject{Id: "something", Val: "a"}
+
+	t.Run("tombstone with payload — unwraps and deletes", func(t *testing.T) {
+		c, txC := SetupMockDB(t)
+		store := setupTombstoneStore(t, c)
+
+		var hookSawKey string
+		var hookSawObj any
+		store.RegisterAfterDelete(func(key string, obj any, _ db.TxClient) error {
+			hookSawKey = key
+			hookSawObj = obj
+			return nil
+		})
+
+		stmt := NewMockStmt(gomock.NewController(t))
+		txC.EXPECT().Stmt(store.deleteStmt).Return(stmt)
+		stmt.EXPECT().Exec(testObject.Id).Return(nil, nil)
+		c.EXPECT().WithTransaction(gomock.Any(), true, gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ bool, f db.WithTransactionFunction) {
+				require.NoError(t, f(txC))
+			})
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: testObject.Id, Obj: testObject}
+		require.NoError(t, store.Delete(tombstone))
+		require.Equal(t, testObject.Id, hookSawKey)
+		require.Equal(t, testObject, hookSawObj,
+			"after-delete hook must see the unwrapped object, not the tombstone wrapper")
+	})
+
+	t.Run("tombstone with nil payload — short-circuits", func(t *testing.T) {
+		c, _ := SetupMockDB(t)
+		store := setupTombstoneStore(t, c)
+
+		hookCalled := false
+		store.RegisterAfterDelete(func(string, any, db.TxClient) error {
+			hookCalled = true
+			return nil
+		})
+		// No EXPECT on WithTransaction — gomock will fail the test if Delete
+		// reaches the SQL path at all.
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: "ghost", Obj: nil}
+		require.NoError(t, store.Delete(tombstone))
+		require.False(t, hookCalled, "after-delete hook must not run for a nil-payload tombstone")
+	})
+}
+
+// setupTombstoneStore is a SetupStore variant whose keyFunc handles
+// cache.DeletedFinalStateUnknown (matching the real DeletionHandling
+// MetaNamespaceKeyFunc that production callers use).
+func setupTombstoneStore(t *testing.T, client *MockClient) *Store {
+	name := "testStoreObject"
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: name}
+	keyFunc := func(obj any) (string, error) {
+		if t, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			return t.Key, nil
+		}
+		return obj.(testStoreObject).Id, nil
+	}
+	s, err := NewStore(context.Background(), testStoreObject{}, keyFunc, client, false, gvk, name, nil, nil)
+	require.NoError(t, err)
+	return s
 }
 
 // List returns a list of all the currently non-empty accumulators


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/55228

Forward-port of #1209 (release/v0.8) to `release/v0.9`.

## Symptom / Fix

Same as #1209: when the reflector loses its watch and falls back to a fresh List, client-go's FIFO deletion-detection can hand `Store.Delete` a `cache.DeletedFinalStateUnknown` tombstone. The after-delete hook's `meta.Accessor` call errors on the wrapper (it doesn't implement `metav1.Object`), rolling back the SQL DELETE and leaving stale rows in the cache.

`Store.Delete` now unwraps the tombstone before running after-delete hooks, and `notifyEventDeleted` drops the now-unnecessary `GetByKey` round-trip (which had its own `!exists` error path that would trigger the same rollback failure mode on a missing cache entry).

## Note on relevance to `release/v0.9`

`release/v0.9` is already on `k8s.io/client-go` v0.36.0, same as `main`, where the `AtomicFIFO` feature gate defaults to `true` and relists go through `Store.Replace` rather than per-object `Store.Delete`. This bug is not currently reachable by default on this branch either. This PR is a defensive/consistency forward-port in case that feature gate is ever disabled, or for any other codepath that reaches `Store.Delete` with a tombstone.

## Tests

Same coverage as #1209: `TestRelistAfterWatchError` (pkg/sqlcache/informer/relist_test.go) reproduces the tombstone-through-relist path end-to-end, plus new `TestDeleteTombstone` unit tests in pkg/sqlcache/store/store_test.go.

Verified locally: `go build ./...` and `go test ./pkg/sqlcache/...` (including the envtest-backed integration suite) pass.