### PR TITLE
[v0.9] Derive generateName prefix from Kind instead of schema ID

### DIFF
--- a/pkg/schema/converter/k8stonorman.go
+++ b/pkg/schema/converter/k8stonorman.go
@@ -4,6 +4,7 @@ package converter
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
@@ -22,6 +23,17 @@ const (
 	gvkExtensionVersion = "version"
 	gvkExtensionKind    = "kind"
 )
+
+var lowerChars = regexp.MustCompile("[a-z]+")
+
+// GenerateNamePrefix derives a metadata.generateName prefix from a kind, mirroring norman's convention (e.g. "User" -> "u-", "GlobalRole" -> "gr-").
+func GenerateNamePrefix(kind string) string {
+	if kind == "" {
+		return ""
+	}
+	base := kind[0:1] + lowerChars.ReplaceAllString(kind[1:], "")
+	return strings.ToLower(base) + "-"
+}
 
 func GVKToVersionedSchemaID(gvk schema.GroupVersionKind) string {
 	if gvk.Group == "" {

--- a/pkg/schema/converter/k8stonorman_test.go
+++ b/pkg/schema/converter/k8stonorman_test.go
@@ -508,6 +508,46 @@ func TestGVKToSchemaID(t *testing.T) {
 	}
 }
 
+func TestGenerateNamePrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{
+			name: "single word kind",
+			kind: "User",
+			want: "u-",
+		},
+		{
+			name: "camel case kind uses initials",
+			kind: "GlobalRole",
+			want: "gr-",
+		},
+		{
+			name: "multiple capitals",
+			kind: "ClusterRoleTemplateBinding",
+			want: "crtb-",
+		},
+		{
+			name: "single letter kind",
+			kind: "T",
+			want: "t-",
+		},
+		{
+			name: "empty kind",
+			kind: "",
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, GenerateNamePrefix(test.kind))
+		})
+	}
+}
+
 func TestGVRToPluralName(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/stores/proxy/proxy_store.go
+++ b/pkg/stores/proxy/proxy_store.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/rancher/steve/pkg/accesscontrol"
 	"github.com/rancher/steve/pkg/attributes"
+	"github.com/rancher/steve/pkg/schema/converter"
 	metricsStore "github.com/rancher/steve/pkg/stores/metrics"
 	"github.com/rancher/steve/pkg/stores/partition"
 )
@@ -430,7 +431,11 @@ func (s *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, params 
 	generateName := input.String("metadata", "generateName")
 
 	if name == "" && generateName == "" {
-		input.SetNested(schema.ID[0:1]+"-", "metadata", "generateName")
+		prefix := schema.ID[0:1] + "-"
+		if gvk := attributes.GVK(schema); gvk.Kind != "" {
+			prefix = converter.GenerateNamePrefix(gvk.Kind)
+		}
+		input.SetNested(prefix, "metadata", "generateName")
 	}
 
 	if attributes.Namespaced(schema) && namespace == "" {

--- a/pkg/stores/proxy/proxy_store_test.go
+++ b/pkg/stores/proxy/proxy_store_test.go
@@ -343,7 +343,7 @@ func TestCreate(t *testing.T) {
 					"apiVersion": "v1",
 					"kind":       "Secret",
 					"metadata": map[string]interface{}{
-						"generateName": "t-",
+						"generateName": "s-",
 						"namespace":    "testing-ns",
 					},
 				}},

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rancher/steve/pkg/resources/common"
 	"github.com/rancher/steve/pkg/resources/virtual"
 	virtualCommon "github.com/rancher/steve/pkg/resources/virtual/common"
+	"github.com/rancher/steve/pkg/schema/converter"
 	metricsStore "github.com/rancher/steve/pkg/stores/metrics"
 	"github.com/rancher/steve/pkg/stores/sqlpartition/listprocessor"
 	"github.com/rancher/steve/pkg/stores/sqlproxy/tablelistconvert"
@@ -849,7 +850,11 @@ func (s *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, params 
 	generateName := input.String("metadata", "generateName")
 
 	if name == "" && generateName == "" {
-		input.SetNested(schema.ID[0:1]+"-", "metadata", "generateName")
+		prefix := schema.ID[0:1] + "-"
+		if gvk := attributes.GVK(schema); gvk.Kind != "" {
+			prefix = converter.GenerateNamePrefix(gvk.Kind)
+		}
+		input.SetNested(prefix, "metadata", "generateName")
 	}
 
 	if attributes.Namespaced(schema) && namespace == "" {

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -1542,7 +1542,7 @@ func TestCreate(t *testing.T) {
 					"apiVersion": "v1",
 					"kind":       "Secret",
 					"metadata": map[string]interface{}{
-						"generateName": "t-",
+						"generateName": "s-",
 						"namespace":    "testing-ns",
 					},
 				}},


### PR DESCRIPTION
Backport of #1237 to `release/v0.9` (Rancher v2.15).

Steve's generic `Create` path defaulted `metadata.generateName` to the first character of the group-qualified schema ID (e.g. `management.cattle.io.user`), producing prefixes like `m-` for new users instead of the expected `u-`. This derives the prefix from the resource Kind, matching norman's convention.

See rancher/rancher#56214.