### PR TITLE
Add ownership filter

### DIFF
--- a/pkg/resources/counts/counts.go
+++ b/pkg/resources/counts/counts.go
@@ -10,11 +10,14 @@ import (
 	"github.com/rancher/steve/pkg/accesscontrol"
 	"github.com/rancher/steve/pkg/attributes"
 	"github.com/rancher/steve/pkg/clustercache"
+	"github.com/rancher/steve/pkg/resources/ownership"
 	"github.com/rancher/wrangler/v3/pkg/schemas"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	schema2 "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 var (
@@ -329,6 +332,21 @@ func (s *Store) getCount(apiOp *types.APIRequest) Count {
 
 		all := access.Grants("list", "*", "*")
 
+		// Some resources from Rancher extension apiservers have additional
+		// visibility that is not just based on RBAC. (eg: ext.cattle.io/v1 Tokens)
+		//
+		// Those requires more filtering rules.
+		ownershipFilter, hasOwnershipFilter := ownership.Lookup(gvk)
+		var userInfo user.Info
+		var isAdmin bool
+		if hasOwnershipFilter {
+			userInfo, _ = request.UserFrom(apiOp.Request.Context())
+			accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
+			isAdmin = accessSet != nil && accessSet.Grants("list", schema2.GroupResource{
+				Resource: "*",
+			}, "", "")
+		}
+
 		for _, obj := range s.ccache.List(gvk) {
 			name, ns, revision, summary, ok := getInfo(obj, schema)
 			if !ok {
@@ -337,6 +355,13 @@ func (s *Store) getCount(apiOp *types.APIRequest) Count {
 
 			if !all && !access.Grants("list", ns, name) && !access.Grants("get", ns, name) {
 				continue
+			}
+
+			if hasOwnershipFilter {
+				objMeta, err := meta.Accessor(obj)
+				if err != nil || userInfo == nil || !ownershipFilter.Matches(userInfo, isAdmin, objMeta.GetLabels()) {
+					continue
+				}
 			}
 
 			if revision > rev {

--- a/pkg/resources/ownership/labelfilter.go
+++ b/pkg/resources/ownership/labelfilter.go
@@ -1,0 +1,45 @@
+package ownership
+
+import (
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// userIDLabelFilter scopes visibility to objects whose owner label matches
+// the requesting user, unless that user is an admin.
+type userIDLabelFilter struct {
+	label string
+}
+
+// NewUserIDLabelFilter returns a Filter that scopes visibility to objects
+// whose metadata.labels[label] matches the requesting user's name, unless
+// the requesting user is an admin. Callers (rancher/rancher's pkg/ext,
+// which owns the actual GVKs and label constants for its
+// extension-apiserver-backed resources) register this via
+// ownership.Register for whichever GVKs need it -- see
+// pkg/ext/stores/install.go's InstallStores.
+func NewUserIDLabelFilter(label string) Filter {
+	return &userIDLabelFilter{label: label}
+}
+
+func (f *userIDLabelFilter) SQLFilter(userInfo user.Info, isAdmin bool) *sqltypes.OrFilter {
+	if isAdmin {
+		return nil
+	}
+	return &sqltypes.OrFilter{
+		Filters: []sqltypes.Filter{
+			{
+				Field:   []string{"metadata", "labels", f.label},
+				Matches: []string{userInfo.GetName()},
+				Op:      sqltypes.Eq,
+			},
+		},
+	}
+}
+
+func (f *userIDLabelFilter) Matches(userInfo user.Info, isAdmin bool, labels map[string]string) bool {
+	if isAdmin {
+		return true
+	}
+	return labels[f.label] == userInfo.GetName()
+}

--- a/pkg/resources/ownership/ownership.go
+++ b/pkg/resources/ownership/ownership.go
@@ -1,0 +1,72 @@
+// Package ownership provides a single place to describe "who owns what" for
+// resources whose visibility is scoped per-user by something other than
+// Kubernetes RBAC (eg: ext.cattle.io Tokens and Kubeconfigs, which are
+// served by rancher's extension apiserver and filtered by a
+// cattle.io/user-id label rather than by SubjectAccessReview).
+//
+// Steve itself has no hardcoded knowledge of which GVKs need this -- that's
+// rancher-specific domain knowledge that rancher/rancher's pkg/ext owns (the
+// actual GVKs and label constants live in pkg/ext/stores/tokens and
+// pkg/ext/stores/kubeconfig). rancher/rancher registers a Filter for each
+// such GVK during extension-apiserver startup, in
+// pkg/ext/stores/install.go's InstallStores, right where those stores are
+// otherwise wired up.
+package ownership
+
+import (
+	"sync"
+
+	"github.com/rancher/steve/pkg/sqlcache/sqltypes"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Filter scopes visibility of a resource to its owning user, for resources
+// where visibility isn't determined by RBAC alone.
+type Filter interface {
+	// SQLFilter returns the additional filter that should be applied when
+	// listing this resource out of steve's SQLite cache for the given user.
+	// Returns nil (no restriction) when the user is an admin.
+	SQLFilter(userInfo user.Info, isAdmin bool) *sqltypes.OrFilter
+
+	// Matches reports whether an object with the given labels should be
+	// visible to the given user. Used by callers (like the count store)
+	// that only have an object's metadata in-hand -- e.g.
+	// counts.Store.getCount, which sees *summary.SummarizedObject values
+	// out of the in-memory clustercache, not unstructured.Unstructured --
+	// and can't run a SQL-level filter.
+	Matches(userInfo user.Info, isAdmin bool, labels map[string]string) bool
+}
+
+var (
+	mu       sync.RWMutex
+	registry = map[schema.GroupVersionKind]Filter{}
+)
+
+// Register adds a Filter for the given GVK. Called by rancher/rancher
+// during extension-apiserver startup (see pkg/ext/stores/install.go's
+// InstallStores) for each resource whose visibility rancher's stores scope
+// per-user rather than by RBAC. Also used directly by integration tests to
+// register a Filter for a test CRD's GVK, letting them exercise the shared
+// list/count filtering logic without needing a real extension apiserver.
+func Register(gvk schema.GroupVersionKind, f Filter) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[gvk] = f
+}
+
+// Unregister removes any Filter registered for gvk. Primarily useful for
+// tests that register a Filter for the duration of a single test.
+func Unregister(gvk schema.GroupVersionKind) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(registry, gvk)
+}
+
+// Lookup returns the Filter registered for gvk, if any.
+func Lookup(gvk schema.GroupVersionKind) (Filter, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	f, ok := registry[gvk]
+	return f, ok
+}

--- a/pkg/resources/ownership/ownership_test.go
+++ b/pkg/resources/ownership/ownership_test.go
@@ -1,0 +1,53 @@
+package ownership
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestLookupRequiresExactGVK guards against a real regression: a Filter
+// registered with a Version-less (or otherwise partial) GVK silently never
+// matches the fully-qualified GVK steve looks up at request time (see
+// pkg/attributes.GVK, which always populates Version) -- Lookup must NOT
+// match a GVK that only partially overlaps with what's registered.
+func TestLookupRequiresExactGVK(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "Thing"}
+	Register(gvk, NewUserIDLabelFilter("cattle.io/user-id"))
+	defer Unregister(gvk)
+
+	tests := []struct {
+		description string
+		lookup      schema.GroupVersionKind
+		expectFound bool
+	}{
+		{
+			description: "exact GVK match is found",
+			lookup:      schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "Thing"},
+			expectFound: true,
+		},
+		{
+			description: "missing Version does not match a versioned registration",
+			lookup:      schema.GroupVersionKind{Group: "test.cattle.io", Kind: "Thing"},
+			expectFound: false,
+		},
+		{
+			description: "different Version does not match",
+			lookup:      schema.GroupVersionKind{Group: "test.cattle.io", Version: "v2", Kind: "Thing"},
+			expectFound: false,
+		},
+		{
+			description: "different Kind does not match",
+			lookup:      schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "OtherThing"},
+			expectFound: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			_, ok := Lookup(test.lookup)
+			if ok != test.expectFound {
+				t.Errorf("Lookup(%s): expected found=%v, got %v", test.lookup, test.expectFound, ok)
+			}
+		})
+	}
+}

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rancher/steve/pkg/client"
 	controllerschema "github.com/rancher/steve/pkg/controllers/schema"
 	"github.com/rancher/steve/pkg/resources/common"
+	"github.com/rancher/steve/pkg/resources/ownership"
 	"github.com/rancher/steve/pkg/resources/virtual"
 	virtualCommon "github.com/rancher/steve/pkg/resources/virtual/common"
 	"github.com/rancher/steve/pkg/schema/converter"
@@ -1058,27 +1059,20 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		return
 	}
 
-	if gvk.Group == "ext.cattle.io" && (gvk.Kind == "Token" || gvk.Kind == "Kubeconfig") {
+	if f, ok := ownership.Lookup(gvk); ok {
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
 		// See https://github.com/rancher/rancher/blob/7266e5e624f0d610c76ab0af33e30f5b72e11f61/pkg/ext/stores/tokens/tokens.go#L1186C2-L1195C3
 		// for similar code on how we determine if a user is admin
-		if accessSet == nil || !accessSet.Grants("list", schema.GroupResource{
+		isAdmin := accessSet != nil && accessSet.Grants("list", schema.GroupResource{
 			Resource: "*",
-		}, "", "") {
-			user, ok := request.UserFrom(apiOp.Request.Context())
-			if !ok {
-				err = apierror.NewAPIError(validation.MissingRequired, "failed to get user info from the request.Context object")
-				return
-			}
-			opts.Filters = append(opts.Filters, sqltypes.OrFilter{
-				Filters: []sqltypes.Filter{
-					{
-						Field:   []string{"metadata", "labels", "cattle.io/user-id"},
-						Matches: []string{user.GetName()},
-						Op:      sqltypes.Eq,
-					},
-				},
-			})
+		}, "", "")
+		userInfo, ok := request.UserFrom(apiOp.Request.Context())
+		if !ok {
+			err = apierror.NewAPIError(validation.MissingRequired, "failed to get user info from the request.Context object")
+			return
+		}
+		if orFilter := f.SQLFilter(userInfo, isAdmin); orFilter != nil {
+			opts.Filters = append(opts.Filters, *orFilter)
 		}
 	}
 

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -48,9 +48,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	rtschema "k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
@@ -792,6 +794,25 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 		}
 	}
 
+	// Some resources (eg: ext.cattle.io Tokens and Kubeconfigs) scope
+	// visibility to their owning user by something other than RBAC -- see
+	// pkg/resources/ownership. ListByPartitions already applies that
+	// scoping to list/count results; apply the same scoping here so watch
+	// events for such resources aren't broadcast to every subscriber
+	// regardless of ownership.
+	gvk := attributes.GVK(schema)
+	ownershipFilter, hasOwnershipFilter := ownership.Lookup(gvk)
+	var ownerUserInfo user.Info
+	var ownerIsAdmin bool
+	if hasOwnershipFilter {
+		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
+		// See ListByPartitions above for how isAdmin is determined.
+		ownerIsAdmin = accessSet != nil && accessSet.Grants("list", rtschema.GroupResource{
+			Resource: "*",
+		}, "", "")
+		ownerUserInfo, _ = request.UserFrom(apiOp.Request.Context())
+	}
+
 	result := make(chan watch.Event)
 	go func() {
 		defer cancel()
@@ -811,7 +832,40 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 				Selector:  selector,
 			},
 		}
-		err := inf.ByOptionsLister.Watch(ctx, opts, result)
+
+		events := result
+		if hasOwnershipFilter {
+			// Interpose an unfiltered channel between the informer and the
+			// caller-visible result channel so each event's ownership can be
+			// checked before it's forwarded.
+			unfiltered := make(chan watch.Event)
+			events = unfiltered
+			forwarderDone := make(chan struct{})
+			go func() {
+				defer close(forwarderDone)
+				for event := range unfiltered {
+					if event.Type == watch.Error {
+						result <- event
+						continue
+					}
+					m, err := meta.Accessor(event.Object)
+					if err != nil {
+						logrus.Debugf("watch cannot process unexpected object: %s", err)
+						continue
+					}
+					if !ownershipFilter.Matches(ownerUserInfo, ownerIsAdmin, m.GetLabels()) {
+						continue
+					}
+					result <- event
+				}
+			}()
+			defer func() {
+				close(unfiltered)
+				<-forwarderDone
+			}()
+		}
+
+		err := inf.ByOptionsLister.Watch(ctx, opts, events)
 		if err != nil {
 			returnErr(err, result)
 			return

--- a/pkg/stores/sqlproxy/proxy_store.go
+++ b/pkg/stores/sqlproxy/proxy_store.go
@@ -47,8 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	rtschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
@@ -281,9 +280,9 @@ var (
 		"id":                  &informer.JSONPathField{Path: []string{"id"}},
 		"metadata.state.name": &informer.JSONPathField{Path: []string{"metadata", "state", "name"}},
 	}
-	namespaceGVK             = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
-	mcioProjectGvk           = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
-	pcioClusterGvk           = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
+	namespaceGVK             = k8sschema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	mcioProjectGvk           = k8sschema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
+	pcioClusterGvk           = k8sschema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
 	namespaceProjectLabelDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
 		SourceGVK: gvkKey("", "v1", "Namespace"),
 		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
@@ -298,7 +297,7 @@ var (
 		ExternalLabelDependencies: []sqltypes.ExternalLabelDependency{namespaceProjectLabelDep},
 	}
 
-	secretGVK                    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+	secretGVK                    = k8sschema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 	secretProjectLabelDisplayDep = sqltypes.MustNewExternalLabelDependency(sqltypes.ExternalLabelDependency{
 		SourceGVK: gvkKey("", "v1", "Secret"),
 		TargetGVK: gvkKey("management.cattle.io", "v3", "Project"),
@@ -391,13 +390,13 @@ type SchemaColumnSetter interface {
 
 type SchemaCollection interface {
 	Schema(id string) *types.APISchema
-	ByGVK(gvk schema.GroupVersionKind) string
+	ByGVK(gvk k8sschema.GroupVersionKind) string
 }
 
 type Cache interface {
 	// AugmentList takes a list of resources, and for some of them,
 	// adds related data to each item in the list
-	AugmentList(ctx context.Context, list *unstructured.UnstructuredList, childGVK schema.GroupVersionKind, childSchemaName string, useSelectors bool, accessList accesscontrol.AccessListByVerb) error
+	AugmentList(ctx context.Context, list *unstructured.UnstructuredList, childGVK k8sschema.GroupVersionKind, childSchemaName string, useSelectors bool, accessList accesscontrol.AccessListByVerb) error
 
 	// ListByOptions returns objects according to the specified list options and partitions.
 	// Specifically:
@@ -427,7 +426,7 @@ type RelationshipNotifier interface {
 }
 
 type TransformBuilder interface {
-	GetTransformFunc(gvk schema.GroupVersionKind, colDefs []common.ColumnDefinition, isCRD bool, jsonPaths map[string]*jsonpath.JSONPath) cache.TransformFunc
+	GetTransformFunc(gvk k8sschema.GroupVersionKind, colDefs []common.ColumnDefinition, isCRD bool, jsonPaths map[string]*jsonpath.JSONPath) cache.TransformFunc
 }
 
 type Store struct {
@@ -448,9 +447,9 @@ type Store struct {
 type CacheFactoryInitializer func() (CacheFactory, error)
 
 type CacheFactory interface {
-	CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) (*factory.Cache, error)
+	CacheFor(ctx context.Context, fields map[string]informer.IndexedField, externalUpdateInfo *sqltypes.ExternalGVKUpdates, selfUpdateInfo *sqltypes.ExternalGVKUpdates, transform cache.TransformFunc, client dynamic.ResourceInterface, gvk k8sschema.GroupVersionKind, namespaced bool, watchable bool, disableWatchList bool) (*factory.Cache, error)
 	DoneWithCache(*factory.Cache)
-	Stop(gvk schema.GroupVersionKind) error
+	Stop(gvk k8sschema.GroupVersionKind) error
 }
 
 // NewProxyStore returns a Store implemented directly on top of kubernetes.
@@ -483,7 +482,7 @@ func NewProxyStore(ctx context.Context, c SchemaColumnSetter, clientGetter clien
 }
 
 // Reset locks the store, resets the underlying cache factory, and warm the namespace cache.
-func (s *Store) Reset(gvk schema.GroupVersionKind) error {
+func (s *Store) Reset(gvk k8sschema.GroupVersionKind) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if s.namespaceCache != nil && gvk == namespaceGVK {
@@ -564,7 +563,7 @@ func (s *Store) initializeNamespaceCache() error {
 	return nil
 }
 
-func getFieldForGVK(gvk schema.GroupVersionKind) map[string]informer.IndexedField {
+func getFieldForGVK(gvk k8sschema.GroupVersionKind) map[string]informer.IndexedField {
 	fields := make(map[string]informer.IndexedField)
 	// Add common fields
 	for k, v := range commonIndexFields {
@@ -585,7 +584,7 @@ func gvkKey(group, version, kind string) string {
 // getFieldAndColInfo converts object field names from types.APISchema's format into steve's
 // cache.sql.informer's IndexedField format (e.g. "metadata.resourceVersion" is ["metadata", "resourceVersion"])
 // It also returns type info for each field
-func getFieldAndColInfo(s *types.APISchema, gvk schema.GroupVersionKind) (map[string]informer.IndexedField, []common.ColumnDefinition) {
+func getFieldAndColInfo(s *types.APISchema, gvk k8sschema.GroupVersionKind) (map[string]informer.IndexedField, []common.ColumnDefinition) {
 	fields := make(map[string]informer.IndexedField)
 	colDefs := common.GetColumnDefinitions(s)
 	typeGuidance := getTypeGuidance(colDefs, gvk)
@@ -807,7 +806,7 @@ func (s *Store) watch(apiOp *types.APIRequest, schema *types.APISchema, w types.
 	if hasOwnershipFilter {
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
 		// See ListByPartitions above for how isAdmin is determined.
-		ownerIsAdmin = accessSet != nil && accessSet.Grants("list", rtschema.GroupResource{
+		ownerIsAdmin = accessSet != nil && accessSet.Grants("list", k8sschema.GroupResource{
 			Resource: "*",
 		}, "", "")
 		ownerUserInfo, _ = request.UserFrom(apiOp.Request.Context())
@@ -1037,7 +1036,7 @@ func (s *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 	return obj, buffer, nil
 }
 
-var TypeGuidanceTable = map[schema.GroupVersionKind]map[string]string{
+var TypeGuidanceTable = map[k8sschema.GroupVersionKind]map[string]string{
 	{Group: "", Version: "v1", Kind: "Secret"}: {
 		"metadata.fields[2]": "INT",
 	},
@@ -1049,7 +1048,7 @@ var TypeGuidanceTable = map[schema.GroupVersionKind]map[string]string{
 	},
 }
 
-func getTypeGuidance(cols []common.ColumnDefinition, gvk schema.GroupVersionKind) map[string]string {
+func getTypeGuidance(cols []common.ColumnDefinition, gvk k8sschema.GroupVersionKind) map[string]string {
 	guidance := make(map[string]string)
 	ptn := regexp.MustCompile(`(?i)\bnumber of\b`)
 	for _, col := range cols {
@@ -1117,7 +1116,7 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 		accessSet := accesscontrol.AccessSetFromAPIRequest(apiOp)
 		// See https://github.com/rancher/rancher/blob/7266e5e624f0d610c76ab0af33e30f5b72e11f61/pkg/ext/stores/tokens/tokens.go#L1186C2-L1195C3
 		// for similar code on how we determine if a user is admin
-		isAdmin := accessSet != nil && accessSet.Grants("list", schema.GroupResource{
+		isAdmin := accessSet != nil && accessSet.Grants("list", k8sschema.GroupResource{
 			Resource: "*",
 		}, "", "")
 		userInfo, ok := request.UserFrom(apiOp.Request.Context())
@@ -1146,21 +1145,21 @@ func (s *Store) ListByPartitions(apiOp *types.APIRequest, apiSchema *types.APISc
 	return
 }
 
-func (s *Store) AugmentRelationships(ctx context.Context, gvk schema.GroupVersionKind, list *unstructured.UnstructuredList, apiOp *types.APIRequest) error {
+func (s *Store) AugmentRelationships(ctx context.Context, gvk k8sschema.GroupVersionKind, list *unstructured.UnstructuredList, apiOp *types.APIRequest) error {
 	type GVKWithSchemaName struct {
-		gvk          schema.GroupVersionKind
+		gvk          k8sschema.GroupVersionKind
 		schemaName   string
 		useSelectors bool
 	}
-	podGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	jobGVK := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
-	dependentChildInfoFromParentGVK := map[schema.GroupVersionKind]GVKWithSchemaName{
-		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}:  {podGVK, "pod", true},
-		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}:   {podGVK, "pod", true},
-		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}:  {podGVK, "pod", true},
-		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}: {podGVK, "pod", true},
-		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}:        {podGVK, "pod", true},
-		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}:    {jobGVK, "batch.job", false},
+	podGVK := k8sschema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	jobGVK := k8sschema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	dependentChildInfoFromParentGVK := map[k8sschema.GroupVersionKind]GVKWithSchemaName{
+		k8sschema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}:  {podGVK, "pod", true},
+		k8sschema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}:   {podGVK, "pod", true},
+		k8sschema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}:  {podGVK, "pod", true},
+		k8sschema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}: {podGVK, "pod", true},
+		k8sschema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}:        {podGVK, "pod", true},
+		k8sschema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}:    {jobGVK, "batch.job", false},
 	}
 	childInfo, ok := dependentChildInfoFromParentGVK[gvk]
 	if !ok {
@@ -1247,7 +1246,7 @@ func (s *Store) cacheForWithDeps(ctx context.Context, apiOp *types.APIRequest, a
 	// so we must initialize this one as well
 	if gvk == pcioClusterGvk {
 		var mgmtSchema *types.APISchema
-		if id := s.schemas.ByGVK(schema.GroupVersionKind{
+		if id := s.schemas.ByGVK(k8sschema.GroupVersionKind{
 			Group:   "management.cattle.io",
 			Version: "v3",
 			Kind:    "Cluster",

--- a/pkg/stores/sqlproxy/proxy_store_test.go
+++ b/pkg/stores/sqlproxy/proxy_store_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/steve/pkg/attributes"
 	"github.com/rancher/steve/pkg/client"
 	"github.com/rancher/steve/pkg/resources/common"
+	"github.com/rancher/steve/pkg/resources/ownership"
 	"github.com/rancher/steve/pkg/sqlcache/informer"
 	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
 	"github.com/rancher/steve/pkg/sqlcache/partition"
@@ -1033,6 +1034,20 @@ func TestAugmentRelationships(t *testing.T) {
 }
 
 func TestListByPartitionWithUserAccess(t *testing.T) {
+	targetGroup := "ext.cattle.io"
+	targetKind := "Token"
+	gvk := schema2.GroupVersionKind{
+		Group:   targetGroup,
+		Version: "v1",
+		Kind:    targetKind,
+	}
+	// This test exercises the ownership filter that (in production) is
+	// registered by rancher/rancher's pkg/ext/stores/install.go for its
+	// extension-apiserver-backed resources -- register the equivalent
+	// filter here so this test doesn't depend on rancher/rancher wiring.
+	ownership.Register(gvk, ownership.NewUserIDLabelFilter("cattle.io/user-id"))
+	defer ownership.Unregister(gvk)
+
 	type testCase struct {
 		description     string
 		accessSetSetter func(accessSet *accesscontrol.AccessSet)
@@ -1091,8 +1106,6 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 			}
 			var partitions []partition.Partition
 			username := "flip"
-			targetGroup := "ext.cattle.io"
-			targetKind := "Token"
 			accessSet := &accesscontrol.AccessSet{ID: username}
 			accessSet.Add("list",
 				schema2.GroupResource{Group: targetGroup, Resource: "token"},
@@ -1120,10 +1133,6 @@ func TestListByPartitionWithUserAccess(t *testing.T) {
 					},
 					"verbs": []string{"list", "watch"},
 				}},
-			}
-			gvk := schema2.GroupVersionKind{
-				Group: targetGroup,
-				Kind:  targetKind,
 			}
 			opts := &sqltypes.ListOptions{
 				Filters: test.orFilters,

--- a/tests/integration/ownership_test.go
+++ b/tests/integration/ownership_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"time"
+
+	"github.com/rancher/steve/pkg/auth"
+	"github.com/rancher/steve/pkg/resources/ownership"
+	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+var testdataOwnershipDir = filepath.Join("testdata", "ownership")
+
+var bananaGVK = k8sschema.GroupVersionKind{Group: "fruits.cattle.io", Version: "v1", Kind: "Banana"}
+
+const (
+	bananaListURLPath = "fruits.cattle.io.bananas"
+	bananaSchemaID    = "fruits.cattle.io.banana"
+)
+
+// TestOwnershipCountMatchesList is a regression test for
+// rancher/rancher#56849: /v1/count used to leak the true global count of
+// resources served by rancher's extension apiserver (ext.cattle.io Tokens,
+// Kubeconfigs) to non-admin users, because the per-user ownership filter
+// that the regular list endpoint applies (see
+// pkg/stores/sqlproxy/proxy_store.go) was never applied to /v1/count (see
+// pkg/resources/counts/counts.go).
+//
+// This test doesn't stand up a real extension apiserver. Instead it
+// registers an ownership.Filter for the Banana CRD's GVK -- functionally
+// identical to what rancher/rancher registers for Tokens/Kubeconfigs -- and
+// asserts that for every user (admin and non-admin), both /v1/count and
+// the regular list endpoint report the exact expected number of visible
+// bananas. Asserting the exact expected counts (rather than only that the
+// two endpoints agree with each other) ensures the test would fail if the
+// ownership filter were dropped from both call sites at once.
+func (i *IntegrationSuite) TestOwnershipCountMatchesList() {
+	ctx := i.T().Context()
+
+	// Register the ownership filter for the duration of this test only, so
+	// it can't leak into other tests running against the same schema.
+	ownership.Register(bananaGVK, ownership.NewUserIDLabelFilter("cattle.io/user-id"))
+	defer ownership.Unregister(bananaGVK)
+
+	manifestsFile := filepath.Join(testdataOwnershipDir, "common.manifests.yaml")
+	gvrs := make(map[k8sschema.GroupVersionResource]struct{})
+	i.doManifest(ctx, manifestsFile, func(ctx context.Context, obj *unstructured.Unstructured, gvr k8sschema.GroupVersionResource) error {
+		gvrs[gvr] = struct{}{}
+		return i.doApply(ctx, obj, gvr)
+	})
+	defer i.doManifestReversed(ctx, manifestsFile, i.doDelete)
+
+	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
+		info, ok, err := auth.Impersonation(req)
+		if ok || err != nil {
+			return info, ok, err
+		}
+		return auth.AlwaysAdmin(req)
+	}
+	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
+
+	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+			UseTempDir:  true,
+		},
+		AuthMiddleware: authMiddleware,
+	})
+	i.Require().NoError(err)
+
+	httpServer := httptest.NewServer(steveHandler)
+	defer httpServer.Close()
+
+	baseURL := httpServer.URL
+
+	for gvr := range gvrs {
+		i.waitForSchema(baseURL, gvr)
+	}
+
+	defer i.maybeStopAndDebug(baseURL)
+
+	totalBananas := 4
+
+	i.Require().EventuallyWithT(func(c *assert.CollectT) {
+		count, ok := i.getCountFor(c, baseURL, "", bananaSchemaID)
+		require.True(c, ok, "no %q entry in /v1/count response yet", bananaSchemaID)
+		require.Equal(c, totalBananas, count, "admin count hasn't converged to the expected total yet")
+	}, 90*time.Second, 1*time.Second)
+
+	tests := []struct {
+		description string
+		username    string // "" = no impersonation header = AlwaysAdmin fallback
+		expected    int
+	}{
+		{description: "admin sees every banana regardless of owner", username: "", expected: totalBananas},
+		{description: "user-alice sees only her own bananas", username: "user-alice", expected: 2},
+		{description: "user-bob sees only his own bananas", username: "user-bob", expected: 1},
+		{description: "user-carol owns no bananas and sees none", username: "user-carol", expected: 0},
+	}
+	for _, test := range tests {
+		i.Run(test.description, func() {
+			listCount := i.countBananasViaList(ctx, baseURL, test.username)
+			countEndpointCount := i.countBananasViaCountEndpoint(ctx, baseURL, test.username)
+
+			assert.Equal(i.T(), test.expected, listCount,
+				"user %q: /v1/%s returned an unexpected number of bananas", test.username, bananaListURLPath)
+			assert.Equal(i.T(), test.expected, countEndpointCount,
+				"user %q: /v1/count returned an unexpected banana count", test.username)
+		})
+	}
+}
+
+func (i *IntegrationSuite) countBananasViaList(ctx context.Context, baseURL, username string) int {
+	url := fmt.Sprintf("%s/v1/%s", baseURL, bananaListURLPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	i.Require().NoError(err)
+	if username != "" {
+		req.Header.Set("Impersonate-User", username)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	i.Require().NoError(err)
+	defer resp.Body.Close()
+	i.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	i.Require().NoError(json.NewDecoder(resp.Body).Decode(&result))
+	return len(result.Data)
+}
+
+type countResponse struct {
+	Data []struct {
+		Counts map[string]struct {
+			Summary struct {
+				Count int `json:"count"`
+			} `json:"summary"`
+		} `json:"counts"`
+	} `json:"data"`
+}
+
+func (i *IntegrationSuite) getCountFor(c require.TestingT, baseURL, username, schemaID string) (int, bool) {
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/count", nil)
+	require.NoError(c, err)
+	if username != "" {
+		req.Header.Set("Impersonate-User", username)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(c, err)
+	defer resp.Body.Close()
+	require.Equal(c, http.StatusOK, resp.StatusCode)
+
+	var result countResponse
+	require.NoError(c, json.NewDecoder(resp.Body).Decode(&result))
+	require.Len(c, result.Data, 1)
+
+	itemCount, ok := result.Data[0].Counts[schemaID]
+	return itemCount.Summary.Count, ok
+}
+
+func (i *IntegrationSuite) countBananasViaCountEndpoint(ctx context.Context, baseURL, username string) int {
+	count, ok := i.getCountFor(i.T(), baseURL, username, bananaSchemaID)
+	i.Require().True(ok, "no %q entry in /v1/count response", bananaSchemaID)
+	return count
+}

--- a/tests/integration/ownership_watch_test.go
+++ b/tests/integration/ownership_watch_test.go
@@ -1,0 +1,246 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/rancher/steve/pkg/auth"
+	"github.com/rancher/steve/pkg/resources/ownership"
+	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/steve/pkg/sqlcache/informer/factory"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// subscribeEvent is a minimal decoding of the JSON messages steve sends over
+// a /v1/subscribe websocket -- see github.com/rancher/apiserver/pkg/subscribe.
+type subscribeEvent struct {
+	Name string `json:"name"`
+	Data struct {
+		ID       string `json:"id"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Error string `json:"error"`
+	} `json:"data"`
+}
+
+// TestOwnershipFiltersWatchEvents is a regression test for
+// rancher/rancher#56849: the per-user ownership.Filter that
+// ListByPartitions applies to list/count results for resources like
+// ext.cattle.io Tokens and Kubeconfigs was never applied to the watch path
+// (Store.watch, used by both /v1/subscribe and WatchNames). A user
+// subscribed to such a resource type would receive resource.change events
+// for every object of that type, including ones owned by other users, even
+// though the same user's list/get requests correctly filtered them out.
+//
+// This test registers an ownership.Filter for the Banana CRD's GVK (same
+// approach as TestOwnershipCountMatchesList) and opens a real websocket
+// /v1/subscribe connection as a non-admin user. It asserts that user only
+// receives resource.change events for bananas they own, and that they do
+// still receive events for their own bananas (a filter-too-aggressive bug
+// would silently look the same as "no leak" if we only checked for the
+// absence of other users' events).
+func (i *IntegrationSuite) TestOwnershipFiltersWatchEvents() {
+	ctx, cancel := context.WithTimeout(i.T().Context(), 60*time.Second)
+	defer cancel()
+
+	ownership.Register(bananaGVK, ownership.NewUserIDLabelFilter("cattle.io/user-id"))
+	defer ownership.Unregister(bananaGVK)
+
+	manifestsFile := "testdata/ownership/common.manifests.yaml"
+	gvrs := make(map[k8sschema.GroupVersionResource]struct{})
+	i.doManifest(ctx, manifestsFile, func(ctx context.Context, obj *unstructured.Unstructured, gvr k8sschema.GroupVersionResource) error {
+		gvrs[gvr] = struct{}{}
+		return i.doApply(ctx, obj, gvr)
+	})
+	defer i.doManifestReversed(ctx, manifestsFile, i.doDelete)
+
+	impersonateOrAdmin := func(req *http.Request) (user.Info, bool, error) {
+		info, ok, err := auth.Impersonation(req)
+		if ok || err != nil {
+			return info, ok, err
+		}
+		return auth.AlwaysAdmin(req)
+	}
+	authMiddleware := auth.ToMiddleware(auth.AuthenticatorFunc(impersonateOrAdmin))
+
+	steveHandler, err := server.New(ctx, i.restCfg, &server.Options{
+		SQLCacheFactoryOptions: factory.CacheFactoryOptions{
+			GCInterval:  15 * time.Minute,
+			GCKeepCount: 1000,
+			UseTempDir:  true,
+		},
+		AuthMiddleware: authMiddleware,
+	})
+	i.Require().NoError(err)
+
+	httpServer := httptest.NewServer(steveHandler)
+	defer httpServer.Close()
+
+	baseURL := httpServer.URL
+	for gvr := range gvrs {
+		i.waitForSchema(baseURL, gvr)
+	}
+	defer i.maybeStopAndDebug(baseURL)
+
+	// Subscribe as user-alice. She owns banana-alice-1 and banana-alice-2,
+	// and has RBAC list/watch access to all bananas (see
+	// common.manifests.yaml) -- if the ownership filter were missing from
+	// the watch path, she'd receive events for banana-bob-1 too.
+	conn := i.dialSubscribe(baseURL, "user-alice", bananaSchemaID)
+	defer conn.Close()
+
+	events := make(chan subscribeEvent, 16)
+	go func() {
+		for {
+			var evt subscribeEvent
+			if err := conn.ReadJSON(&evt); err != nil {
+				close(events)
+				return
+			}
+			events <- evt
+		}
+	}()
+
+	// Wait for the initial resource.start ack before mutating anything, so
+	// we know the subscription is live.
+	i.waitForSubscribeEvent(events, "resource.start", "", 10*time.Second)
+
+	// The informer backing the watch is created lazily on first access and
+	// takes a moment to fully sync -- if we mutate bananas before it's
+	// ready, the mutations just land in its initial List instead of firing
+	// as watch events. Force it to warm up by polling the regular list
+	// endpoint until all four fixture bananas are visible.
+	i.Require().Eventually(func() bool {
+		return i.countBananasViaList(ctx, baseURL, "") == 4
+	}, 15*time.Second, 200*time.Millisecond, "banana informer never finished its initial sync")
+
+	// Update bob's banana first. If the fix regresses, this is the event
+	// that would leak to alice.
+	i.patchBananaLabel(ctx, "banana-bob-1", "leaked", "yes")
+
+	// Then update alice's own banana. This must arrive -- it proves the
+	// filter isn't just dropping every event (too aggressive == same
+	// observable behavior as "no leak" if we only checked for bob's event).
+	i.patchBananaLabel(ctx, "banana-alice-1", "own-update", "yes")
+
+	// Collect every resource.change event that arrives within the window,
+	// instead of discarding non-matching ones while searching for alice's
+	// own event -- otherwise a leaked banana-bob-1 event that happens to
+	// arrive before banana-alice-1's would be silently thrown away by the
+	// search itself, defeating the whole point of the test.
+	var changeEvents []subscribeEvent
+	deadline := time.After(15 * time.Second)
+collect:
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				break collect
+			}
+			if evt.Name != "resource.change" {
+				continue
+			}
+			changeEvents = append(changeEvents, evt)
+			if evt.Data.Metadata.Name == "banana-alice-1" {
+				// Give any already-in-flight events a brief moment to also
+				// arrive before we stop collecting.
+				select {
+				case <-time.After(2 * time.Second):
+				case <-deadline:
+				}
+				break collect
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+
+	var sawOwnUpdate bool
+	for _, evt := range changeEvents {
+		require.NotEqual(i.T(), "banana-bob-1", evt.Data.Metadata.Name,
+			"alice must not receive watch events for bananas she doesn't own")
+		if evt.Data.Metadata.Name == "banana-alice-1" {
+			sawOwnUpdate = true
+		}
+	}
+	require.True(i.T(), sawOwnUpdate,
+		"alice should receive resource.change events for her own bananas")
+}
+
+// dialSubscribe opens a websocket connection to steve's /v1/subscribe
+// endpoint impersonating the given user, and sends the initial subscribe
+// message for resourceType.
+func (i *IntegrationSuite) dialSubscribe(baseURL, username, resourceType string) *websocket.Conn {
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1)
+	wsURL = strings.Replace(wsURL, "https://", "wss://", 1)
+	wsURL += "/v1/subscribe"
+
+	header := http.Header{}
+	if username != "" {
+		header.Set("Impersonate-User", username)
+	}
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	i.Require().NoError(err, "dialing %s", wsURL)
+
+	payload, err := json.Marshal(map[string]string{"resourceType": resourceType})
+	i.Require().NoError(err)
+	i.Require().NoError(conn.WriteMessage(websocket.TextMessage, payload))
+
+	return conn
+}
+
+// waitForSubscribeEvent blocks until an event of the given name arrives
+// (optionally filtered further by the object name it concerns), or fails
+// the test after timeout.
+func (i *IntegrationSuite) waitForSubscribeEvent(events <-chan subscribeEvent, name, objectName string, timeout time.Duration) subscribeEvent {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				i.Require().FailNow(fmt.Sprintf("subscribe channel closed while waiting for %q event", name))
+			}
+			if evt.Name != name {
+				continue
+			}
+			if objectName != "" && evt.Data.Metadata.Name != objectName {
+				continue
+			}
+			return evt
+		case <-deadline:
+			i.Require().FailNow(fmt.Sprintf("timed out waiting for %q event (object=%q)", name, objectName))
+			return subscribeEvent{}
+		}
+	}
+}
+
+func (i *IntegrationSuite) patchBananaLabel(ctx context.Context, name, labelKey, labelValue string) {
+	gvr := k8sschema.GroupVersionResource{Group: bananaGVK.Group, Version: bananaGVK.Version, Resource: "bananas"}
+	obj, err := i.client.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+	i.Require().NoError(err)
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[labelKey] = labelValue
+	obj.SetLabels(labels)
+
+	_, err = i.client.Resource(gvr).Update(ctx, obj, metav1.UpdateOptions{})
+	i.Require().NoError(err)
+}

--- a/tests/integration/testdata/ownership/common.manifests.yaml
+++ b/tests/integration/testdata/ownership/common.manifests.yaml
@@ -1,0 +1,83 @@
+apiVersion: fruits.cattle.io/v1
+kind: Banana
+metadata:
+  name: banana-alice-1
+  labels:
+    cattle.io/user-id: user-alice
+---
+apiVersion: fruits.cattle.io/v1
+kind: Banana
+metadata:
+  name: banana-alice-2
+  labels:
+    cattle.io/user-id: user-alice
+---
+apiVersion: fruits.cattle.io/v1
+kind: Banana
+metadata:
+  name: banana-bob-1
+  labels:
+    cattle.io/user-id: user-bob
+---
+apiVersion: fruits.cattle.io/v1
+kind: Banana
+metadata:
+  name: banana-unowned-1
+---
+# Every user in this test (admin included) is granted a blanket "list all
+# bananas" RBAC rule. This mirrors the real-world ext.cattle.io Token/
+# Kubeconfig setup: RBAC alone grants everyone list access, and the extra
+# per-user scoping comes entirely from the ownership.Filter, not from RBAC.
+# If ownership.Filter weren't applied to /v1/count, this RBAC rule would be
+# enough for a non-admin to see the true global count.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ownership-test-banana-lister
+rules:
+  - apiGroups: ["fruits.cattle.io"]
+    resources: ["bananas"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ownership-test-banana-lister-alice
+subjects:
+  - kind: User
+    name: user-alice
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ownership-test-banana-lister
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ownership-test-banana-lister-bob
+subjects:
+  - kind: User
+    name: user-bob
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ownership-test-banana-lister
+  apiGroup: rbac.authorization.k8s.io
+---
+# user-carol owns zero bananas but still has the same blanket RBAC list
+# grant as everyone else, so she can exercise the "authenticated, RBAC
+# allows list, but ownership.Filter legitimately yields zero" case as
+# distinct from an outright RBAC-denied (403/404) request.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ownership-test-banana-lister-carol
+subjects:
+  - kind: User
+    name: user-carol
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ownership-test-banana-lister
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/56849

Steve does a single watch via admin privileges per resource and stores that into the SQLite cache. Resources like ext.cattle.io Kubeconfigs and Tokens have special behavior where a user is only able to see its own tokens / kubeconfigs (which is global). To make this additional restriction with Steve, we were adding a SQL filter. We forgot we also need to filter the result of the `/v1/count` endpoint.

# Summary of changes

Abstract away a bit this additional "ownership filter" (see pkg/resources/ownership). Introduces a new interface with two methods: one to add a SQLite filter, another to do basic filtering on the object. (Note: the count endpoint doesn't use the SQLite database for its data)

Introduces a UserIDLabelFilter type that implements this interface. It is only used in tests in steve. 

The SQLite filter is removed from steve and moved to rancher/rancher closer to where the stores are set. That seems like the more sensible thing to do. (I'm happy to leave it in steve though if anyone wants it here).

# Tests

I added an integration test using the UserIDLabelFilter to test for regression. We don't have infrastructure code yet to deploy an actual extension apiserver, so I'm testing with a CRD instead of a custom made "Token" API.