### PR TITLE
Use unique temp SQLite path per integration test cache factory

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -78,6 +78,15 @@ type Server struct {
 	SQLCache                   bool
 }
 
+// SQLCacheDBPath returns the path to the SQLite database file backing the SQL cache,
+// or "" if SQLCache is disabled.
+func (s *Server) SQLCacheDBPath() string {
+	if s.cacheFactory == nil {
+		return ""
+	}
+	return s.cacheFactory.DBPath()
+}
+
 type Options struct {
 	// Controllers If the controllers are passed in the caller must also start the controllers
 	Controllers                *Controllers

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,11 +80,11 @@ type Server struct {
 
 // SQLCacheDBPath returns the path to the SQLite database file backing the SQL cache,
 // or "" if SQLCache is disabled.
-func (s *Server) SQLCacheDBPath() string {
-	if s.cacheFactory == nil {
+func (c *Server) SQLCacheDBPath() string {
+	if c.cacheFactory == nil {
 		return ""
 	}
-	return s.cacheFactory.DBPath()
+	return c.cacheFactory.DBPath()
 }
 
 type Options struct {

--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -29,6 +29,7 @@ const EncryptAllEnvVar = "CATTLE_ENCRYPT_CACHE_ALL"
 // CacheFactory builds Informer instances and keeps a cache of instances it created
 type CacheFactory struct {
 	dbClient db.Client
+	dbPath   string
 
 	// ctx determines when informers need to stop
 	ctx    context.Context
@@ -96,6 +97,11 @@ type CacheFactoryOptions struct {
 	// GCKeepCount is how many events to keep in memory
 	GCKeepCount             int
 	DBMetricsUpdateInterval time.Duration
+	// UseTempDir stores the SQLite cache database in a unique temp file instead of the
+	// fixed InformerObjectCacheDBPath. Each CacheFactory otherwise deletes and recreates
+	// that shared file on startup, which races with other CacheFactory instances (e.g.
+	// concurrent/sequential test runs) still using it. Tests should set this to true.
+	UseTempDir bool
 }
 
 // NewCacheFactory returns an informer factory instance
@@ -110,7 +116,7 @@ func NewCacheFactoryWithContext(ctx context.Context, opts CacheFactoryOptions) (
 		return nil, err
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	dbClient, dbPath, err := db.NewClient(ctx, nil, m, m, false)
+	dbClient, dbPath, err := db.NewClient(ctx, nil, m, m, opts.UseTempDir)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -122,6 +128,7 @@ func NewCacheFactoryWithContext(ctx context.Context, opts CacheFactoryOptions) (
 
 		encryptAll: os.Getenv(EncryptAllEnvVar) == "true",
 		dbClient:   dbClient,
+		dbPath:     dbPath,
 
 		gcKeepCount: opts.GCKeepCount,
 
@@ -296,6 +303,11 @@ func (f *CacheFactory) DoneWithCache(cache *Cache) {
 	}
 
 	cache.gi.wg.Done()
+}
+
+// DBPath returns the path to the SQLite database file backing this cache factory.
+func (f *CacheFactory) DBPath() string {
+	return f.dbPath
 }
 
 // Stop cancels ctx which stops any running informers, assigns a new ctx, resets the GVK-informer cache, and resets

--- a/tests/integration/associateddata_test.go
+++ b/tests/integration/associateddata_test.go
@@ -51,6 +51,7 @@ func (i *IntegrationSuite) TestAssociatedData() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 		AuthMiddleware: authMiddleware,
 	})

--- a/tests/integration/association_test.go
+++ b/tests/integration/association_test.go
@@ -30,6 +30,7 @@ func (i *IntegrationSuite) TestListAssociations() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/column_test.go
+++ b/tests/integration/column_test.go
@@ -29,6 +29,7 @@ func (i *IntegrationSuite) TestListColumns() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/filtering_test.go
+++ b/tests/integration/filtering_test.go
@@ -29,6 +29,7 @@ func (i *IntegrationSuite) TestListFiltering() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/list_test.go
+++ b/tests/integration/list_test.go
@@ -87,6 +87,7 @@ func (i *IntegrationSuite) runListTest(ctx context.Context, sqlCache bool, gvrs 
 			SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 				GCInterval:  15 * time.Minute,
 				GCKeepCount: 1000,
+				UseTempDir:  true,
 			},
 			AuthMiddleware: authMiddleware,
 		})

--- a/tests/integration/namespace_formatter_test.go
+++ b/tests/integration/namespace_formatter_test.go
@@ -44,6 +44,7 @@ func (i *IntegrationSuite) TestNamespaceFormatter() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 		AuthMiddleware: authMiddleware,
 	})

--- a/tests/integration/non_listable_resource_test.go
+++ b/tests/integration/non_listable_resource_test.go
@@ -17,16 +17,17 @@ import (
 func (i *IntegrationSuite) TestIssue51930() {
 	ctx := i.T().Context()
 	// Start steve with SQL Cache enabled
-	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+	steveServer, err := server.New(ctx, i.restCfg, &server.Options{
 		SQLCache: true,
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)
 
-	httpServer := httptest.NewServer(steveHandler)
+	httpServer := httptest.NewServer(steveServer)
 	defer httpServer.Close()
 
 	baseURL := httpServer.URL
@@ -58,9 +59,7 @@ func (i *IntegrationSuite) TestIssue51930() {
 	fmt.Printf("TokenReview list response: %d\n", resp.StatusCode)
 
 	// Check if the table was created in the SQLite database.
-	// The DB path is in i.sqliteDatabaseFile
-
-	db, err := sql.Open("sqlite", i.sqliteDatabaseFile)
+	db, err := sql.Open("sqlite", steveServer.SQLCacheDBPath())
 	i.Require().NoError(err)
 	defer db.Close()
 

--- a/tests/integration/podrestarts_test.go
+++ b/tests/integration/podrestarts_test.go
@@ -58,6 +58,7 @@ func (i *IntegrationSuite) runPodRestartsTest(ctx context.Context, sqlCache bool
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 		AuthMiddleware: authMiddleware,
 	})

--- a/tests/integration/schema_refresh_test.go
+++ b/tests/integration/schema_refresh_test.go
@@ -56,6 +56,7 @@ func (i *IntegrationSuite) TestSchemaRefresh() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/sorting_test.go
+++ b/tests/integration/sorting_test.go
@@ -30,6 +30,7 @@ func (i *IntegrationSuite) TestListSorting() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)
@@ -130,6 +131,7 @@ func (i *IntegrationSuite) TestListSortPodsByStateName() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/state_test.go
+++ b/tests/integration/state_test.go
@@ -35,6 +35,7 @@ func (i *IntegrationSuite) TestStateUpdate() {
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 			GCInterval:  15 * time.Minute,
 			GCKeepCount: 1000,
+			UseTempDir:  true,
 		},
 	})
 	i.Require().NoError(err)

--- a/tests/integration/summary_test.go
+++ b/tests/integration/summary_test.go
@@ -99,6 +99,7 @@ func (i *IntegrationSuite) runSummaryTest(ctx context.Context, sqlCache bool, gv
 			SQLCacheFactoryOptions: factory.CacheFactoryOptions{
 				GCInterval:  15 * time.Minute,
 				GCKeepCount: 1000,
+				UseTempDir:  true,
 			},
 			AuthMiddleware: authMiddleware,
 		})


### PR DESCRIPTION
Refs rancher/rancher#56459

Each integration test's `server.New()` builds its own `CacheFactory`, backed by the fixed `InformerObjectCacheDBPath`. Opening that path deletes and recreates the file every time, so one test's setup could delete the SQLite file still in use by a previous test's not-yet-stopped informer goroutines - causing sporadic `no such table` / `SQL logic error` failures across unrelated tests in CI.

Fix: give each test's cache factory a unique temp-dir SQLite path (`UseTempDir: true`) instead of sharing the fixed one.