### PR TITLE
Retry CacheFor when a concurrent schema Stop() resets the cache

### DIFF
--- a/pkg/sqlcache/informer/factory/informer_factory.go
+++ b/pkg/sqlcache/informer/factory/informer_factory.go
@@ -5,6 +5,7 @@ package factory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -16,11 +17,17 @@ import (
 	"github.com/rancher/steve/pkg/sqlcache/encryption"
 	"github.com/rancher/steve/pkg/sqlcache/informer"
 	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 )
+
+// ErrCacheReset is returned (wrapped) by CacheFor when a concurrent Stop(gvk) (eg: triggered
+// by a schema/column definition change) canceled the cache's context while we were waiting
+// for it to sync. Unlike other CacheFor errors, this one is safe for a caller to retry:
+// Stop() always leaves the informer ready for a fresh initialization by the time it returns.
+var ErrCacheReset = errors.New("cache was reset by a concurrent Stop")
 
 // EncryptAllEnvVar is set to "true" if users want all types' data blobs to be encrypted in SQLite
 // otherwise only variables in defaultEncryptedResourceTypes will have their blobs encrypted
@@ -240,7 +247,7 @@ func (f *CacheFactory) initializeInformerLocked(gi *guardedInformer, fields map[
 	}
 
 	if err := i.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
-		if !watchable && errors.IsMethodNotSupported(err) {
+		if !watchable && k8serrors.IsMethodNotSupported(err) {
 			// expected, continue without logging
 			return
 		}
@@ -274,7 +281,7 @@ func (f *CacheFactory) waitForCacheReady(ctx context.Context, gvk schema.GroupVe
 
 	if !cache.WaitForCacheSync(ctx.Done(), gi.informer.HasSynced) {
 		if gi.ctx.Err() != nil {
-			return nil, fmt.Errorf("cache context canceled while waiting for SQL cache sync for %v: %w", gvk, gi.ctx.Err())
+			return nil, fmt.Errorf("cache context canceled while waiting for SQL cache sync for %v: %w: %w", gvk, ErrCacheReset, gi.ctx.Err())
 		}
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("request context canceled while waiting for SQL cache sync for %v: %w", gvk, ctx.Err())

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -1296,7 +1296,19 @@ func (s *Store) cacheFor(ctx context.Context, apiOp *types.APIRequest, apiSchema
 	transformFunc := s.transformBuilder.GetTransformFunc(gvk, cols, attributes.IsCRD(apiSchema), attributes.CRDJSONPathParsers(apiSchema))
 	tableClient := &tablelistconvert.Client{ResourceInterface: client}
 	ns := attributes.Namespaced(apiSchema)
-	inf, err := s.cacheFactory.CacheFor(ctx, fields, externalGVKDependencies[gvk], selfGVKDependencies[gvk], transformFunc, tableClient, gvk, ns, controllerschema.IsListWatchable(apiSchema), watchlist.Disabled(apiSchema))
+
+	// A concurrent schema/column definition change can reset gvk's cache (see
+	// factory.ErrCacheReset) right as we're waiting for it to become ready, canceling our
+	// wait. That's a transient race, not a real failure, and the cache is immediately usable
+	// again once Stop() returns - so retry a few times instead of failing the request.
+	const maxCacheResetRetries = 3
+	var inf *factory.Cache
+	for attempt := 0; attempt <= maxCacheResetRetries; attempt++ {
+		inf, err = s.cacheFactory.CacheFor(ctx, fields, externalGVKDependencies[gvk], selfGVKDependencies[gvk], transformFunc, tableClient, gvk, ns, controllerschema.IsListWatchable(apiSchema), watchlist.Disabled(apiSchema))
+		if err == nil || !errors.Is(err, factory.ErrCacheReset) {
+			break
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("cachefor %v: %w", gvk, err)
 	}

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -2378,3 +2378,77 @@ func TestPatchFallsBackToAPIOpNamespace(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "testing-ns", gotNamespace)
 }
+
+func TestCacheForRetriesOnConcurrentReset(t *testing.T) {
+	cg := NewMockClientGetter(gomock.NewController(t))
+	cf := NewMockCacheFactory(gomock.NewController(t))
+	ri := NewMockResourceInterface(gomock.NewController(t))
+	tb := NewMockTransformBuilder(gomock.NewController(t))
+	bloi := NewMockByOptionsLister(gomock.NewController(t))
+	c := &factory.Cache{ByOptionsLister: &informer.Informer{ByOptionsLister: bloi}}
+
+	s := &Store{
+		clientGetter:     cg,
+		cacheFactory:     cf,
+		transformBuilder: tb,
+	}
+
+	apiOp := &types.APIRequest{Request: &http.Request{URL: &url.URL{}}}
+	apiSchema := &types.APISchema{
+		Schema: &schemas.Schema{Attributes: map[string]interface{}{
+			"verbs": []string{"list", "watch"},
+		}},
+	}
+	gvk := schema2.GroupVersionKind{Group: "some", Version: "test", Kind: "gvk"}
+	attributes.SetGVK(apiSchema, gvk)
+
+	cg.EXPECT().TableAdminClient(apiOp, apiSchema, "", &WarningBuffer{}).Return(ri, nil)
+	tb.EXPECT().GetTransformFunc(gvk, gomock.Any(), false, nil).
+		Return(func(obj interface{}) (interface{}, error) { return obj, nil })
+
+	gomock.InOrder(
+		// First call races with a concurrent schema Stop() and should be retried, not failed.
+		cf.EXPECT().CacheFor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gvk, gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("cache context canceled while waiting for SQL cache sync for %v: %w", gvk, factory.ErrCacheReset)),
+		cf.EXPECT().CacheFor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gvk, gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(c, nil),
+	)
+
+	got, err := s.cacheFor(context.Background(), apiOp, apiSchema)
+	assert.NoError(t, err)
+	assert.Equal(t, c, got)
+}
+
+func TestCacheForDoesNotRetryOnOtherErrors(t *testing.T) {
+	cg := NewMockClientGetter(gomock.NewController(t))
+	cf := NewMockCacheFactory(gomock.NewController(t))
+	ri := NewMockResourceInterface(gomock.NewController(t))
+	tb := NewMockTransformBuilder(gomock.NewController(t))
+
+	s := &Store{
+		clientGetter:     cg,
+		cacheFactory:     cf,
+		transformBuilder: tb,
+	}
+
+	apiOp := &types.APIRequest{Request: &http.Request{URL: &url.URL{}}}
+	apiSchema := &types.APISchema{
+		Schema: &schemas.Schema{Attributes: map[string]interface{}{
+			"verbs": []string{"list", "watch"},
+		}},
+	}
+	gvk := schema2.GroupVersionKind{Group: "some", Version: "test", Kind: "gvk"}
+	attributes.SetGVK(apiSchema, gvk)
+
+	cg.EXPECT().TableAdminClient(apiOp, apiSchema, "", &WarningBuffer{}).Return(ri, nil)
+	tb.EXPECT().GetTransformFunc(gvk, gomock.Any(), false, nil).
+		Return(func(obj interface{}) (interface{}, error) { return obj, nil })
+
+	// An unrelated, non-retryable error should be surfaced immediately, with no retry.
+	cf.EXPECT().CacheFor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gvk, gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(nil, errors.New("boom"))
+
+	_, err := s.cacheFor(context.Background(), apiOp, apiSchema)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Refs rancher/rancher#56459

`Store.Reset(gvk)` cancels a GVK's informer context to interrupt any in-flight `CacheFor` wait when a CRD/column definition change requires rebuilding the cache. A concurrent read for the same GVK sees this as a canceled-context error and surfaces a 500, even though the cache is immediately usable again once `Stop()` returns.

Fix: export `factory.ErrCacheReset` so callers can identify this transient, safe-to-retry race, and retry a few times at the `sqlproxy` call site instead of failing the request. `CacheFor`'s own error contract is unchanged (an existing unit test relies on it erroring on this race), so the retry lives one layer up.